### PR TITLE
Dummy Inverter Option

### DIFF
--- a/batcontrol.py
+++ b/batcontrol.py
@@ -11,7 +11,7 @@ import sys
 
 LOGFILE = "batcontrol.log"
 CONFIGFILE = "config/batcontrol_config.yaml"
-VALID_UTILITIES = ['tibber','awattar_at','awattar_de', 'evcc']
+VALID_UTILITIES = ['tibber','awattar_at','awattar_de','evcc']
 VALID_INVERTERS = ['fronius_gen24']
 ERROR_IGNORE_TIME = 600
 TIME_BETWEEN_EVALUATIONS = 120

--- a/batcontrol.py
+++ b/batcontrol.py
@@ -11,7 +11,7 @@ import sys
 
 LOGFILE = "batcontrol.log"
 CONFIGFILE = "config/batcontrol_config.yaml"
-VALID_UTILITIES = ['tibber','awattar_at','awattar_de']
+VALID_UTILITIES = ['tibber','awattar_at','awattar_de', 'evcc']
 VALID_INVERTERS = ['fronius_gen24']
 ERROR_IGNORE_TIME = 600
 TIME_BETWEEN_EVALUATIONS = 120
@@ -112,7 +112,11 @@ class Batcontrol(object):
                 pass
             else:
                 raise RuntimeError(f'[BatCtrl] Utility Tibber requires an apikey. Please provide the apikey in your configuration file')
-            
+        elif config['utility']['type'] in ['evcc']:
+            if 'url' in config['utility'].keys():
+                pass
+            else:
+                raise RuntimeError(f'[BatCtrl] Utility EVCC requires an URL. Please provide the URL in your configuration file')
         else:
             config['utility']['apikey']=None
             

--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -13,11 +13,12 @@ inverter:
   max_charge_rate: 5000 # Watt
   max_grid_power: 25000 # Watt
 utility:
-  type: tibber # [tibber, awattar_at, awattar_de]
+  type: tibber # [tibber, awattar_at, awattar_de, evcc]
   apikey: YOUR-PASSWORD # only required for tibber get one from https://developer.tibber.com/ Zz-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXx
   vat: 0.20 # only required for awattar
   fees: 0.015 # only required for awattar
   markup: 0.03 # only required for awattar
+  url: http://evcc.local/api/tariff/grid # only required for evcc
 
 pvinstallations:
   - name: Haus #name

--- a/dynamictariff/dynamictariff.py
+++ b/dynamictariff/dynamictariff.py
@@ -1,6 +1,8 @@
 
 from .awattar import Awattar
 from .tibber import Tibber
+from .evcc import Evcc
+
 class DynamicTariff(object):
     def __new__(cls,  config:dict, timezone,min_time_between_API_calls):
         selected_tariff=None
@@ -32,6 +34,11 @@ class DynamicTariff(object):
                 raise RuntimeError (f'[Dynamic Tariff] Tibber requires an API token. Please provide "apikey :YOURKEY" in your configuration file')
             token = config['apikey']
             selected_tariff=Tibber(timezone,token,min_time_between_API_calls)
+
+        elif provider.lower()=='evcc':
+            if not 'url' in config.keys() :
+                raise RuntimeError (f'[Dynamic Tariff] EVCC requires an URL. Please provide "url" in your configuration file, like http://evcc.local/api/tariff/grid')
+            selected_tariff= Evcc(timezone,config['url'],min_time_between_API_calls)
         else:
             raise RuntimeError(f'[DynamicTariff] Unkown provider {provider}')
         return selected_tariff

--- a/dynamictariff/dynamictariff.py
+++ b/dynamictariff/dynamictariff.py
@@ -16,7 +16,6 @@ class DynamicTariff(object):
             vat = float(config['vat'])
             markup = float(config['markup'])
             fees = float(config['fees'])
-            
             selected_tariff= Awattar(timezone,'at',fees,markup,vat,min_time_between_API_calls)
         
         elif provider.lower()=='awattar_de':
@@ -27,8 +26,8 @@ class DynamicTariff(object):
             vat = float(config['vat'])
             markup = float(config['markup'])
             fees = float(config['fees'])
-            
             selected_tariff= Awattar(timezone,'de',fees,markup,vat,min_time_between_API_calls)
+
         elif provider.lower()=='tibber':
             if not 'apikey' in config.keys() :
                 raise RuntimeError (f'[Dynamic Tariff] Tibber requires an API token. Please provide "apikey :YOURKEY" in your configuration file')

--- a/dynamictariff/evcc.py
+++ b/dynamictariff/evcc.py
@@ -1,0 +1,68 @@
+from .baseclass import DynamicTariffBaseclass
+import requests
+import datetime
+import math
+
+class Evcc(DynamicTariffBaseclass):
+    
+    def __init__(self, timezone , url , min_time_between_API_calls=60):
+        super().__init__(timezone,min_time_between_API_calls)
+        self.url=url
+    
+    def get_raw_data_from_provider(self):
+        response=requests.get(self.url)
+        
+        if response.status_code != 200:
+           raise RuntimeError(f'[EVCC] API returned {response}')
+        # {"result":
+        #     { "rates": [
+        #            {
+        #                "start":"2024-06-20T08:00:00+02:00",
+        #                "end":"2024-06-20T09:00:00+02:00",
+        #                "price":0.35188299999999995
+        #             },
+        #            {
+        #               "start":"2024-06-20T09:00:00+02:00",
+        #                "end":"2024-06-20T10:00:00+02:00",
+        #                "price":0.3253459999999999"
+        #            }
+        #        ]
+        #     }
+        # }
+        
+
+        raw_data=response.json()
+        return raw_data
+        
+        
+    def get_prices_from_raw_data(self):
+        data=self.raw_data['result']['rates']
+        now=datetime.datetime.now().astimezone(self.timezone)
+        prices={}
+
+
+        for item in data:
+            # "start":"2024-06-20T08:00:00+02:00" to timestamp
+            timestamp=datetime.datetime.fromisoformat(item['start']).astimezone(self.timezone)
+            diff=timestamp-now
+            rel_hour=math.ceil(diff.total_seconds()/3600)   
+            if rel_hour >=0:
+                prices[rel_hour]=item['price']
+        return prices
+
+def test():
+    import sys
+    import json
+    import pytz
+    if len(sys.argv) != 2:
+        print("Usage: python evcc.py <url>")
+        sys.exit(1)
+
+    url = sys.argv[1]
+    evcc = Evcc(pytz.timezone('Europe/Berlin'), url)  # Assuming the Evcc constructor takes a URL
+
+    prices = evcc.get_prices()
+    print(json.dumps(prices, indent=4))
+
+if __name__ == "__main__":
+    test()

--- a/fronius/baseclass.py
+++ b/fronius/baseclass.py
@@ -1,0 +1,23 @@
+""" Parent Class for implementing inverters and test drivers"""
+
+class InverterBaseclass(object):
+    def set_mode_force_charge():
+        raise RuntimeError("[Inverter Base Class] Function 'set_mode_force_charge' not implemented")
+    
+    def set_mode_allow_discharge():
+        raise RuntimeError("[Inverter Base Class] Function 'set_mode_allow_discharge' not implemented")
+
+    def set_mode_avoid_discharge():
+        raise RuntimeError("[Inverter Base Class] Function 'set_mode_avoid_discharge' not implemented") 
+
+    def get_stored_energy():
+        raise RuntimeError("[Inverter Base Class] Function 'get_stored_energy' not implemented")
+
+    def get_free_capacity():
+        raise RuntimeError("[Inverter Base Class] Function 'get_free_capacity' not implemented")
+    
+    def get_max_capacity():
+        raise RuntimeError("[Inverter Base Class] Function 'get_max_soc' not implemented")
+
+    def get_SOC():
+        raise RuntimeError("[Inverter Base Class] Function 'get_SOC' not implemented")

--- a/fronius/fronius.py
+++ b/fronius/fronius.py
@@ -26,9 +26,10 @@ def strip_dict(original):
 TIMEOFUSE_CONFIG_FILENAME = 'timeofuse_config.json'
 BATTERY_CONFIG_FILENAME = 'battery_config.json'
 
-
-class FroniusWR(object):
+from .baseclass import InverterBaseclass
+class FroniusWR(InverterBaseclass):
     def __init__(self, address, user, password,max_charge_rate,max_grid_power) -> None:
+        super().__init__()
         self.login_attempts=0
         self.address = address
         self.capacity = -1
@@ -65,7 +66,10 @@ class FroniusWR(object):
         capa=self.get_capacity()
         energy=(current_soc-self.min_soc)/100*capa
         return energy
-    
+
+    def get_max_capacity(self):
+        return self.max_soc
+
     def get_usable_capacity(self):
         usable_capa=(self.max_soc-self.min_soc)/100*self.get_capacity()
         return usable_capa

--- a/fronius/inverter.py
+++ b/fronius/inverter.py
@@ -1,0 +1,10 @@
+class Inverter(object):
+    def __new__(cls, config:dict):
+        if config['type'].lower() == 'fronius_gen24':
+            from .fronius import FroniusWR
+            return FroniusWR(config['address'], config['user'], config['password'], config['max_charge_rate'], config['max_grid_power'])
+        elif config['type'].lower() == 'testdriver':
+            from .testdriver import Testdriver
+            return Testdriver(config['max_charge_rate'], config['max_grid_power'])
+        else:
+            raise RuntimeError(f'[Inverter] Unkown inverter type {config["type"]}')

--- a/fronius/testdriver.py
+++ b/fronius/testdriver.py
@@ -1,0 +1,37 @@
+import logging
+from .baseclass import InverterBaseclass
+
+logger = logging.getLogger('__main__')
+logger.info(f'[Fronius] loading module ')
+
+#from .fronius import InverterBaseclass
+
+class Testdriver(InverterBaseclass):
+    def __init__(self, max_charge_rate:float, max_grid_power:float):
+        self.max_charge_rate=max_charge_rate
+        self.max_grid_power=max_grid_power
+        self.stored_energy=2000
+        self.max_capacity=5000
+        self.SOC=99.0
+        self.mode='allow_discharge'
+        
+    def set_mode_force_charge(self):
+        self.mode='force_charge'
+        
+    def set_mode_allow_discharge(self):
+        self.mode='allow_discharge'
+        
+    def set_mode_avoid_discharge(self):
+        self.mode='avoid_discharge'
+        
+    def get_stored_energy(self):
+        return self.stored_energy
+        
+    def get_free_capacity(self):
+        return self.max_capacity-self.stored_energy
+        
+    def get_max_capacity(self):
+        return self.max_capacity
+        
+    def get_SOC(self):
+        return self.SOC


### PR DESCRIPTION
Servus,
ohne Wechselrichter zu testen geht nicht, aber für bestimmte funktionen wäre es extrem hilfreich.

Mit dem PR wird die Funktionen der Fronius Klasse in einer allgemeine Inverter Klasse umgebaut. Direkter Zugriff auf Attribute wird auf Methoden gemappt.
Aktuell macht die Dummy-Klasse nichts weiter als ein paar statische Informationen zu liefern.

Angedacht war, dass man im auch das Lastprofil in die Klasse lädt und damit (zusammen im einer Varianz) die Rückmeldungen liefert. Aber so reicht es schonmal.

Bitte gebe mir Feedback wenn ich irgendwo noch etwas anpassen soll.

edit: Vorraussetzung ist der Merge vom EVCC PR (oder die Änderung hier nimmt das auch mit).

Liebe Grüße
Matthias