### PR TITLE
Add query parameter to allow modification of horizon used to forecast PV production in fcsolar.py

### DIFF
--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -45,6 +45,7 @@ pvinstallations:
     declination: 32 #inclination toward horizon 0..90 0=flat 90=vertical (e.g. wallmounted)
     azimuth: -90 # -90:East, 0:South, 90:West -180..180
     kWp: 15.695 # power in kWp
+    horizon: # leave empty for default PVGIS horizon, only modify if solar array is shaded by trees or houses
     api: #fcsolarapi
   - name: Garage  #... further installations
     lat: 48.4334480
@@ -52,6 +53,7 @@ pvinstallations:
     declination: 32
     azimuth: 87
     kWp: 6.030
+    horizon: 30,30,30,0,0,0 # leave empty for default PVGIS horizon, only modify if solar array is shaded by trees or houses
     api: #fcsolarapi
 consumption_forecast:
   annual_consumption: 4500 # total consumption in kWh p.a. the load profile 

--- a/forecastsolar/fcsolar.py
+++ b/forecastsolar/fcsolar.py
@@ -116,8 +116,12 @@ class FCSolar(ForecastSolarInterface):
             elif 'api' in unit.keys() and unit['api'] is not None:
                 apikey_urlmod = unit['api'] +"/" # ForecastSolar api
 
+            horizon_querymod = ''
+            if 'horizon' in unit.keys() and unit['horizon'] is not None:
+                horizon_querymod = "?horizon=" + unit['horizon']  # ForecastSolar api
+
             url = (f"https://api.forecast.solar/{apikey_urlmod}estimate/"
-                   f"watthours/period/{lat}/{lon}/{dec}/{az}/{kwp}")
+                   f"watthours/period/{lat}/{lon}/{dec}/{az}/{kwp}{horizon_querymod}")
             logger.info(
                 '[FCSolar] Requesting Information for PV Installation %s', name)
 


### PR DESCRIPTION
As FCSolar and most other production forecast APIs use PVGIS as the underlying source, they pull horizon data from a single database. This reflects the ground level horizon but does not account for shading from trees or houses. 

This affects batcontrol if the array is shaded in the morning hours from a neighbouring house or trees.

This PR allows people to define their own horizon file according to these instructions: 
https://doc.forecast.solar/horizon
and here:
https://joint-research-centre.ec.europa.eu/photovoltaic-geographical-information-system-pvgis/getting-started-pvgis/pvgis-user-manual_en#ref-2-using-horizon-information
