### PR TITLE
Set allow grid charging at the end of initialisation

### DIFF
--- a/inverter/fronius.py
+++ b/inverter/fronius.py
@@ -84,6 +84,7 @@ class FroniusWR(InverterBaseclass):
             )
         self.max_soc = self.previous_battery_config['BAT_M0_SOC_MAX']
         self.get_time_of_use()  # save timesofuse
+        self.set_allow_grid_charging(True)
 
     def get_SOC(self):
         path = '/solar_api/v1/GetPowerFlowRealtimeData.fcgi'
@@ -275,12 +276,9 @@ class FroniusWR(InverterBaseclass):
                           "TimeTable": {"Start": "00:00", "End": "23:59"},
                           "Weekdays": {"Mon": True, "Tue": True, "Wed": True, "Thu": True, "Fri": True, "Sat": True, "Sun": True}
                           }]
-        self.set_allow_grid_charging(False)
         return self.set_time_of_use(timeofuselist)
 
     def set_mode_allow_discharge(self):
-        self.set_allow_grid_charging(False)
-
         timeofuselist = []
         if self.max_pv_charge_rate > 0:
             timeofuselist = [{'Active': True,
@@ -303,7 +301,6 @@ class FroniusWR(InverterBaseclass):
                           "TimeTable": {"Start": "00:00", "End": "23:59"},
                           "Weekdays": {"Mon": True, "Tue": True, "Wed": True, "Thu": True, "Fri": True, "Sat": True, "Sun": True}
                           }]
-        self.set_allow_grid_charging(True)
         return self.set_time_of_use(timeofuselist)
 
     def restore_time_of_use_config(self):


### PR DESCRIPTION
Currently this is set at every calculation, this is wholly uneccessary as the time of use limits are sufficient to achieve the intended behaviour. It is now set as a last step on initialisation, as this is needed to get intended behaviour if this was not set already by the user.

Configuration is reset to config prior to initialisation on script shut down as before.

