### PR TITLE
evcc-plugin: Fix for saving old charge_from_Grid vlaue

### DIFF
--- a/src/batcontrol/evcc_api.py
+++ b/src/batcontrol/evcc_api.py
@@ -191,10 +191,6 @@ class EvccApi():
             self.old_allow_discharge_limit = self.get_always_allow_discharge_limit_function()
         if self.old_max_charge_limit is None:
             self.old_max_charge_limit = self.get_max_charge_limit_function()
-            if self.old_max_charge_limit > self.battery_halt_soc_float:
-                # Only store if the old value is higher than the new battery_hold one,
-                # which may be altered by batcontrol to a lower value.
-                self.old_max_charge_limit = None
 
     def __restore_old_limits(self):
         """ Restore old limits, if set and set to None """


### PR DESCRIPTION
Removed condition to store old max charge limit if it exceeds battery halt state of charge. This if results in discarding an old saved state. Without the condition, the parameter is stored once and then restored after charging.

Closes #171