### PR TITLE
Add Dockerfile : adding the basic docker file and build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.20
+
+# add required libraries as py3-* Alpine packages 
+# (this is equivalent to doing 
+# pip install -r requirements.txt )
+# the dependencies here need to reflect what batcontrol depends on
+RUN apk add --no-cache \
+            python3 \
+            py3-numpy \
+            py3-pandas\
+            py3-yaml\
+            py3-requests\
+            py3-paho-mqtt
+
+COPY ./ /batcontrol
+WORKDIR /batcontrol
+RUN ln -s /data/options.json /batcontrol/config/batcontrol_config.yaml
+
+CMD [ "./batcontrol.py" ]

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker buildx build . -t hashtagknorke:batcontrol


### PR DESCRIPTION
Based on the draft found in https://github.com/muexxl/batcontrol_addon , this PR adds 
- a `Dockerfile` and 
- a build script `build_docker.sh` for creating a docker image based on the batcontrol code

the resulting docker image does not install the dependencies from requirements.txt via pip. Instead it installs the corresponding Alpine `py3-*` packages. Thus the Dockerfile needs to be adjusted accordingly whenever new dependencies are added to requirements.txt file.   

The name of the docker image is a literal within the `build_docker.sh` file 

This could provide a trivial basic implementation for providing  #21 