### PR TITLE
Fixes #33

### DIFF
--- a/batcontrol.py
+++ b/batcontrol.py
@@ -485,7 +485,7 @@ class Batcontrol(object):
             self.mqtt_api.publish_mode(mode)
         # leaving force charge mode, reset charge rate
         if self.last_charge_rate > 0 and mode != MODE_FORCE_CHARGING:
-            self._set_charge_rate = 0
+            self._set_charge_rate(0)
 
     def allow_discharging(self):
         logger.debug(f'[BatCTRL] Mode: Allow Discharging')


### PR DESCRIPTION
On exiting forced charging from grid mode, _set_charge_rate was bound to int causing a crash

Fixes https://github.com/muexxl/batcontrol/issues/33

@MaStr 