### PR TITLE
Upgrade CI to use UV

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           pyproject-file: "pyproject.toml"
+          enable-cache: true
+          cache-local-path: "${{ github.workspace }}/.uv"
           prune-cache: false
           cache-dependency-glob: "**/pyproject.toml"
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -24,14 +24,10 @@ jobs:
 
       - name: Set up uv with Python ${{ matrix.python-version }}
         id: setup-uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
-          pyproject-file: "pyproject.toml"
-          enable-cache: true
-          cache-local-path: "${{ github.workspace }}/.uv"
-          prune-cache: false
-          cache-dependency-glob: "**/pyproject.toml"
+          activate-environment: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -36,4 +36,4 @@ jobs:
 
       - name: Run pylint
         run: |
-          pylint --fail-under 9 --source-roots ./src batcontrol
+          pylint -j 0 --fail-under 9 --source-roots ./src batcontrol

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -31,6 +31,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           pyproject-file: "pyproject.toml"
           prune-cache: false
+          cache-dependency-glob: "**/pyproject.toml"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -37,4 +37,4 @@ jobs:
 
       - name: Run pylint
         run: |
-          pylint --fail-under 9 --source-roots ./src batcontrol
+          pylint -j 0 --fail-under 9 --source-roots ./src batcontrol

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           pyproject-file: "pyproject.toml"
+          prune-cache: false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -24,16 +24,16 @@ jobs:
         with:
           fetch-depth: 0  # Alle Commits holen
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - name: Set up uv with Python ${{ matrix.python-version }}
+        id: setup-uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
+          pyproject-file: "pyproject.toml"
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install .
-          pip install pylint
+          uv pip install pylint
 
       - name: Run pylint
         run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run pylint
         run: |
-          pylint -j 0 --fail-under 9 --source-roots ./src batcontrol
+          pylint --fail-under 9 --source-roots ./src batcontrol

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Alle Commits holen
 
       - name: Set up uv with Python ${{ matrix.python-version }}
         id: setup-uv

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          uv pip install .
           uv pip install pylint
 
       - name: Run pylint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,7 @@ where = ["./src"]
 
 [tool.setuptools.dynamic]
 version = {attr = "batcontrol.__pkginfo__.__version__"}
+
+# Configure additional tools
+[tool.uv]
+required-version = "~=0.6.0" # Pin uv to major version for stability


### PR DESCRIPTION
This pull request updates the Python environment setup in the CI workflow to use the `uv` tool for improved dependency management and stability. It also introduces a configuration for `uv` in the `pyproject.toml` file.

### CI Workflow Updates:
* [`.github/workflows/pylint.yml`](diffhunk://#diff-3fb2867e4a7c0ecbfdf0f36a3078f1689dca17453c5e0ebdd0671bb94733b5a3L24-R39): Replaced `actions/setup-python@v3` with `astral-sh/setup-uv@v6` for setting up Python and managing dependencies. Enabled `activate-environment` for `uv` and updated commands to use `uv` for installing dependencies and running `pylint`. Added parallelism (`-j 0`) to `pylint` for performance improvements.

### Configuration Updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R28-R31): Added a `[tool.uv]` section to pin the `uv` version to `~=0.6.0` for stability.