### PR TITLE
Make  max logfile size working again and enhance logging setup

### DIFF
--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -6,7 +6,7 @@ timezone: Europe/Berlin #your time zone. not optional.
 loglevel: debug
 logfile_enabled: true
 log_everything: false # if false debug messages from fronius.auth and urllib3.connectionpool will be suppressed
-max_logfile_size: 100 #kB
+max_logfile_size: 200 #kB
 logfile_path: logs/batcontrol.log
 battery_control:
                                  # min_price_difference is the absolute minimum price difference in Euro to justify charging your battery

--- a/src/batcontrol/__main__.py
+++ b/src/batcontrol/__main__.py
@@ -24,7 +24,9 @@ def main() -> int:
     loglevel = config.get('loglevel', 'info')
     logfile_enabled = config.get('logfile_enabled', LOGFILE_ENABLED_DEFAULT)
     log_everything = config.get('log_everything', False)
-    logfile = LOGFILE if logfile_enabled else None
+    max_logfile_size = config.get('max_logfile_size', 200)  # Default 200KB
+    logfile_path = config.get('logfile_path', LOGFILE)
+    logfile = logfile_path if logfile_enabled else None
 
     if not logfile_enabled:
         logger.info("Logfile disabled in config. Proceeding without logfile")
@@ -38,7 +40,7 @@ def main() -> int:
     }
 
     # Setup the logger based on the config
-    setup_logging(level=loglevel_mapping.get(loglevel, logging.INFO), logfile=logfile)
+    setup_logging(level=loglevel_mapping.get(loglevel, logging.INFO), logfile=logfile, max_logfile_size_kb=max_logfile_size)
     logger = logging.getLogger(__name__)
 
     # Reduce the default loglevel for urllib3.connectionpool

--- a/src/batcontrol/setup.py
+++ b/src/batcontrol/setup.py
@@ -4,12 +4,13 @@ import os
 import yaml
 from logging.handlers import RotatingFileHandler
 
-def setup_logging(level=logging.INFO, logfile=None):
+def setup_logging(level=logging.INFO, logfile=None, max_logfile_size_kb=200):
     """Configure root logger with consistent formatting.
     
     Args:
         level (int): Log level to set for the root logger.
         logfile (str): If specified, log to this file as well as the console.
+        max_logfile_size_kb (int): Maximum log file size in kilobytes before rotation.
 
     Returns:
         logging.Logger: Root logger
@@ -36,7 +37,9 @@ def setup_logging(level=logging.INFO, logfile=None):
     if logfile:
         if not os.path.exists(os.path.dirname(logfile)):
             os.makedirs(os.path.dirname(logfile))
-        file_handler = RotatingFileHandler(logfile, maxBytes=10*1024*1024, backupCount=2)
+        # Convert KB to bytes for RotatingFileHandler
+        max_bytes = max_logfile_size_kb * 1024
+        file_handler = RotatingFileHandler(logfile, maxBytes=max_bytes, backupCount=2)
         file_handler.setFormatter(formatter)
         root_logger.addHandler(file_handler)
 


### PR DESCRIPTION
During the latest changes, that config option was not used anymore.
This PR implements it again and increase the logfile size to 200Kb, because of excessive logging.