### PR TITLE
build: switch test setup from pip to uv

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,18 +16,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+    - name: Set up uv with Python ${{ matrix.python-version }}
+      id: setup-uv
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
+        activate-environment: true
+        enable-cache: true
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        if [ -f pyproject.toml ]; then pip install -e '.[test]'; fi
+        if [ -f pyproject.toml ]; then uv pip install -e '.[test]'; fi
     - name: Test with pytest
       run: |
-        python -m pytest tests/ --cov=src/batcontrol --cov-report=xml
+        uv run pytest tests/ --cov=src/batcontrol --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v6
       with:

--- a/README.MD
+++ b/README.MD
@@ -126,12 +126,9 @@ client.loop_forever()
 ```sh
 git clone https://github.com/MaStr/batcontrol.git
 cd batcontrol
-```
-
-
-virtualenv venv
-source venv/bin/activate
-pip install .
+uv venv --python 3.13 --allow-existing
+source .venv/bin/activate
+uv pip install .
 ```
 
 ## Testing:
@@ -139,8 +136,8 @@ pip install .
 The project uses pytest for running tests. To run the tests:
 
 ```sh
-# Install test dependencies
-pip install pytest pytest-cov
+# Install the package together with test dependencies
+uv pip install -e '.[test]'
 
 # Run tests
 ./run_tests.sh
@@ -275,17 +272,17 @@ To uninstall batcontrol and restore the inverter settings follow these steps:
 
 # Local development
 
-For running batcontrol off the repository for development puroposes, it is required to uses pip with [Developermode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html)
+For running batcontrol off the repository for development purposes, it is recommended to use an editable install.
 
 ```sh
 git clone https://github.com/MaStr/batcontrol.git
 cd batcontrol
-python -m venv .venv
+uv venv --python 3.13 --allow-existing
 # Activate your environment with:
 #      `source .venv/bin/activate` on Unix/macOS
 # or   `.venv\Scripts\activate` on Windows
 
-pip install --editable . 
+uv pip install --editable .
 
 # Now you have access to your package
 # as if it was installed in .venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ version = {attr = "batcontrol.__pkginfo__.__version__"}
 
 # Configure additional tools
 [tool.uv]
-required-version = "~=0.7.0" # Pin uv to major version for stability
+required-version = ">=0.7.0" # Keep a minimum version while allowing newer uv releases
 
 # Testing configuration
 [tool.pytest.ini_options]

--- a/run_tests.ps1
+++ b/run_tests.ps1
@@ -1,13 +1,12 @@
 # PowerShell version of run_tests.sh
 
-# Activate virtual environment if it exists (Windows path used by venv)
-if (Test-Path -Path .\.venv\Scripts\Activate.ps1) {
-    . .\.venv\Scripts\Activate.ps1
-}
+uv venv --python 3.13 --allow-existing
 
-# Ensure pytest and helpers are installed
-python -m pip install --upgrade pip
-python -m pip install pytest pytest-cov pytest-asyncio
+# Activate the virtual environment created by uv
+. .\.venv\Scripts\Activate.ps1
+
+# Install the package together with test dependencies from pyproject.toml
+uv pip install -e '.[test]'
 
 # Run pytest with coverage and logging options
 $params = @(
@@ -18,6 +17,6 @@ $params = @(
     '--log-cli-date-format=%Y-%m-%d %H:%M:%S'
 )
 
-python -m pytest @params
+uv run pytest @params
 
 exit $LASTEXITCODE

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
 
-# Activate virtual environment if it exists (if running outside of container)
-if [ -f "./venv/activate" ]; then
-    source ./venv/activate
-fi
+uv venv --python 3.13 --allow-existing
 
 # Install the package together with test dependencies from pyproject.toml
-pip install -e '.[test]'
+uv pip install -e '.[test]'
 
 # Run tests with coverage
-python -m pytest tests/ --cov=src/batcontrol --log-cli-level=DEBUG --log-cli-format="%(asctime)s [%(levelname)8s] %(name)s: %(message)s" --log-cli-date-format="%Y-%m-%d %H:%M:%S"
+uv run pytest tests/ --cov=src/batcontrol --log-cli-level=DEBUG --log-cli-format="%(asctime)s [%(levelname)8s] %(name)s: %(message)s" --log-cli-date-format="%Y-%m-%d %H:%M:%S"
 
 # Exit with the same status as pytest
 exit $?


### PR DESCRIPTION
Switch the `pytest` workflow and test helper scripts from `pip` to `uv`, update the README examples, and relax the minimum `uv` version.

Leave the `Dockerfile` unchanged for now; container build migration can follow separately.