### PR TITLE
evcc: Enhance API usage bufferSoC

### DIFF
--- a/batcontrol.py
+++ b/batcontrol.py
@@ -9,6 +9,9 @@ import yaml
 import pytz
 import numpy as np
 
+import mqtt_api
+import evcc_api
+
 from forecastconsumption import forecastconsumption
 from dynamictariff import dynamictariff as tariff_factory
 from inverter import inverter as inverter_factory
@@ -144,10 +147,10 @@ class Batcontrol:
         self.max_charging_from_grid_limit = self.batconfig['max_charging_from_grid_limit']
         self.min_price_difference = self.batconfig['min_price_difference']
         self.min_price_difference_rel = self.__get_config_with_defaults(
-                                            self.batconfig,
-                                            'min_price_difference_rel',
-                                            0
-                                        )
+            self.batconfig,
+            'min_price_difference_rel',
+            0
+        )
 
         self.charge_rate_multiplier = 1.1
         self.soften_price_difference_on_charging = False
@@ -157,25 +160,25 @@ class Batcontrol:
         if self.__is_config_key_valid(config, 'battery_control_expert'):
             battery_control_expert = self.config['battery_control_expert']
             self.soften_price_difference_on_charging = self.__get_config_with_defaults(
-                  battery_control_expert,
-                  'soften_price_difference_on_charging',
-                  False
-                )
+                battery_control_expert,
+                'soften_price_difference_on_charging',
+                False
+            )
             self.soften_price_difference_on_charging_factor = self.__get_config_with_defaults(
-                  battery_control_expert,
-                  'soften_price_difference_on_charging_factor',
-                  5
-                )
+                battery_control_expert,
+                'soften_price_difference_on_charging_factor',
+                5
+            )
             self.round_price_digits = self.__get_config_with_defaults(
-                  battery_control_expert,
-                  'round_price_digits',
-                  4
-                )
+                battery_control_expert,
+                'round_price_digits',
+                4
+            )
             self.charge_rate_multiplier = self.__get_config_with_defaults(
-                  battery_control_expert,
-                  'charge_rate_multiplier',
-                  1.1
-                )
+                battery_control_expert,
+                'charge_rate_multiplier',
+                1.1
+            )
 
         self.charge_rate_multiplier = 1.1
         self.soften_price_difference_on_charging = False
@@ -185,32 +188,31 @@ class Batcontrol:
         if self.__is_config_key_valid(config, 'battery_control_expert'):
             battery_control_expert = self.config['battery_control_expert']
             self.soften_price_difference_on_charging = self.__get_config_with_defaults(
-                  battery_control_expert,
-                  'soften_price_difference_on_charging',
-                  False
-                )
+                battery_control_expert,
+                'soften_price_difference_on_charging',
+                False
+            )
             self.soften_price_difference_on_charging_factor = self.__get_config_with_defaults(
-                  battery_control_expert,
-                  'soften_price_difference_on_charging_factor',
-                  5
-                )
+                battery_control_expert,
+                'soften_price_difference_on_charging_factor',
+                5
+            )
             self.round_price_digits = self.__get_config_with_defaults(
-                  battery_control_expert,
-                  'round_price_digits',
-                  4
-                )
+                battery_control_expert,
+                'round_price_digits',
+                4
+            )
             self.charge_rate_multiplier = self.__get_config_with_defaults(
-                  battery_control_expert,
-                  'charge_rate_multiplier',
-                  1.1
-                )
+                battery_control_expert,
+                'charge_rate_multiplier',
+                1.1
+            )
 
         self.mqtt_api = None
         if 'mqtt' in config.keys():
 
             if config['mqtt']['enabled']:
                 logger.info('[Main] MQTT Connection enabled')
-                import mqtt_api
                 self.mqtt_api = mqtt_api.MqttApi(config['mqtt'])
                 self.mqtt_api.wait_ready()
                 # Register for callbacks
@@ -251,10 +253,14 @@ class Batcontrol:
         if 'evcc' in config.keys():
             if config['evcc']['enabled']:
                 logger.info('[Main] evcc Connection enabled')
-                import evcc_api
                 self.evcc_api = evcc_api.EvccApi(config['evcc'])
                 self.evcc_api.register_block_function(
                     self.set_discharge_blocked)
+                self.evcc_api.register_always_allow_discharge_limit(
+                    self.set_always_allow_discharge_limit,
+                    self.get_always_allow_discharge_limit
+                )
+                self.evcc_api.start()
                 self.evcc_api.wait_ready()
                 logger.info('[Main] evcc Connection ready')
 
@@ -264,17 +270,19 @@ class Batcontrol:
         try:
             self.inverter.shutdown()
             del self.inverter
+            if self.evcc_api is not None:
+                self.evcc_api.shutdown()
+                del self.evcc_api
         except:
             pass
 
-    def __get_config_with_defaults(self, config:dict, key:str, default):
+    def __get_config_with_defaults(self, config: dict, key: str, default):
         """ Get a key from a config dictionary with a default value """
         if key in config.keys():
             return config[key]
         return default
 
-
-    def __is_config_key_valid(self, config:dict, key:str):
+    def __is_config_key_valid(self, config: dict, key: str):
         """ Check if a key is in a config dictionary """
         if key in config.keys():
             return True
@@ -343,7 +351,7 @@ class Batcontrol:
             )
 
         global loglevel
-        loglevel = self.__get_config_with_defaults(config, 'loglevel', 'info' )
+        loglevel = self.__get_config_with_defaults(config, 'loglevel', 'info')
 
         if loglevel == 'debug':
             logger.setLevel(logging.DEBUG)
@@ -361,10 +369,10 @@ class Batcontrol:
             )
 
         log_is_enabled = self.__get_config_with_defaults(
-                                    config,
-                                    'logfile_enabled',
-                                    LOGFILE_ENABLED_DEFAULT
-                                )
+            config,
+            'logfile_enabled',
+            LOGFILE_ENABLED_DEFAULT
+        )
         if log_is_enabled:
             self.setup_logfile(config)
         else:
@@ -378,8 +386,8 @@ class Batcontrol:
     def setup_logfile(self, config):
         """ Setup the logfile and correpsonding handlers """
 
-        if self.__is_config_key_valid(config , 'max_logfile_size'):
-            if isinstance(config['max_logfile_size'],int):
+        if self.__is_config_key_valid(config, 'max_logfile_size'):
+            if isinstance(config['max_logfile_size'], int):
                 pass
             else:
                 raise RuntimeError(
@@ -447,11 +455,25 @@ class Batcontrol:
         """ Main calculation & control loop """
         # Reset some values
         self.__reset_run_data()
+
+        # Verify some constrains:
+        #   always_allow_discharge needs to be above max_charging from grid.
+        #   if not, it will oscillate between discharging and charging.
+        if self.always_allow_discharge_limit < self.max_charging_from_grid_limit:
+            logger.warning("[BatCtrl] always_allow_discharge_limit (%.2f) is"
+                           " below max_charging_from_grid_limit (%.2f)",
+                            self.always_allow_discharge_limit ,
+                            self.max_charging_from_grid_limit
+                           )
+            self.max_charging_from_grid_limit = self.always_allow_discharge_limit - 0.01
+            logger.warning("[BatCtrl] Lowering max_charging_from_grid_limit to %.2f" ,
+                           self.max_charging_from_grid_limit )
+
         # for API
         self.refresh_static_values()
         self.set_discharge_limit(
             self.get_max_capacity() * self.always_allow_discharge_limit
-            )
+        )
         self.last_run_time = time.time()
 
         # prune log file if file is too large
@@ -486,7 +508,7 @@ class Batcontrol:
         for h in range(fc_period+1):
             production[h] = production_forecast[h]
             consumption[h] = consumption_forecast[h]
-            prices[h] = round(price_dict[h],self.round_price_digits)
+            prices[h] = round(price_dict[h], self.round_price_digits)
 
         net_consumption = consumption-production
         logger.debug('[BatCTRL] Production FCST: %s',
@@ -495,7 +517,8 @@ class Batcontrol:
                      np.ndarray.round(consumption, 1))
         logger.debug('[BatCTRL] Net Consumption FCST: %s',
                      np.ndarray.round(net_consumption, 1))
-        logger.debug('[BatCTRL] Prices: %s', np.ndarray.round(prices, self.round_price_digits))
+        logger.debug('[BatCTRL] Prices: %s', np.ndarray.round(
+            prices, self.round_price_digits))
         # negative = charging or feed in
         # positive = dis-charging or grid consumption
 
@@ -592,7 +615,8 @@ class Batcontrol:
         production = -np.array(net_consumption)
         production[production < 0] = 0
         min_price_difference = self.min_price_difference
-        min_dynamic_price_difference = self.__calculate_min_dynamic_price_difference(current_price)
+        min_dynamic_price_difference = self.__calculate_min_dynamic_price_difference(
+            current_price)
 
         # evaluation period until price is first time lower then current price
         for h in range(1, max_hour):
@@ -600,7 +624,8 @@ class Batcontrol:
             found_lower_price = False
             # Soften the price difference to avoid too early charging
             if self.soften_price_difference_on_charging:
-                modified_price = current_price-min_price_difference/self.soften_price_difference_on_charging_factor
+                modified_price = current_price-min_price_difference / \
+                    self.soften_price_difference_on_charging_factor
                 found_lower_price = future_price <= modified_price
             else:
                 found_lower_price = future_price <= current_price
@@ -654,7 +679,7 @@ class Batcontrol:
         if recharge_energy <= 0:
             logger.debug(
                 "[Rule] No additional energy required, because stored energy is sufficient."
-                )
+            )
             recharge_energy = 0
 
         if recharge_energy > free_capacity:
@@ -699,9 +724,11 @@ class Batcontrol:
 
         current_price = prices[0]
 
-        min_dynamic_price_difference = self.__calculate_min_dynamic_price_difference(current_price)
+        min_dynamic_price_difference = self.__calculate_min_dynamic_price_difference(
+            current_price)
         if self.mqtt_api is not None:
-            self.mqtt_api.publish_min_dynamic_price_diff(min_dynamic_price_difference)
+            self.mqtt_api.publish_min_dynamic_price_diff(
+                min_dynamic_price_difference)
 
         max_hour = len(net_consumption)
         # relevant time range : until next recharge possibility
@@ -710,14 +737,14 @@ class Batcontrol:
             if future_price <= current_price-min_dynamic_price_difference:
                 max_hour = h
                 logger.debug(
-                     "[Rule] Recharge possible in %d hours, limiting evaluation window.",
-                     h )
+                    "[Rule] Recharge possible in %d hours, limiting evaluation window.",
+                    h)
                 logger.debug(
-                      "[Rule] Future price: %.3f < Current price: %.3f - dyn_price_diff. %.3f ",
-                      future_price,
-                      current_price,
-                      min_dynamic_price_difference
-                    )
+                    "[Rule] Future price: %.3f < Current price: %.3f - dyn_price_diff. %.3f ",
+                    future_price,
+                    current_price,
+                    min_dynamic_price_difference
+                )
                 break
         dt = datetime.timedelta(hours=max_hour-1)
         t0 = datetime.datetime.now()
@@ -788,34 +815,35 @@ class Batcontrol:
         if self.discharge_blocked:
             logger.debug(
                 '[BatCTRL] Discharge blocked due to external lock'
-                )
+            )
             return False
 
         if stored_usable_energy > reserved_storage:
             # allow discharging
             logger.debug(
                 "[Rule] Discharge allowed. Stored usable energy %0.1f Wh >"
-                 " Reserved energy %0.1f Wh",
-                         stored_usable_energy,
-                         reserved_storage
-                         )
+                " Reserved energy %0.1f Wh",
+                stored_usable_energy,
+                reserved_storage
+            )
             return True
 
         # forbid discharging
         logger.debug(
             "[Rule] Discharge forbidden. Stored usable energy %0.1f Wh <= Reserved energy %0.1f Wh",
-                        stored_usable_energy,
-                        reserved_storage
-                        )
+            stored_usable_energy,
+            reserved_storage
+        )
 
         return False
 
     def __calculate_min_dynamic_price_difference(self, price: float) -> float:
         """ Calculate the dynamic limit for the current price """
         return round(
-            max(self.min_price_difference, self.min_price_difference_rel * abs(price)),
+            max(self.min_price_difference,
+                self.min_price_difference_rel * abs(price)),
             self.round_price_digits
-            )
+        )
 
     def __set_charge_rate(self, charge_rate: int):
         """ Set charge rate and publish to mqtt """
@@ -904,7 +932,8 @@ class Batcontrol:
         """ Returns the stored eneregy in the battery in kWh with considering
             the MIN_SOC of inverters. """
         if not self.fetched_stored_usable_energy:
-            self.set_stored_usable_energy( self.inverter.get_stored_usable_energy())
+            self.set_stored_usable_energy(
+                self.inverter.get_stored_usable_energy())
             self.fetched_stored_usable_energy = True
         return self.last_stored_usable_energy
 
@@ -939,7 +968,7 @@ class Batcontrol:
             self.mqtt_api.publish_stored_usable_energy_capacity(
                 stored_usable_energy)
 
-    def set_discharge_limit(self, discharge_limit)-> None:
+    def set_discharge_limit(self, discharge_limit) -> None:
         """ Sets the always_allow_discharge_limit and publishes it to the API.
             This is the value in Wh.
         """
@@ -947,6 +976,17 @@ class Batcontrol:
         if self.mqtt_api is not None:
             self.mqtt_api.publish_always_allow_discharge_limit_capacity(
                 discharge_limit)
+
+    def set_always_allow_discharge_limit(self, always_allow_discharge_limit: float) -> None:
+        """ Set the always allow discharge limit for battery control """
+        self.always_allow_discharge_limit = always_allow_discharge_limit
+        if self.mqtt_api is not None:
+            self.mqtt_api.publish_always_allow_discharge_limit(
+                always_allow_discharge_limit)
+
+    def get_always_allow_discharge_limit(self) -> float:
+        """ Get the always allow discharge limit for battery control """
+        return self.always_allow_discharge_limit
 
     def set_discharge_blocked(self, discharge_blocked) -> None:
         """ Avoid discharging if an external block is received,
@@ -1031,7 +1071,7 @@ class Batcontrol:
             return
         logger.info(
             '[BatCtrl] API: Setting always allow discharge limit to %.2f', limit)
-        self.always_allow_discharge_limit = limit
+        self.set_always_allow_discharge_limit(limit)
 
     def api_set_max_charging_from_grid_limit(self, limit: float):
         """ Set max charging from grid limit for battery control via external API request.
@@ -1061,11 +1101,12 @@ class Batcontrol:
         """ Log and change config min_price_difference_rel from external call """
         if min_price_difference_rel < 0:
             logger.warning(
-                 '[BatCtrl] API: Invalid min price rel difference %.3f', min_price_difference_rel)
+                '[BatCtrl] API: Invalid min price rel difference %.3f', min_price_difference_rel)
             return
         logger.info(
-              '[BatCtrl] API: Setting min price rel difference to %.3f', min_price_difference_rel)
+            '[BatCtrl] API: Setting min price rel difference to %.3f', min_price_difference_rel)
         self.min_price_difference_rel = min_price_difference_rel
+
 
 if __name__ == '__main__':
     bc = Batcontrol(CONFIGFILE)

--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -82,6 +82,7 @@ evcc:
   loadpoint_topic:
     - evcc/loadpoints/1/charging
     - evcc/loadpoints/2/charging
+  battery_soc_topic: evcc/site/bufferSoc
   username: user
   password: password
   tls: false

--- a/evcc_api.py
+++ b/evcc_api.py
@@ -1,4 +1,3 @@
-
 """
 This module provides the EvccApi class for interacting with an
 evcc (Electric Vehicle Charging Controller) via MQTT.
@@ -8,7 +7,7 @@ import re
 import logging
 import paho.mqtt.client as mqtt
 
-logger = logging.getLogger('__main__')
+logger = logging.getLogger('__main__').getChild("evcc")
 logger.info('[evcc] loading module')
 
 class EvccApi():
@@ -19,10 +18,18 @@ class EvccApi():
         config (dict): Configuration dictionary containing MQTT broker details, topics.
         evcc_is_online (bool): Internal state indicating if evcc is online.
         evcc_is_charging (bool): Internal state indicating if evcc is charging.
+        evcc_batterSoc_threshold (int): BufferSOC value from evcc.
         block_function (function): Function to be called to block/unblock Battery.
+        set_always_allow_discharge_limit_function (function): Function to set the discharge limit.
+        get_always_allow_discharge_limit_function (function): Function to get the discharge limit.
+        evcc_loadpoint_status (dict): Internal state to store the loadpoint status.
         topic_status (str): MQTT topic for evcc status messages.
         topic_loadpoint (str): MQTT topic for evcc loadpoint messages.
+        topic_battery_soc_threshold (str): MQTT topic for evcc battery SOC threshold.
         client (mqtt.Client): MQTT client instance.
+        align_battery_load_thresshold (bool): If set, use evcc/site/bufferSoc as
+                                              discharge_allow_threshold while charging.
+        old_discharge_allow_threshold (int): Old discharge_allow_threshold value.
 
     Methods:
         __init__(config: dict):
@@ -33,6 +40,9 @@ class EvccApi():
 
         register_block_function(function):
             Registers a function to be called to block/unblock charging.
+
+        register_always_allow_discharge_limit(setter, getter):
+            Registers a function to set and get the discharge limit while charging
 
         set_evcc_online(online: bool):
             Sets the evcc online status and handles state changes.
@@ -46,11 +56,15 @@ class EvccApi():
         handle_charging_message(message):
             Handles incoming charging messages from the MQTT broker.
 
+        handle_battery_soc_threshold(message):
+            Handles incoming bufferSOC messages from the MQTT broker.
+
         _handle_message(client, userdata, message):
             Internal callback function to handle incoming MQTT messages.
     """
-    def __init__(self, config:dict):
-        self.config=config
+
+    def __init__(self, config: dict):
+        self.config = config
 
         # internal state
         self.evcc_is_online = False
@@ -59,9 +73,15 @@ class EvccApi():
         self.evcc_loadpoint_status = {}
 
         self.block_function = None
+        self.set_always_allow_discharge_limit_function = None
+        self.get_always_allow_discharge_limit_function = None
 
         self.topic_status = config['status_topic']
         self.list_topics_loadpoint = []
+        self.topic_battery_soc_threshold = config.get(
+            'battery_soc_topic', None)
+        self.evcc_batterSoc_threshold = None # bufferSOC pylint: disable=invalid-name
+        self.old_discharge_allow_threshold = None
 
         if isinstance(config['loadpoint_topic'], str):
             self.list_topics_loadpoint.append(config['loadpoint_topic'])
@@ -70,7 +90,8 @@ class EvccApi():
         else:
             logger.error('[evcc] Invalid loadpoint_topic type')
 
-        self.client = mqtt.Client()
+        self.client = mqtt.Client(clean_session=True)
+
         if 'logger' in config and config['logger'] is True:
             self.client.enable_logger(logger)
 
@@ -88,22 +109,43 @@ class EvccApi():
                 ciphers=config['tls']['ciphers']
             )
 
-        self.client.loop_start()
-        self.client.connect(config['broker'], config['port'], 60)
-        self.client.on_connect = self.on_connect
-
-        self.wait_ready()
         # Register callback functions, survives reconnects
-        self.client.message_callback_add(self.topic_status, self._handle_message)
+        self.client.message_callback_add(
+            self.topic_status, self._handle_message)
+        if self.topic_battery_soc_threshold is not None:
+            logger.info('[evcc] Enabling bufferSOC threshold management.')
+            self.client.message_callback_add(
+                self.topic_battery_soc_threshold, self._handle_message)
         for topic in self.list_topics_loadpoint:
             self.__store_loadpoint_status(topic, False)
             self.client.message_callback_add(topic, self._handle_message)
 
-    def on_connect(self, client, userdata, flags, rc): # pylint: disable=unused-argument
+        self.client.on_connect = self.on_connect
+
+    def start(self):
+        """ Start MQTT connection after all init is completed"""
+        self.client.loop_start()
+        self.client.connect(self.config['broker'], self.config['port'], 60)
+        self.wait_ready()
+
+
+    def shutdown(self):
+        """ Shutdown the evcc mqtt client """
+        self.client.unsubscribe(self.topic_status)
+        if self.topic_battery_soc_threshold is not None:
+            self.client.unsubscribe(self.topic_battery_soc_threshold)
+        for topic in self.list_topics_loadpoint:
+            self.client.unsubscribe(topic)
+        self.client.loop_stop()
+        self.client.disconnect()
+
+    def on_connect(self, client, userdata, flags, rc):  # pylint: disable=unused-argument
         """ Callback function for MQTT on_connect """
         logger.info('[evcc] Connected to MQTT Broker with result code %s', rc)
         # Subscribe to status and loadpoint(s)
-        self.client.subscribe(self.topic_status)
+        self.client.subscribe(self.topic_status, qos=1)
+        if self.topic_battery_soc_threshold is not None:
+            self.client.subscribe(self.topic_battery_soc_threshold, qos=1)
         for topic in self.list_topics_loadpoint:
             logger.info('[evcc] Subscribing to %s', topic)
             self.client.subscribe(topic)
@@ -125,7 +167,39 @@ class EvccApi():
         """ Register a function to be called to block/unblock battery while charging """
         self.block_function = function
 
-    def set_evcc_online(self, online:bool):
+    def register_always_allow_discharge_limit(self, setter, getter):
+        """ Register a function to set and get the discharge limit while charging """
+        self.set_always_allow_discharge_limit_function = setter
+        self.get_always_allow_discharge_limit_function = getter
+
+
+    def __save_old_allow_discharge_limit(self):
+        """ Save old limit, if not already set."""
+        if self.old_discharge_allow_threshold is None:
+            self.old_discharge_allow_threshold = self.get_always_allow_discharge_limit_function()
+
+    def __restore_old_allow_discharge_limit(self):
+        """ Restore old limit, if set and set to None """
+        if not self.old_discharge_allow_threshold is None:
+            logger.info("[evcc] Restoring allow_discharge_limit %.2f" , self.old_discharge_allow_threshold)
+            self.set_always_allow_discharge_limit_function (
+                self.old_discharge_allow_threshold
+            )
+            self.old_discharge_allow_threshold = None
+
+    def set_evcc_discharge_limit_on_batcontrol(self):
+        """ Set allow_discharge_limit on batcontrol"""
+        if self.evcc_batterSoc_threshold is not None:
+            new_threshold = self.evcc_batterSoc_threshold / 100
+            logger.info('[evcc] Setting always_allow_discharge_limit to %.2f',
+                    new_threshold)
+            self.set_always_allow_discharge_limit_function(
+                new_threshold
+            )
+        else:
+            logger.error('[evcc] No bufferSOC value received')
+
+    def set_evcc_online(self, online: bool):
         """ Set the evcc online status and handle state changes.
             If the evcc goes offline while charging, we remove an existing block.
         """
@@ -137,12 +211,13 @@ class EvccApi():
                     logger.error('[evcc] evcc was charging, remove block')
                     self.evcc_is_charging = False
                     self.block_function(False)
+                    self.__restore_old_allow_discharge_limit()
                     self.__reset_loadpoint_status()
             else:
                 logger.info('[evcc] evcc is online')
             self.evcc_is_online = online
 
-    def set_evcc_charging(self, charging:bool):
+    def set_evcc_charging(self, charging: bool):
         """ Set the evcc charging status and handle state changes """
         if self.evcc_is_charging != charging:
             if charging is True:
@@ -150,13 +225,17 @@ class EvccApi():
                 logger.info('[evcc] evcc is charging, set block')
                 self.evcc_is_charging = True
                 self.block_function(True)
+                if self.topic_battery_soc_threshold is not None:
+                    self.__save_old_allow_discharge_limit()
+                    self.set_evcc_discharge_limit_on_batcontrol()
             else:
                 logger.info('[evcc] evcc is not charging, remove block')
                 self.evcc_is_charging = False
                 self.block_function(False)
+                self.__restore_old_allow_discharge_limit()
         self.evcc_is_charging = charging
 
-    def __store_loadpoint_status(self, topic:str, is_charging:bool):
+    def __store_loadpoint_status(self, topic: str, is_charging: bool):
         """ Store the loadpoint status """
         send_info = False
         if topic not in self.evcc_loadpoint_status:
@@ -172,7 +251,6 @@ class EvccApi():
             else:
                 logger.info('[evcc] Loadpoint %s is charging.', topic)
 
-
     def __reset_loadpoint_status(self):
         """ Reset the loadpoint status """
         for topic in self.list_topics_loadpoint:
@@ -180,13 +258,34 @@ class EvccApi():
 
     def handle_status_messages(self, message):
         """ Handle incoming status messages from the MQTT broker """
+        #logger.debug('[evcc] Received status message: %s', message.payload)
         if message.payload == b'online':
             self.set_evcc_online(True)
         elif message.payload == b'offline':
             self.set_evcc_online(False)
 
+    def handle_battery_soc_threshold(self, message):
+        """ Handling incoming bufferSOC message, change if needed. """
+        #logger.debug('[evcc] Received bufferSOC message: %s', message.payload)
+        if message.payload == b'':
+            # Initial Messages from evcc on restart.
+            return
+        try:
+            new_soc = int(message.payload)
+            if self.evcc_batterSoc_threshold is None or \
+               self.evcc_batterSoc_threshold != new_soc:
+                self.evcc_batterSoc_threshold = new_soc
+                logger.info('[evcc] New bufferSOC value: %s', new_soc)
+                if self.evcc_is_charging is True:
+                    self.set_always_allow_discharge_limit_function(new_soc/100)
+        except ValueError:
+            logger.error('[evcc] Could not convert bufferSOC to int')
+
     def handle_charging_message(self, message):
         """ Handle incoming charging messages from the MQTT broker """
+        if message.payload == b'':
+            # Initial Messages from evcc on restart.
+            return
         if re.match(b'true', message.payload, re.IGNORECASE):
             self.__store_loadpoint_status(message.topic, True)
         elif re.match(b'false', message.payload, re.IGNORECASE):
@@ -202,13 +301,17 @@ class EvccApi():
                 return
         self.set_evcc_charging(False)
 
-    def _handle_message(self, client, userdata, message): # pylint: disable=unused-argument
+    def _handle_message(self, client, userdata, message):  # pylint: disable=unused-argument
         """ Message dispatching function """
-        logger.debug('[evcc] Received message on %s', message.topic)
-        if message.topic == self.config['status_topic']:
+        #logger.debug('[evcc] Received message on %s', message.topic)
+        if message.topic == self.topic_status:
             self.handle_status_messages(message)
+        elif self.topic_battery_soc_threshold is not None and \
+                message.topic == self.topic_battery_soc_threshold:
+            self.handle_battery_soc_threshold(message)
         # Check if message.topic is in self.list_topics_loadpoint
         elif message.topic in self.list_topics_loadpoint:
             self.handle_charging_message(message)
         else:
-            logger.warning('[evcc] No callback registered for %s', message.topic)
+            logger.warning(
+                '[evcc] No callback registered for %s', message.topic)


### PR DESCRIPTION
it is possible to subscribe the configuration topic evcc/site/bufferSoC.

This parameter reflects the "priority ev charge" limit from the GUI. Changes on evcc gui are relfected in that topic, and now being used by evcc-batcontrol.

If charging starts, evcc-plugin sets allow_discharge to this value. If charging ends, the old value is restored.

To prevent some weird issues with recharging from grid, max_charging_from_grid is lowered (but not restored).

The connection handling is reworked to improve timing issues with retained topics.