### PR TITLE
Fix the example value for max_pv_chage_rate

### DIFF
--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -36,8 +36,8 @@ inverter:
   address: 192.168.0.XX # the local IP of your inverter. needs to be reachable from the machine that runs batcontrol
   user: customer #customer or technician lowercase only!!
   password: YOUR-PASSWORD #
-  max_grid_charge_rate: 5000 # Watt
-  max_pv_charge_rate: 3000 # Watt ; This allows to limit the PV to Battery charge rate. Set to 0 for unlimited charging.
+  max_grid_charge_rate: 5000 # Watt, Upper limit for Grid to Battery charge rate.
+  max_pv_charge_rate: 0 # Watt, This allows to limit the PV to Battery charge rate. Set to 0 for unlimited charging.
 
 #--------------------------
 #  Dynamic Tariff Provider

--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -37,7 +37,7 @@ inverter:
   user: customer #customer or technician lowercase only!!
   password: YOUR-PASSWORD #
   max_grid_charge_rate: 5000 # Watt
-  max_pv_charge_rate : 3000 # Watt
+  #max_pv_charge_rate: 3000 # Watt ; This allows to limit the PV to Battery charge rate
 
 #--------------------------
 #  Dynamic Tariff Provider

--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -37,7 +37,7 @@ inverter:
   user: customer #customer or technician lowercase only!!
   password: YOUR-PASSWORD #
   max_grid_charge_rate: 5000 # Watt
-  #max_pv_charge_rate: 3000 # Watt ; This allows to limit the PV to Battery charge rate
+  max_pv_charge_rate: 3000 # Watt ; This allows to limit the PV to Battery charge rate. Set to 0 for unlimited charging.
 
 #--------------------------
 #  Dynamic Tariff Provider


### PR DESCRIPTION
The config-key had an unintended whitespace, which resulted into not a behavior of an unlimited PV charge.

 This is already in the "field" from users relying on the dummy
 config.

 So this behavior is now reflectred with a fixed key entry and an uncommented line.

#163 