### PR TITLE
Fix license error when building the package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "batcontrol"
 dynamic = ["version"]
 description = "Optimize electricity costs by recharging your PV battery when electricity is cheap and solar power is insufficient"
 authors = [{name = "Stephan Mükusch", email = "muexxl@gmx.net"}]
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">3.8, <3.13"
 dependencies = [


### PR DESCRIPTION
Fixes the warning: `SetuptoolsDeprecationWarning: project.license as a TOML table is deprecated`

Had the same error in another project, so I fixed it for batcontrol aswell :)