### PR TITLE
Fix the failing release action

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,6 +1,9 @@
 # .github/workflows/prepare-release.yml
 name: Prepare Release
 
+permissions: 
+  contents: write # Grants write access to repository contents (required for creating releases)
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
This pull request makes a small but important change to the GitHub Actions workflow file `.github/workflows/prepare-release.yml`. The change adds a `permissions` section to grant write access to repository contents, which is required for creating releases.