### PR TITLE
Make Debug array values more readable

### DIFF
--- a/batcontrol.py
+++ b/batcontrol.py
@@ -289,7 +289,7 @@ class Batcontrol(object):
         logger.debug('[BatCTRL] Production FCST: %s', ', '.join(f'{v:.2f}' for v in production))
         logger.debug('[BatCTRL] Consumption FCST: %s', ', '.join(f'{v:.2f}' for v in consumption))
         logger.debug('[BatCTRL] Net Consumption FCST: %s', ', '.join(f'{v:.2f}' for v in net_consumption))
-        logger.debug('[BatCTRL] Prices: : %s', ', '.join(f'{v:.2f}' for v in prices))
+        logger.debug('[BatCTRL] Prices: %s', ', '.join(f'{v:.2f}' for v in prices))
         # negative = charging or feed in
         # positive = dis-charging or grid consumption
 

--- a/batcontrol.py
+++ b/batcontrol.py
@@ -286,10 +286,10 @@ class Batcontrol(object):
             prices[h] = price_dict[h]
         
         net_consumption = consumption-production
-        logger.debug('[BatCTRL] Production FCST: %s', ', '.join(f'{v:.2f}' for v in production))
-        logger.debug('[BatCTRL] Consumption FCST: %s', ', '.join(f'{v:.2f}' for v in consumption))
-        logger.debug('[BatCTRL] Net Consumption FCST: %s', ', '.join(f'{v:.2f}' for v in net_consumption))
-        logger.debug('[BatCTRL] Prices: %s', ', '.join(f'{v:.2f}' for v in prices))
+        logger.debug('[BatCTRL] Production FCST: %s', np.ndarray.round(production,1))
+        logger.debug('[BatCTRL] Consumption FCST: %s', np.ndarray.round(consumption,1))
+        logger.debug('[BatCTRL] Net Consumption FCST: %s', np.ndarray.round(net_consumption,1))
+        logger.debug('[BatCTRL] Prices: %s', np.ndarray.round(prices,3))
         # negative = charging or feed in
         # positive = dis-charging or grid consumption
 

--- a/batcontrol.py
+++ b/batcontrol.py
@@ -286,10 +286,10 @@ class Batcontrol(object):
             prices[h] = price_dict[h]
         
         net_consumption = consumption-production
-        logger.debug(f'[BatCTRL] Production FCST {production}')
-        logger.debug(f'[BatCTRL] Consumption FCST {consumption}')
-        logger.debug(f'[BatCTRL] Net Consumption FCST {net_consumption}')
-        logger.debug(f'[BatCTRL] prices {prices}')
+        logger.debug('[BatCTRL] Production FCST: %s', ', '.join(f'{v:.2f}' for v in production))
+        logger.debug('[BatCTRL] Consumption FCST: %s', ', '.join(f'{v:.2f}' for v in consumption))
+        logger.debug('[BatCTRL] Net Consumption FCST: %s', ', '.join(f'{v:.2f}' for v in net_consumption))
+        logger.debug('[BatCTRL] Prices: : %s', ', '.join(f'{v:.2f}' for v in prices))
         # negative = charging or feed in
         # positive = dis-charging or grid consumption
 

--- a/forecastconsumption/forecastconsumption.py
+++ b/forecastconsumption/forecastconsumption.py
@@ -71,8 +71,9 @@ class ForecastConsumption(object):
                 energy = df['energy'].median()
             prediction[h]=energy*self.scaling_factor
         
-        logger.debug('[FC Cons] predicting consumption: %s', ', '.join(f'{v:.2f}' for v in prediction.values()))
+        logger.debug('[FC Cons] predicting consumption: %s', np.array(list(prediction.values())).round(1))
         return prediction
+
     
     def get_annual_value(self):
         self.dataframe['energy'].sum()*8760/2016/1000

--- a/forecastconsumption/forecastconsumption.py
+++ b/forecastconsumption/forecastconsumption.py
@@ -71,7 +71,7 @@ class ForecastConsumption(object):
                 energy = df['energy'].median()
             prediction[h]=energy*self.scaling_factor
         
-        logger.debug(f'[FC Cons] predicting consumption {prediction}')
+        logger.debug('[FC Cons] predicting consumption: %s', ', '.join(f'{v:.2f}' for v in prediction.values()))
         return prediction
     
     def get_annual_value(self):


### PR DESCRIPTION
Before
```
2024-11-07 10:41:55 DEBUG [FC Cons] predicting consumption {0: 349.31066637990733, 1: 337.44065310859133, 2: 449.94174003422916, 3: 431.4012223906464, 4: 429.96383934717215, 5: 366.52213189636865, 6: 385.9124414911546, 7: 377.04416591312025, 8: 332.00330902738034, 9: 410.7293260535633, 10: 530.6202775056219, 11: 478.6638363088132, 12: 321.7042259195338, 13: 234.85612362430874}

```
After:
```
2024-11-07 10:54:30 DEBUG [FC Cons] predicting consumption: 349.31, 337.44, 449.94, 431.40, 429.96, 366.52, 385.91, 377.04, 332.00, 410.73, 530.62, 478.66, 321.70, 234.86
```

Same is true for 

-  Production FCST:
- Consumption FCST:
- Net Consumption FCST:
- Prices:

