### PR TITLE
evcc-prices: adapt to API changes

### DIFF
--- a/src/batcontrol/dynamictariff/evcc.py
+++ b/src/batcontrol/dynamictariff/evcc.py
@@ -75,7 +75,7 @@ class Evcc(DynamicTariffBaseclass):
             diff=timestamp-now
             rel_hour=math.ceil(diff.total_seconds()/3600)
             if rel_hour >=0:
-                if item.has_key('value'):
+                if item.get('value', None) is not None:
                     prices[rel_hour]=item['value']
                 else:
                     prices[rel_hour]=item['price']

--- a/src/batcontrol/dynamictariff/evcc.py
+++ b/src/batcontrol/dynamictariff/evcc.py
@@ -75,7 +75,10 @@ class Evcc(DynamicTariffBaseclass):
             diff=timestamp-now
             rel_hour=math.ceil(diff.total_seconds()/3600)
             if rel_hour >=0:
-                prices[rel_hour]=item['price']
+                if item.has_key('value'):
+                    prices[rel_hour]=item['value']
+                else:
+                    prices[rel_hour]=item['price']
         return prices
 
 def test():

--- a/src/batcontrol/dynamictariff/evcc.py
+++ b/src/batcontrol/dynamictariff/evcc.py
@@ -75,6 +75,7 @@ class Evcc(DynamicTariffBaseclass):
             diff=timestamp-now
             rel_hour=math.ceil(diff.total_seconds()/3600)
             if rel_hour >=0:
+                # since evcc 0.203.0 value is the name of the price field.
                 if item.get('value', None) is not None:
                     prices[rel_hour]=item['value']
                 else:


### PR DESCRIPTION
The price field turned into the fieldname „value“.