### PR TITLE
tests: address post-merge review feedback

### DIFF
--- a/tests/batcontrol/inverter/test_inverter_factory.py
+++ b/tests/batcontrol/inverter/test_inverter_factory.py
@@ -4,6 +4,16 @@ from batcontrol.inverter.inverter import Inverter
 from batcontrol.inverter.mqtt_inverter import MqttInverter
 
 
+@pytest.fixture(autouse=True)
+def reset_inverter_counter():
+    original_value = Inverter.num_inverters
+    Inverter.num_inverters = 0
+
+    yield
+
+    Inverter.num_inverters = original_value
+
+
 def test_factory_creates_mqtt_inverter():
     """Factory should create an MQTT inverter for type mqtt."""
     config = {
@@ -40,7 +50,7 @@ def test_factory_rejects_unknown_type():
         "max_grid_charge_rate": 5000,
     }
 
-    with pytest.raises(RuntimeError, match="Unkown inverter type"):
+    with pytest.raises(RuntimeError, match="inverter type"):
         Inverter.create_inverter(config)
 
 

--- a/tests/batcontrol/test_production_offset.py
+++ b/tests/batcontrol/test_production_offset.py
@@ -67,7 +67,7 @@ class TestProductionOffset:
         }
 
     @pytest.fixture
-    def batcontrol_with_patched_factories(self, mock_config, mocker):
+    def make_batcontrol(self, mocker):
         core_module = 'batcontrol.core'
 
         mocker.patch(f'{core_module}.tariff_factory')
@@ -75,22 +75,29 @@ class TestProductionOffset:
         mocker.patch(f'{core_module}.solar_factory')
         mocker.patch(f'{core_module}.consumption_factory')
 
-        bc = Batcontrol(mock_config)
+        created_instances = []
 
-        yield bc
+        def _make(config):
+            bc = Batcontrol(config)
+            created_instances.append(bc)
+            return bc
 
-        bc.shutdown()
+        yield _make
 
-    def test_production_offset_initialization_default(
-        self, mock_config, batcontrol_with_patched_factories
-    ):
+        for bc in created_instances:
+            bc.shutdown()
+
+    @pytest.fixture
+    def batcontrol_with_patched_factories(self, mock_config, make_batcontrol):
+        yield make_batcontrol(mock_config)
+
+    def test_production_offset_initialization_default(self, mock_config, make_batcontrol):
         """Test that production offset initializes with default value when not configured"""
         del mock_config['battery_control_expert']['production_offset_percent']
 
-        batcontrol = Batcontrol(mock_config)
+        batcontrol = make_batcontrol(mock_config)
 
         assert batcontrol.production_offset_percent == 1.0
-        batcontrol.shutdown()
 
     def test_production_offset_initialization_from_config(
         self, batcontrol_with_patched_factories


### PR DESCRIPTION
This follows up on a couple of useful Copilot review points from already-merged test PRs.

It addresses the factory-test feedback from #320 by resetting `Inverter.num_inverters` per test and by loosening the unknown-type assertion so it no longer bakes in the current typo in the production error message:
- https://github.com/MaStr/batcontrol/pull/320#discussion_r3073687434
- https://github.com/MaStr/batcontrol/pull/320#discussion_r3073687381

It also addresses the #321 feedback on `test_production_offset_initialization_default`, which was still constructing a fresh `Batcontrol(...)` outside the patched fixture setup:
- https://github.com/MaStr/batcontrol/pull/321#discussion_r3075242881