### PR TITLE
tests: add inverter factory coverage

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 testpaths = tests
+pythonpath = src
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*

--- a/tests/batcontrol/inverter/test_inverter_factory.py
+++ b/tests/batcontrol/inverter/test_inverter_factory.py
@@ -1,0 +1,145 @@
+import pytest
+
+from batcontrol.inverter.inverter import Inverter
+from batcontrol.inverter.mqtt_inverter import MqttInverter
+
+
+def test_factory_creates_mqtt_inverter():
+    """Factory should create an MQTT inverter for type mqtt."""
+    config = {
+        "type": "mqtt",
+        "capacity": 10000,
+        "max_grid_charge_rate": 5000,
+    }
+
+    inverter = Inverter.create_inverter(config)
+
+    assert isinstance(inverter, MqttInverter)
+    assert inverter.capacity == 10000
+    assert inverter.max_grid_charge_rate == 5000
+
+
+def test_factory_uses_max_charge_rate_alias_for_mqtt():
+    """Factory should map max_charge_rate to max_grid_charge_rate."""
+    config = {
+        "type": "mqtt",
+        "capacity": 10000,
+        "max_charge_rate": 4200,
+    }
+
+    inverter = Inverter.create_inverter(config)
+
+    assert isinstance(inverter, MqttInverter)
+    assert inverter.max_grid_charge_rate == 4200
+
+
+def test_factory_rejects_unknown_type():
+    """Factory should reject unknown inverter types."""
+    config = {
+        "type": "does_not_exist",
+        "max_grid_charge_rate": 5000,
+    }
+
+    with pytest.raises(RuntimeError, match="Unkown inverter type"):
+        Inverter.create_inverter(config)
+
+
+def test_factory_builds_fronius_with_expected_config(mocker):
+    """Factory should pass the expected mapped config to FroniusWR."""
+    mock_instance = mocker.MagicMock()
+    mock_fronius = mocker.patch(
+        "batcontrol.inverter.fronius.FroniusWR",
+        autospec=True,
+        return_value=mock_instance,
+    )
+
+    config = {
+        "type": "fronius_gen24",
+        "address": "192.168.1.100",
+        "user": "customer",
+        "password": "secret",
+        "max_grid_charge_rate": 5000,
+        "max_pv_charge_rate": 1700,
+        "fronius_inverter_id": 3,
+        "fronius_controller_id": 4,
+    }
+
+    inverter = Inverter.create_inverter(config)
+
+    mock_fronius.assert_called_once_with(
+        {
+            "address": "192.168.1.100",
+            "user": "customer",
+            "password": "secret",
+            "max_grid_charge_rate": 5000,
+            "max_pv_charge_rate": 1700,
+            "fronius_inverter_id": 3,
+            "fronius_controller_id": 4,
+        }
+    )
+    assert inverter is mock_instance
+
+
+def test_factory_defaults_max_pv_charge_rate_for_fronius(mocker):
+    """Factory should default max_pv_charge_rate to 0 for Fronius."""
+    mock_instance = mocker.MagicMock()
+    mock_fronius = mocker.patch(
+        "batcontrol.inverter.fronius.FroniusWR",
+        autospec=True,
+        return_value=mock_instance,
+    )
+
+    config = {
+        "type": "fronius_gen24",
+        "address": "192.168.1.100",
+        "user": "customer",
+        "password": "secret",
+        "max_grid_charge_rate": 5000,
+    }
+
+    Inverter.create_inverter(config)
+
+    mock_fronius.assert_called_once_with(
+        {
+            "address": "192.168.1.100",
+            "user": "customer",
+            "password": "secret",
+            "max_grid_charge_rate": 5000,
+            "max_pv_charge_rate": 0,
+            "fronius_inverter_id": 1,
+            "fronius_controller_id": 0,
+        }
+    )
+
+
+def test_factory_applies_fronius_id_defaults(mocker):
+    """Factory should apply default Fronius inverter/controller IDs."""
+    mock_instance = mocker.MagicMock()
+    mock_fronius = mocker.patch(
+        "batcontrol.inverter.fronius.FroniusWR",
+        autospec=True,
+        return_value=mock_instance,
+    )
+
+    config = {
+        "type": "fronius_gen24",
+        "address": "192.168.1.100",
+        "user": "customer",
+        "password": "secret",
+        "max_grid_charge_rate": 5000,
+        "max_pv_charge_rate": 1200,
+    }
+
+    Inverter.create_inverter(config)
+
+    mock_fronius.assert_called_once_with(
+        {
+            "address": "192.168.1.100",
+            "user": "customer",
+            "password": "secret",
+            "max_grid_charge_rate": 5000,
+            "max_pv_charge_rate": 1200,
+            "fronius_inverter_id": 1,
+            "fronius_controller_id": 0,
+        }
+    )


### PR DESCRIPTION
This adds coverage for common inverter factory behavior around MQTT creation, `max_charge_rate` alias handling, unknown type rejection, and Fronius config/default mapping. Backend-specific behavior stays in backend-specific test files.

It also switches pytest import-path handling to `pythonpath = src`, so the new test file does not need manual `sys.path` setup.

@MaStr One tooling question in the same spirit: would you be open to using `uv` in CI/setup instead of `pip`? I noticed the project is currently pinned to an older `uv` line in `pyproject.toml`, so I’m also wondering whether you’d be open to upgrading that pin first, if needed.