### PR TITLE
Bump uv to version 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,4 @@ version = {attr = "batcontrol.__pkginfo__.__version__"}
 
 # Configure additional tools
 [tool.uv]
-required-version = "~=0.6.0" # Pin uv to major version for stability
+required-version = "~=0.7.0" # Pin uv to major version for stability


### PR DESCRIPTION
This pull request updates the dependency version for the `uv` tool in `pyproject.toml` to ensure compatibility with the latest features and improvements.

Dependency update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L31-R31): Updated the `required-version` for the `uv` tool from `~=0.6.0` to `~=0.7.0` to pin it to the latest major version for stability.