### PR TITLE
Add MQTT Connection retry

### DIFF
--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -27,6 +27,8 @@ mqtt:
   topic: batcontrol
   username: user
   password: password
+  retry_attempts: 5 # optional, default: 5
+  retry_delay: 10 # seconds, optional, default: 10
   tls: false
   cafile: /etc/ssl/certs/ca-certificates.crt
   certfile: /etc/ssl/certs/client.crt


### PR DESCRIPTION
handling connection errors for MQTT gracefully, attempting a configurable amount of retries in a configurable frequency

This is especially helpful when starting up multiple containers e.g. in a docker compose setup where the MQTT broker needs some boot time 