### PR TITLE
introduce proper OS-level timezone handling in Docker setup 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ LABEL maintainer="matthias.strubel@aod-rpg.de"
 
 ENV BATCONTROL_VERSION=${VERSION}
 ENV BATCONTROL_GIT_SHA=${GIT_SHA}
+# Set default timezone to UTC, override with -e TZ=Europe/Berlin or similar 
+# when starting the container 
+# or set the timezone in docker-compose.yml in the environment section,
+ENV TZ=UTC  
 
 RUN mkdir -p /app /app/logs /app/config
 WORKDIR /app
@@ -19,7 +23,8 @@ RUN apk add --no-cache \
             py3-pandas\
             py3-yaml\
             py3-requests\
-            py3-paho-mqtt
+            py3-paho-mqtt \
+            tzdata
 
 
 COPY *.py ./

--- a/README.MD
+++ b/README.MD
@@ -51,7 +51,6 @@ mkdir -p ./config -p ./logs
 - Download the the latest [batcontrol_config.yaml](https://raw.githubusercontent.com/muexxl/batcontrol/refs/heads/main/config/batcontrol_config_dummy.yaml) sample, adjust and place it to config/batcontrol_config.yaml.
 
 - Use the default load_profile (automatically) or create your own.-
-
 ### Plain Docker
 
 ```
@@ -79,6 +78,39 @@ services:
 ```
 
 Then start the container using `docker-compose up -d`.
+
+### Adjusting Timezone
+
+To adjust the timezone for logging and output, set the `TZ` environment variable.
+
+#### Plain Docker
+
+```
+docker run -d \
+  --name batcontrol \
+  -v /path/to/config:/app/config \
+  -v /path/to/logs:/app/logs \
+  -e TZ=Europe/Berlin \
+  muexx/batcontrol:latest
+```
+
+#### Docker-compose example
+
+Add the `TZ` environment variable to your `docker-compose.yml`:
+
+```
+version: '3.8'
+
+services:
+  batcontrol:
+    image: muexx/batcontrol:latest
+    volumes:
+      - ./config:/app/config
+      - ./logs:/app/logs
+    environment:
+      - TZ=Europe/Berlin
+    restart: unless-stopped
+```
 
 # FAQs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,5 +36,9 @@ if test ! -e "/app/logs/batcontrol.log" ; then
   ln -s /app/logs/batcontrol.log /app/batcontrol.log
 fi
 
+# Output the timezone
+echo "Current local time is: $(date)"
+echo "Configured timezone (env var TZ) is: $TZ"
+
 # Start batcontrol.py
 exec python /app/batcontrol.py


### PR DESCRIPTION
fixes #98 


- Configures the default timezone to `UTC` in the Dockerfile 
- Output the current local time and configured timezone in the `entrypoint.sh` script.
- Add `tzdata` package to `Dockerfile`

- default implementation in `logging.Formatter.converter` then uses `time.localtime` to create logging timestamps in local timezone

Timezone can be adjusted by passing in an override for TZ env var either in docker run or in docker-compose.yml
e.g. 
```
docker run -it --rm -e TZ=Europe/London batcontrol
```