### PR TITLE
Add an automatic release workflow using github actions

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,78 @@
+name: Bump version
+
+on:
+  workflow_call:
+    inputs:
+      bump-type:
+        description: 'The type of bump to perform'
+        required: true
+        type: string
+        default: 'patch'
+    outputs:
+      bumped:
+        description: 'Whether the version was bumped'
+        value: ${{ jobs.bump.outputs.bumped }}
+      previous-version:
+        description: 'The previous version'
+        value: ${{ jobs.bump.outputs.previous-version }}
+      current-version:
+        description: 'The current version'
+        value: ${{ jobs.bump.outputs.current-version }}
+
+  workflow_dispatch:
+    inputs:
+      bump-type:
+        description: 'The type of bump to perform'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+        - major
+        - minor
+        - patch
+        - release
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    outputs:
+      bumped: ${{ steps.bump.outputs.bumped }}
+      previous-version: ${{ steps.bump.outputs.previous-version }}
+      current-version: ${{ steps.bump.outputs.current-version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for tags history
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+        
+      - name: Install bump2version
+        run: pip install bump2version
+
+      - name: Setup git user
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Bump version
+        id: bump
+        run: |
+          echo "previous-version=$(bump-my-version show current_version)" >> $GITHUB_OUTPUT
+          bump-my-version bump ${{ inputs.bump-type }} --commit
+          ([[ $? -gt 0 ]] && echo "bumped=false" || echo "bumped=true") >> $GITHUB_OUTPUT
+          echo "current-version=$(bump-my-version show current_version)" >> $GITHUB_OUTPUT
+
+      - name: Check
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          echo "Version was bumped from ${{ steps.bump.outputs.previous-version }} to ${{ steps.bump.outputs.current-version }}!"
+
+      - name: Push changes
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          git push
+          git push --tags

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -45,13 +45,14 @@ jobs:
         with:
           fetch-depth: 0  # Required for tags history
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
+      - name: Setup uv
+        id: setup-uv
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.12'
         
       - name: Install bump2version
-        run: pip install bump2version
+        run: uv pip install bump-my-version
 
       - name: Setup git user
         run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,97 @@
+# .github/workflows/prepare-release.yml
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv with Python 3.12
+        id: setup-uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: 3.12
+          activate-environment: true
+          
+      - name: Install bump-my-version
+        run: uv pip install bump-my-version
+        
+      - name: Setup git user
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          
+      - name: Create release branch
+        id: create_branch
+        run: |
+          BRANCH="prepare-release"
+          git switch -c $BRANCH
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          
+      - name: Bump version
+        id: bump_version
+        run: |
+          # Get current version before bump
+          CURRENT_VERSION=$(bump-my-version show current_version)
+          echo "previous-version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          
+          # Bump version
+          bump-my-version bump release --commit
+          
+          # Get new version after bump
+          NEW_VERSION=$(bump-my-version show current_version)
+          echo "current-version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          
+      - name: Build package
+        id: build
+        run: |
+          uv build --no-sources .
+          echo "WHEEL_FILE=$(ls dist/*.whl)" >> $GITHUB_OUTPUT
+          echo "TAR_FILE=$(ls dist/*.tar.gz)" >> $GITHUB_OUTPUT
+          
+      - name: Create Draft Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ${{ steps.build.outputs.WHEEL_FILE }}
+            ${{ steps.build.outputs.TAR_FILE }}
+          draft: true
+          name: "Release ${{ steps.bump_version.outputs.current-version }}"
+          tag_name: v${{ steps.bump_version.outputs.current-version }}
+          body: |
+            ## Release ${{ steps.bump_version.outputs.current-version }}
+            
+            *Release notes will be added here*
+            
+            ### Artifacts
+            - Python wheel package
+            - Source distribution
+          
+      - name: Push branch
+        run: git push -f -u origin ${{ steps.create_branch.outputs.branch }}
+          
+      - name: Create PR
+        id: create-pr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: "Release ${{ steps.bump_version.outputs.current-version }}"
+          body: |
+            # Release ${{ steps.bump_version.outputs.current-version }}
+            
+            This PR prepares release ${{ steps.bump_version.outputs.current-version }}.
+            
+            ## Manual steps after review:
+            1. Merge this PR
+            2. Create a tag with the release version on the merged commit
+            3. Finalize the release on GitHub
+            
+            The tag will trigger Docker image build automatically.
+          branch: ${{ steps.create_branch.outputs.branch }}
+          base: main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,27 @@ version = {attr = "batcontrol.__pkginfo__.__version__"}
 # Configure additional tools
 [tool.uv]
 required-version = "~=0.6.0" # Pin uv to major version for stability
+
+# Bump Version
+[tool.bumpversion]
+current_version = "0.5.0dev"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?P<release>dev)?"
+serialize = [
+    "{major}.{minor}.{patch}{release}",
+    "{major}.{minor}.{patch}"
+]
+ignore_current_version = true
+tag_name = "{new_version}"
+message = "Bump version: {current_version} → {new_version}"
+
+[tool.bumpversion.parts.release]
+optional_value = ""
+values = [
+    "dev",
+    ""
+]
+
+[[tool.bumpversion.files]]
+filename = "src/batcontrol/__pkginfo__.py"
+search = "__version__ = \"{current_version}\""
+replace = "__version__ = \"{new_version}\""

--- a/src/batcontrol/__pkginfo__.py
+++ b/src/batcontrol/__pkginfo__.py
@@ -1,1 +1,1 @@
-__version__ = '0.5.0dev'
+__version__ = "0.5.0dev"


### PR DESCRIPTION
This PR adds a streamlined release process using GitHub Actions:

- Adds bump-my-version configuration to automated version bumping
- Creates a reusable workflow for version bumping
- Implements a "Prepare Release" workflow that:
  - Creates a branch with bumped version
  - Builds package artifacts (wheel file and source distribution)
  - Creates a draft GitHub release
  - Opens a PR for review

Now for release just: 
1. trigger the new workflow and review PR
2. Merge the PR and complete the draft release
3. Manually tag the merged commit to trigger docker build

This is just a first implementation, can be automated even further in the future (e.g. automatically tag commits, trigger docker build on release, automatically triggering an update for the ha repo). Let me know what you think :)