### PR TITLE
Add sensor_unit configuration support for HomeAssistant forecasts

### DIFF
--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -122,6 +122,9 @@ consumption_forecast:
   #   base_url: ws://homeassistant:8123  # Your HomeAssistant URL
   #   apitoken: YOUR_LONG_LIVED_ACCESS_TOKEN  # Get from HomeAssistant Profile
   #   entity_id: sensor.energy_consumption  # Entity ID with consumption data (in Wh or kWh)
+  #   sensor_unit: auto  # Options: 'auto' (default, auto-detect), 'Wh', or 'kWh'
+  #                      # Set to 'Wh' or 'kWh' to skip auto-detection (faster startup)
+  #                      # Use 'auto' for first-time setup or if you're unsure
   #   history_days: [-7, -14, -21]  # Days to look back for historical data
   #   history_weights: [1, 1, 1]  # Weight for each history period (1-10), higher = more influence
   #   cache_ttl_hours: 48.0  # How long to cache computed statistics (hours)

--- a/src/batcontrol/forecastconsumption/consumption.py
+++ b/src/batcontrol/forecastconsumption/consumption.py
@@ -74,11 +74,12 @@ def _create_homeassistant_forecast(tz, config) -> ForecastConsumptionInterface:
 
     cache_ttl_hours = ha_config.get('cache_ttl_hours', 48.0)
     multiplier = ha_config.get('multiplier', 1.0)
+    sensor_unit = ha_config.get('sensor_unit', "auto")
 
     logger.info(
         "Creating HomeAssistant consumption forecast: "
-        "entity_id=%s, history_days=%s, weights=%s, multiplier=%0.2f",
-        entity_id, history_days, history_weights, multiplier
+        "entity_id=%s, history_days=%s, weights=%s, multiplier=%0.2f, sensor_unit=%s",
+        entity_id, history_days, history_weights, multiplier, sensor_unit
     )
 
     consumption = ForecastConsumptionHomeAssistant(
@@ -89,7 +90,8 @@ def _create_homeassistant_forecast(tz, config) -> ForecastConsumptionInterface:
         history_days=history_days,
         history_weights=history_weights,
         cache_ttl_hours=cache_ttl_hours,
-        multiplier=multiplier
+        multiplier=multiplier,
+        sensor_unit=sensor_unit
     )
     return consumption
 

--- a/tests/batcontrol/forecastconsumption/test_consumption_factory.py
+++ b/tests/batcontrol/forecastconsumption/test_consumption_factory.py
@@ -1,0 +1,219 @@
+"""Tests for consumption forecast factory (Issue #241)"""
+
+from unittest.mock import patch
+import pytest
+import pytz
+from src.batcontrol.forecastconsumption.consumption import (
+    Consumption,
+    _create_homeassistant_forecast
+)
+from src.batcontrol.forecastconsumption.forecast_homeassistant import (
+    ForecastConsumptionHomeAssistant
+)
+
+
+@pytest.fixture
+def timezone():
+    """Return Berlin timezone for testing"""
+    return pytz.timezone('Europe/Berlin')
+
+
+class TestConsumptionFactory:
+    """Test cases for Consumption factory with sensor_unit support"""
+
+    @patch.object(ForecastConsumptionHomeAssistant, '_check_sensor_unit', return_value=1.0)
+    def test_create_homeassistant_with_sensor_unit_wh(self, mock_check, timezone):
+        """Test factory creates HomeAssistant forecast with sensor_unit='Wh'"""
+        config = {
+            'type': 'homeassistant-api',
+            'homeassistant_api': {
+                'base_url': 'http://localhost:8123',
+                'apitoken': 'test_token',
+                'entity_id': 'sensor.test',
+                'sensor_unit': 'Wh'
+            }
+        }
+
+        forecaster = Consumption.create_consumption(timezone, config)
+
+        assert isinstance(forecaster, ForecastConsumptionHomeAssistant)
+        assert forecaster.sensor_unit == 'wh'
+        assert forecaster.unit_conversion_factor == 1.0
+        # Should NOT call _check_sensor_unit when explicitly set
+        mock_check.assert_not_called()
+
+    @patch.object(ForecastConsumptionHomeAssistant, '_check_sensor_unit', return_value=1000.0)
+    def test_create_homeassistant_with_sensor_unit_kwh(self, mock_check, timezone):
+        """Test factory creates HomeAssistant forecast with sensor_unit='kWh'"""
+        config = {
+            'type': 'homeassistant-api',
+            'homeassistant_api': {
+                'base_url': 'http://localhost:8123',
+                'apitoken': 'test_token',
+                'entity_id': 'sensor.test',
+                'sensor_unit': 'kWh'
+            }
+        }
+
+        forecaster = Consumption.create_consumption(timezone, config)
+
+        assert isinstance(forecaster, ForecastConsumptionHomeAssistant)
+        assert forecaster.sensor_unit == 'kwh'
+        assert forecaster.unit_conversion_factor == 1000.0
+        mock_check.assert_not_called()
+
+    @patch.object(ForecastConsumptionHomeAssistant, '_check_sensor_unit', return_value=1.0)
+    def test_create_homeassistant_with_sensor_unit_auto(self, mock_check, timezone):
+        """Test factory creates HomeAssistant forecast with sensor_unit='auto'"""
+        config = {
+            'type': 'homeassistant-api',
+            'homeassistant_api': {
+                'base_url': 'http://localhost:8123',
+                'apitoken': 'test_token',
+                'entity_id': 'sensor.test',
+                'sensor_unit': 'auto'
+            }
+        }
+
+        forecaster = Consumption.create_consumption(timezone, config)
+
+        assert isinstance(forecaster, ForecastConsumptionHomeAssistant)
+        assert forecaster.sensor_unit == 'auto'
+        # SHOULD call _check_sensor_unit for 'auto'
+        mock_check.assert_called_once()
+
+    @patch.object(ForecastConsumptionHomeAssistant, '_check_sensor_unit', return_value=1.0)
+    def test_create_homeassistant_without_sensor_unit(self, mock_check, timezone):
+        """Test factory creates HomeAssistant forecast without sensor_unit (default behavior)"""
+        config = {
+            'type': 'homeassistant-api',
+            'homeassistant_api': {
+                'base_url': 'http://localhost:8123',
+                'apitoken': 'test_token',
+                'entity_id': 'sensor.test'
+                # No sensor_unit specified
+            }
+        }
+
+        forecaster = Consumption.create_consumption(timezone, config)
+
+        assert isinstance(forecaster, ForecastConsumptionHomeAssistant)
+        assert forecaster.sensor_unit == 'auto'
+        # SHOULD call _check_sensor_unit when not specified
+        mock_check.assert_called_once()
+
+    @patch.object(ForecastConsumptionHomeAssistant, '_check_sensor_unit', return_value=1.0)
+    def test_create_homeassistant_flat_config_with_sensor_unit(self, mock_check, timezone):
+        """Test factory handles flat config structure (HomeAssistant addon quirk)"""
+        # HomeAssistant addon doesn't support 3-level nesting, so config is flat
+        config = {
+            'type': 'homeassistant-api',
+            'base_url': 'http://localhost:8123',
+            'apitoken': 'test_token',
+            'entity_id': 'sensor.test',
+            'sensor_unit': 'kWh'
+        }
+
+        forecaster = Consumption.create_consumption(timezone, config)
+
+        assert isinstance(forecaster, ForecastConsumptionHomeAssistant)
+        assert forecaster.sensor_unit == 'kwh'
+        assert forecaster.unit_conversion_factor == 1000.0
+        mock_check.assert_not_called()
+
+    @patch.object(ForecastConsumptionHomeAssistant, '_check_sensor_unit', return_value=1.0)
+    def test_create_homeassistant_sensor_unit_case_insensitive(self, mock_check, timezone):  # pylint: disable=redefined-outer-name
+        """Test that sensor_unit is handled case-insensitively in factory"""
+        config = {
+            'type': 'homeassistant-api',
+            'homeassistant_api': {
+                'base_url': 'http://localhost:8123',
+                'apitoken': 'test_token',
+                'entity_id': 'sensor.test',
+                'sensor_unit': 'WH'  # Uppercase
+            }
+        }
+
+        forecaster = Consumption.create_consumption(timezone, config)
+
+        assert forecaster.sensor_unit == 'wh'
+        assert forecaster.unit_conversion_factor == 1.0
+        mock_check.assert_not_called()
+
+    @patch.object(ForecastConsumptionHomeAssistant, '_check_sensor_unit', return_value=1.0)
+    def test_create_homeassistant_with_all_params_including_sensor_unit(self, mock_check, timezone):
+        """Test factory passes sensor_unit along with other parameters"""
+        config = {
+            'type': 'homeassistant-api',
+            'homeassistant_api': {
+                'base_url': 'http://localhost:8123',
+                'apitoken': 'test_token',
+                'entity_id': 'sensor.test',
+                'history_days': [-7, -14],
+                'history_weights': [2, 1],
+                'cache_ttl_hours': 24.0,
+                'multiplier': 1.5,
+                'sensor_unit': 'Wh'
+            }
+        }
+
+        forecaster = Consumption.create_consumption(timezone, config)
+
+        assert isinstance(forecaster, ForecastConsumptionHomeAssistant)
+        assert forecaster.history_days == [-7, -14]
+        assert forecaster.history_weights == [2, 1]
+        assert forecaster.cache_ttl_hours == 24.0
+        assert forecaster.multiplier == 1.5
+        assert forecaster.sensor_unit == 'wh'
+        assert forecaster.unit_conversion_factor == 1.0
+        mock_check.assert_not_called()
+
+
+class TestCreateHomeAssistantForecast:
+    """Test _create_homeassistant_forecast helper function directly"""
+
+    @patch.object(ForecastConsumptionHomeAssistant, '_check_sensor_unit', return_value=1.0)
+    def test_sensor_unit_extracted_from_nested_config(self, mock_check, timezone):
+        """Test sensor_unit is correctly extracted from nested config"""
+        config = {
+            'homeassistant_api': {
+                'base_url': 'http://localhost:8123',
+                'apitoken': 'test_token',
+                'entity_id': 'sensor.test',
+                'sensor_unit': 'kWh'
+            }
+        }
+
+        forecaster = _create_homeassistant_forecast(timezone, config)
+
+        assert forecaster.sensor_unit == 'kwh'
+        mock_check.assert_not_called()
+
+    @patch.object(ForecastConsumptionHomeAssistant, '_check_sensor_unit', return_value=1.0)
+    def test_sensor_unit_extracted_from_flat_config(self, mock_check, timezone):  # pylint: disable=redefined-outer-name
+        """Test sensor_unit is correctly extracted from flat config"""
+        config = {
+            'base_url': 'http://localhost:8123',
+            'apitoken': 'test_token',
+            'entity_id': 'sensor.test',
+            'sensor_unit': 'Wh'
+        }
+
+        forecaster = _create_homeassistant_forecast(timezone, config)
+
+        assert forecaster.sensor_unit == 'wh'
+        mock_check.assert_not_called()
+
+    @patch.object(ForecastConsumptionHomeAssistant, '_check_sensor_unit', return_value=1.0)
+    def test_sensor_unit_defaults_to_none(self, mock_check, timezone):  # pylint: disable=redefined-outer-name
+        """Test sensor_unit defaults to None when not provided"""
+        config = {
+            'base_url': 'http://localhost:8123',
+            'apitoken': 'test_token',
+            'entity_id': 'sensor.test'
+        }
+
+        forecaster = _create_homeassistant_forecast(timezone, config)
+
+        assert forecaster.sensor_unit == 'auto'
+        mock_check.assert_called_once()


### PR DESCRIPTION
- Introduced sensor_unit parameter in ForecastConsumptionHomeAssistant to allow explicit unit configuration ('auto', 'Wh', 'kWh').
- Updated consumption.py and forecast_homeassistant.py to handle sensor_unit logic.
- Enhanced batcontrol_config_dummy.yaml with sensor_unit documentation.
- Added comprehensive tests for sensor_unit handling in test_consumption_factory.py and test_homeassistant.py.

Closed #241