### PR TITLE
gracefully handle multiple changed files

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Get changed files
       id: changed-files
       run: |
-        CHANGED_FILES=$(git diff --name-only $BASE_BRANCH...HEAD -- '*.py')
+        CHANGED_FILES=$(git diff --name-only $BASE_BRANCH...HEAD -- '*.py' | tr '\n' ' ')
         echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
 
     - name: Analysing the code with pylint

--- a/p.py
+++ b/p.py
@@ -1,0 +1,4 @@
+import a
+print(a.x)
+from x import y
+

--- a/p.py
+++ b/p.py
@@ -1,4 +1,0 @@
-import a
-print(a.x)
-from x import y
-


### PR DESCRIPTION
Modify the pylint workflow to output changed Python files as a space-separated list instead of a newline-separated list.