### PR TITLE
Prefer-binary over source to always use piwheels even if source version is actually newer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ LABEL maintainer="matthias.strubel@aod-rpg.de"
 
 # Copy the built wheel from the builder stage and install it
 COPY --from=builder /wheels /wheels
-RUN pip install --no-cache-dir --extra-index-url https://piwheels.org/simple /wheels/*.whl && rm -rf /wheels
+
+# Update pip and install runtime dependencies
+RUN pip install --no-cache-dir --extra-index-url https://piwheels.org/simple --prefer-binary /wheels/*.whl && rm -rf /wheels
 
 ENV BATCONTROL_VERSION=${VERSION}
 ENV BATCONTROL_GIT_SHA=${GIT_SHA}


### PR DESCRIPTION
This pull request updates the `Dockerfile` to improve the installation process for Python dependencies by ensuring binary packages are preferred during installation.

Key change:

* Updated the `RUN pip install` command in the `Dockerfile` to include the `--prefer-binary` flag, ensuring pip prioritizes binary packages when installing dependencies. This change may improve compatibility and reduce build times.