### PR TITLE
Fronius: Less restrictive on missing auth header

### DIFF
--- a/inverter/fronius.py
+++ b/inverter/fronius.py
@@ -600,6 +600,7 @@ class FroniusWR(InverterBaseclass):
 
     def __split_response_auth_header(self, response):
         """ Split the response header into a dictionary."""
+        auth_dict = {}
         # stupid API bug: nonce headers with different capitalization at different end points
         if 'X-WWW-Authenticate' in response.headers:
             auth_string = response.headers['X-WWW-Authenticate']
@@ -610,7 +611,8 @@ class FroniusWR(InverterBaseclass):
         else:
             logger.error(
                 '[Inverter] No authentication header found in response')
-            return None
+            # Return an empty header to work with Fronius below 1.35.4-1
+            return auth_dict
 
         auth_list = auth_string.replace(" ", "").replace('"', '').split(',')
         logger.debug("[Inverter] Authentication header: %s", auth_list)

--- a/inverter/fronius.py
+++ b/inverter/fronius.py
@@ -609,9 +609,9 @@ class FroniusWR(InverterBaseclass):
         elif 'Authentication-Info' in response.headers:
             auth_string = response.headers['Authentication-Info']
         else:
-            logger.error(
+            # Return an empty dict to work with Fronius below 1.35.4-1
+            logger.debug(
                 '[Inverter] No authentication header found in response')
-            # Return an empty header to work with Fronius below 1.35.4-1
             return auth_dict
 
         auth_list = auth_string.replace(" ", "").replace('"', '').split(',')


### PR DESCRIPTION
Closes 0.4.0  Login does not work below 1.35.4-1 #129