### PR TITLE
Rewrite re-evaluation trigger every 3 minutes and add fixed offset of 15 secs

### DIFF
--- a/batcontrol.py
+++ b/batcontrol.py
@@ -96,13 +96,14 @@ class Batcontrol(object):
         self.dynamic_tariff = dynamictariff.DynamicTariff(
             config['utility'],
             timezone,
-            TIME_BETWEEN_UTILITY_API_CALLS
+            TIME_BETWEEN_UTILITY_API_CALLS,
+            DELAY_EVALUATION_BY_SECONDS
         )
 
         self.inverter = inverter.Inverter(config['inverter'])
 
         self.pvsettings = config['pvinstallations']
-        self.fc_solar = forecastsolar.ForecastSolar(self.pvsettings, timezone)
+        self.fc_solar = forecastsolar.ForecastSolar(self.pvsettings, timezone, DELAY_EVALUATION_BY_SECONDS)
 
         self.load_profile = config['consumption_forecast']['load_profile']
         try:
@@ -112,7 +113,7 @@ class Batcontrol(object):
             annual_consumption = 0
 
         self.fc_consumption = forecastconsumption.ForecastConsumption(
-            self.load_profile, timezone, annual_consumption)
+            self.load_profile, timezone, annual_consumption )
 
         self.batconfig = config['battery_control']
         self.time_at_forecast_error = -1
@@ -817,7 +818,7 @@ if __name__ == '__main__':
                                                    microseconds=now.microsecond)
             # add time increments to trigger next evaluation
             next_eval += datetime.timedelta(minutes=EVALUATIONS_EVERY_MINUTES,
-                                              seconds=DELAY_EVALUATION_BY_SECONDS,
+                                              seconds=0,
                                               microseconds=0)
             sleeptime = (next_eval - now).total_seconds()
             logger.info("[Main] Next evaluation at %s. Sleeping for %.0f seconds",

--- a/dynamictariff/awattar.py
+++ b/dynamictariff/awattar.py
@@ -32,8 +32,8 @@ class Awattar(DynamicTariffBaseclass):
         Inherits from DynamicTariffBaseclass
     """
 
-    def __init__(self, timezone ,country:str, min_time_between_API_calls=0):
-        super().__init__(timezone,min_time_between_API_calls)
+    def __init__(self, timezone ,country:str, min_time_between_API_calls=0, delay_evaluation_by_seconds=0):
+        super().__init__(timezone,min_time_between_API_calls, delay_evaluation_by_seconds)
         country= country.lower()
         if country in ['at','de']:
             self.url=f'https://api.awattar.{country}/v1/marketdata'

--- a/dynamictariff/baseclass.py
+++ b/dynamictariff/baseclass.py
@@ -4,7 +4,6 @@ import random
 import logging
 
 logger = logging.getLogger('__main__')
-logger.setLevel(logging.DEBUG)
 
 class DynamicTariffBaseclass:
     """ Parent Class for implementing different tariffs"""

--- a/dynamictariff/baseclass.py
+++ b/dynamictariff/baseclass.py
@@ -1,19 +1,33 @@
 """ Parent Class for implementing different tariffs"""
 import time
+import random
+import logging
+
+logger = logging.getLogger('__main__')
+logger.setLevel(logging.DEBUG)
 
 class DynamicTariffBaseclass:
     """ Parent Class for implementing different tariffs"""
-    def __init__(self, timezone,min_time_between_API_calls) -> None:  #pylint: disable=invalid-name
+    def __init__(self, timezone,min_time_between_API_calls, delay_evaluation_by_seconds) -> None:  #pylint: disable=invalid-name
         self.raw_data={}
         self.last_update=0
         self.min_time_between_updates=min_time_between_API_calls
         self.timezone=timezone
+        self.delay_evaluation_by_seconds=delay_evaluation_by_seconds
 
     def get_prices(self):
         """ Get prices from provider """
         now=time.time()
         time_passed=now-self.last_update
         if time_passed> self.min_time_between_updates:
+            # Not on initial call
+            if self.last_update > 0 and self.delay_evaluation_by_seconds > 0:
+                sleeptime = random.randrange(0, self.delay_evaluation_by_seconds, 1)
+                logger.debug(
+                        '[Tariff] Waiting for %d seconds before requesting new data',
+                        sleeptime)
+                time.sleep(sleeptime)
+
             self.raw_data=self.get_raw_data_from_provider()
             self.last_update=now
         prices=self.get_prices_from_raw_data()

--- a/dynamictariff/dynamictariff.py
+++ b/dynamictariff/dynamictariff.py
@@ -20,7 +20,9 @@ from .evcc import Evcc
 
 class DynamicTariff:
     """ Select and configure a dynamic tariff provider based on the given configuration """
-    def __new__(cls,  config:dict, timezone,min_time_between_API_calls):  # pylint: disable=invalid-name
+    def __new__(cls,  config:dict, timezone,
+                min_time_between_API_calls,  # pylint: disable=invalid-name
+                delay_evaluation_by_seconds):
         selected_tariff=None
         provider=config['type']
 
@@ -34,7 +36,7 @@ class DynamicTariff:
             vat = float(config['vat'])
             markup = float(config['markup'])
             fees = float(config['fees'])
-            selected_tariff= Awattar(timezone,'at',min_time_between_API_calls)
+            selected_tariff= Awattar(timezone,'at',min_time_between_API_calls, delay_evaluation_by_seconds)
             selected_tariff.set_price_parameters(vat,fees,markup)
 
         elif provider.lower()=='awattar_de':
@@ -47,7 +49,7 @@ class DynamicTariff:
             vat = float(config['vat'])
             markup = float(config['markup'])
             fees = float(config['fees'])
-            selected_tariff= Awattar(timezone,'de',min_time_between_API_calls)
+            selected_tariff= Awattar(timezone,'de',min_time_between_API_calls, delay_evaluation_by_seconds)
             selected_tariff.set_price_parameters(vat,fees,markup)
 
         elif provider.lower()=='tibber':
@@ -57,7 +59,7 @@ class DynamicTariff:
                     'Please provide "apikey :YOURKEY" in your configuration file'
                     )
             token = config['apikey']
-            selected_tariff=Tibber(timezone,token,min_time_between_API_calls)
+            selected_tariff=Tibber(timezone,token,min_time_between_API_calls, delay_evaluation_by_seconds)
 
         elif provider.lower()=='evcc':
             if not 'url' in config.keys() :

--- a/dynamictariff/evcc.py
+++ b/dynamictariff/evcc.py
@@ -34,7 +34,8 @@ class Evcc(DynamicTariffBaseclass):
         Inherits from DynamicTariffBaseclass
     """
     def __init__(self, timezone , url , min_time_between_API_calls=60):
-        super().__init__(timezone,min_time_between_API_calls)
+        super().__init__(timezone,min_time_between_API_calls, 0)
+        self.delay_evaluation_by_seconds=0
         self.url=url
 
     def get_raw_data_from_provider(self):

--- a/dynamictariff/tibber.py
+++ b/dynamictariff/tibber.py
@@ -10,8 +10,8 @@ class Tibber(DynamicTariffBaseclass):
     """ Implement Tibber API to get dynamic electricity prices
         Inherits from DynamicTariffBaseclass
     """
-    def __init__(self, timezone , token, min_time_between_API_calls=0):
-        super().__init__(timezone,min_time_between_API_calls)
+    def __init__(self, timezone , token, min_time_between_API_calls=0, delay_evaluation_by_seconds=0):
+        super().__init__(timezone,min_time_between_API_calls, delay_evaluation_by_seconds)
         self.access_token=token
         self.url="https://api.tibber.com/v1-beta/gql"
 

--- a/forecastsolar/forecastsolar.py
+++ b/forecastsolar/forecastsolar.py
@@ -8,7 +8,6 @@ import requests
 
 logger = logging.getLogger('__main__')
 logger.info(f'[FCSolar] loading module ')
-logger.setLevel(logging.DEBUG)
 
 class ForecastSolar(object):
     def __init__(self, pvinstallations, timezone,

--- a/forecastsolar/forecastsolar.py
+++ b/forecastsolar/forecastsolar.py
@@ -1,4 +1,5 @@
 import datetime
+import random
 import time
 import math
 import json
@@ -7,19 +8,28 @@ import requests
 
 logger = logging.getLogger('__main__')
 logger.info(f'[FCSolar] loading module ')
+logger.setLevel(logging.DEBUG)
 
 class ForecastSolar(object):
-    def __init__(self, pvinstallations, timezone) -> None:
+    def __init__(self, pvinstallations, timezone,
+                 delay_evaluation_by_seconds) -> None:
         self.pvinstallations = pvinstallations
         self.results = {}
         self.last_update = 0
         self.seconds_between_updates = 900
         self.timezone=timezone
+        self.delay_evaluation_by_seconds=delay_evaluation_by_seconds
 
     def get_forecast(self):
         t0 = time.time()
         dt = t0-self.last_update
         if dt > self.seconds_between_updates:
+            if self.last_update > 0 and self.delay_evaluation_by_seconds > 0:
+                sleeptime = random.randrange(0, self.delay_evaluation_by_seconds, 1)
+                logger.debug(
+                    '[FCSolar] Waiting for %d seconds before requesting new data',
+                    sleeptime)
+                time.sleep(sleeptime)
             self.get_raw_forecast()
             self.last_update = t0
         prediction = {}


### PR DESCRIPTION
Implements and closes https://github.com/muexxl/batcontrol/issues/63 and ensures the run is triggered on multiples of 3 minutes on the clock. (e.g. 03, 06, 09, 12, 15, 18, etc.)

To avoid API overload at the exact minute a delay of 15 seconds has been implemented.

The interval and the delay is currently not configurable, although maybe that would be wise to add to the config?