### PR TITLE
Support single-zone static price in tariff_zones provider

### DIFF
--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -74,10 +74,15 @@ utility:
   vat: 0.19 # only required for awattar and energyforecast
   fees: 0.015 # only required for awattar and energyforecast
   markup: 0.03 # only required for awattar and energyforecast
+  # tariff_zones supports 1, 2 or 3 zones and doubles as a static single-price mode.
+  # Single zone (static price): set only tariff_zone_1; zone_1_hours may be omitted
+  # and defaults to all 24 hours. Example:
+  #   type: tariff_zones
+  #   tariff_zone_1: 0.30   # flat price for the whole day, Euro/kWh incl. vat/fees
   # tariff_zone_1: 0.2733 # only required for tariff_zones, Euro/kWh incl. vat/fees (peak hours)
   # zone_1_hours: 7-22 # hours assigned to zone 1; supports ranges (7-22), singles (7), or mixed (0-5,6,7)
-  # tariff_zone_2: 0.1734 # only required for tariff_zones, Euro/kWh incl. vat/fees (off-peak hours)
-  # zone_2_hours: 0-6,23 # hours assigned to zone 2 (must cover remaining hours)
+  # tariff_zone_2: 0.1734 # optional: second zone price, Euro/kWh incl. vat/fees (off-peak hours)
+  # zone_2_hours: 0-6,23 # optional: hours assigned to zone 2 (required if tariff_zone_2 is set)
   # tariff_zone_3: 0.2100 # optional third zone price
   # zone_3_hours: 17-20 # optional hours for zone 3 (must not overlap with zone 1 or 2)
   # apikey: YOUR_API_KEY # MANDATORY for energyforecast and tibber. Uncomment and set if using those providers.

--- a/src/batcontrol/dynamictariff/dynamictariff.py
+++ b/src/batcontrol/dynamictariff/dynamictariff.py
@@ -147,6 +147,18 @@ class DynamicTariff:
                         f'[DynTariff] {hours_key} and {price_key} must both be '
                         'set or both omitted'
                     )
+            # Once any additional zone is configured, zone_1_hours must be
+            # provided explicitly (the all-24-hours default only applies in
+            # single-zone static mode). Fail fast at factory time instead of
+            # deferring to the first price fetch.
+            extra_zone_configured = any(
+                f'tariff_zone_{z}' in config for z in (2, 3)
+            )
+            if extra_zone_configured and 'zone_1_hours' not in config:
+                raise RuntimeError(
+                    '[DynTariff] zone_1_hours must be set when additional '
+                    'zones (tariff_zone_2 or tariff_zone_3) are configured'
+                )
             zone_1_hours = config.get('zone_1_hours')
             tariff_zone_2 = config.get('tariff_zone_2')
             zone_2_hours = config.get('zone_2_hours')

--- a/src/batcontrol/dynamictariff/dynamictariff.py
+++ b/src/batcontrol/dynamictariff/dynamictariff.py
@@ -131,23 +131,36 @@ class DynamicTariff:
                 selected_tariff.upgrade_48h_to_96h()
 
         elif provider.lower() == 'tariff_zones':
-            required_fields = ['tariff_zone_1', 'zone_1_hours', 'tariff_zone_2', 'zone_2_hours']
-            for field in required_fields:
-                if field not in config:
+            # Only tariff_zone_1 is strictly required. A single-zone
+            # configuration acts as a static flat price for all 24 hours.
+            if 'tariff_zone_1' not in config:
+                raise RuntimeError(
+                    '[DynTariff] Please include tariff_zone_1 in your configuration file'
+                )
+            # zone_2 and zone_3 are optional, but price and hours must be
+            # provided together for each additional zone.
+            for zone in (2, 3):
+                price_key = f'tariff_zone_{zone}'
+                hours_key = f'zone_{zone}_hours'
+                if (price_key in config) != (hours_key in config):
                     raise RuntimeError(
-                        f'[DynTariff] Please include {field} in your configuration file'
+                        f'[DynTariff] {price_key} and {hours_key} must both be '
+                        'provided or both omitted'
                     )
-            zone_3_hours = config.get('zone_3_hours')
+            zone_1_hours = config.get('zone_1_hours')
+            tariff_zone_2 = config.get('tariff_zone_2')
+            zone_2_hours = config.get('zone_2_hours')
             tariff_zone_3 = config.get('tariff_zone_3')
+            zone_3_hours = config.get('zone_3_hours')
             selected_tariff = TariffZones(
                 timezone,
                 min_time_between_api_calls,
                 delay_evaluation_by_seconds,
                 target_resolution=target_resolution,
                 tariff_zone_1=float(config['tariff_zone_1']),
-                zone_1_hours=config['zone_1_hours'],
-                tariff_zone_2=float(config['tariff_zone_2']),
-                zone_2_hours=config['zone_2_hours'],
+                zone_1_hours=zone_1_hours,
+                tariff_zone_2=float(tariff_zone_2) if tariff_zone_2 is not None else None,
+                zone_2_hours=zone_2_hours,
                 tariff_zone_3=float(tariff_zone_3) if tariff_zone_3 is not None else None,
                 zone_3_hours=zone_3_hours,
             )

--- a/src/batcontrol/dynamictariff/dynamictariff.py
+++ b/src/batcontrol/dynamictariff/dynamictariff.py
@@ -144,8 +144,8 @@ class DynamicTariff:
                 hours_key = f'zone_{zone}_hours'
                 if (price_key in config) != (hours_key in config):
                     raise RuntimeError(
-                        f'[DynTariff] {price_key} and {hours_key} must both be '
-                        'provided or both omitted'
+                        f'[DynTariff] {hours_key} and {price_key} must both be '
+                        'set or both omitted'
                     )
             zone_1_hours = config.get('zone_1_hours')
             tariff_zone_2 = config.get('tariff_zone_2')

--- a/src/batcontrol/dynamictariff/tariffzones.py
+++ b/src/batcontrol/dynamictariff/tariffzones.py
@@ -1,21 +1,29 @@
 """Tariff_zones provider
 
 Simple dynamic tariff provider that assigns a fixed price to each hour of the day
-using up to three configurable zones.
+using one, two, or three configurable zones.
+
+This doubles as a "static price mode": by configuring only zone 1 (without
+zone_1_hours, or with zone_1_hours covering all 24 hours), every hour of the
+day gets the same fixed price.
 
 Config options (in utility config for provider):
 - type: tariff_zones
 - tariff_zone_1: price for zone 1 hours (float, Euro/kWh incl. VAT/fees, required)
-- zone_1_hours: comma-separated list of hours assigned to zone 1, e.g. "7,8,9,10"
-- tariff_zone_2: price for zone 2 hours (float, Euro/kWh incl. VAT/fees, required)
-- zone_2_hours: comma-separated list of hours assigned to zone 2, e.g. "0,1,2,3,4,5,6"
+- zone_1_hours: hours assigned to zone 1 (optional; defaults to all 24 hours
+                when no other zones are configured — enables single-price mode)
+- tariff_zone_2: price for zone 2 hours (float, optional)
+- zone_2_hours: hours assigned to zone 2 (required if tariff_zone_2 is set)
 - tariff_zone_3: price for zone 3 hours (float, optional)
-- zone_3_hours: comma-separated list of hours assigned to zone 3 (optional)
+- zone_3_hours: hours assigned to zone 3 (required if tariff_zone_3 is set)
 
 Rules:
+- tariff_zone_1 is always required.
 - Every hour 0-23 must appear in exactly one zone (ValueError if any hour is missing).
 - No hour may appear more than once across all zones (ValueError on duplicate).
+- zone_2_hours and tariff_zone_2 must both be set or both omitted.
 - zone_3_hours and tariff_zone_3 must both be set or both omitted.
+- In single-zone mode, zone_1_hours defaults to all 24 hours if unset.
 
 The class produces hourly prices (native_resolution=60) for the next 48
 hours aligned to the current hour. The baseclass will handle conversion to
@@ -41,7 +49,12 @@ logger = logging.getLogger(__name__)
 
 
 class TariffZones(DynamicTariffBaseclass):
-    """Multi-zone tariff with up to 3 zones; each zone owns a set of hours."""
+    """Static/zone tariff with 1 to 3 zones; each zone owns a set of hours.
+
+    When only zone 1 is configured, this acts as a flat static price for all 24
+    hours. When zone 2 (and optionally zone 3) is added, the day is split
+    across the zones' hour assignments.
+    """
 
     def __init__(
             self,
@@ -92,12 +105,13 @@ class TariffZones(DynamicTariffBaseclass):
         """Raise RuntimeError/ValueError if the zone configuration is incomplete or invalid."""
         if self._tariff_zone_1 is None:
             raise RuntimeError('[TariffZones] tariff_zone_1 must be set')
-        if self._zone_1_hours is None:
-            raise RuntimeError('[TariffZones] zone_1_hours must be set')
-        if self._tariff_zone_2 is None:
-            raise RuntimeError('[TariffZones] tariff_zone_2 must be set')
-        if self._zone_2_hours is None:
-            raise RuntimeError('[TariffZones] zone_2_hours must be set')
+
+        zone2_hours_set = self._zone_2_hours is not None
+        zone2_price_set = self._tariff_zone_2 is not None
+        if zone2_hours_set != zone2_price_set:
+            raise RuntimeError(
+                '[TariffZones] zone_2_hours and tariff_zone_2 must both be set or both omitted'
+            )
 
         zone3_hours_set = self._zone_3_hours is not None
         zone3_price_set = self._tariff_zone_3 is not None
@@ -105,6 +119,16 @@ class TariffZones(DynamicTariffBaseclass):
             raise RuntimeError(
                 '[TariffZones] zone_3_hours and tariff_zone_3 must both be set or both omitted'
             )
+
+        # Single-zone (static price) mode: if zone 1 is the only configured
+        # zone and no explicit hours are given, default to all 24 hours.
+        if self._zone_1_hours is None:
+            if not zone2_price_set and not zone3_price_set:
+                self._zone_1_hours = list(range(24))
+            else:
+                raise RuntimeError(
+                    '[TariffZones] zone_1_hours must be set when additional zones are configured'
+                )
 
         # Check for duplicate hours across all zones
         seen = {}

--- a/src/batcontrol/dynamictariff/tariffzones.py
+++ b/src/batcontrol/dynamictariff/tariffzones.py
@@ -23,7 +23,9 @@ Rules:
 - No hour may appear more than once across all zones (ValueError on duplicate).
 - zone_2_hours and tariff_zone_2 must both be set or both omitted.
 - zone_3_hours and tariff_zone_3 must both be set or both omitted.
-- In single-zone mode, zone_1_hours defaults to all 24 hours if unset.
+- In single-zone mode, zone_1_hours defaults to all 24 hours only when it
+  is unset. If zone_1_hours is provided explicitly, it is NOT auto-extended
+  and must cover every hour 0-23 on its own.
 
 The class produces hourly prices (native_resolution=60) for the next 48
 hours aligned to the current hour. The baseclass will handle conversion to

--- a/tests/batcontrol/dynamictariff/test_tariffzones.py
+++ b/tests/batcontrol/dynamictariff/test_tariffzones.py
@@ -140,8 +140,32 @@ def test_missing_prices_raises():
 
 
 def test_missing_hours_raises():
+    """zone_2 has a price but no hours — must fail the paired-option check."""
     t = TariffZones(make_tz(), tariff_zone_1=0.27, tariff_zone_2=0.17)
+    with pytest.raises(RuntimeError, match='zone_2_hours and tariff_zone_2'):
+        t._get_prices_native()
+
+
+def test_zone1_hours_missing_with_additional_zone_raises():
+    """If any extra zone is configured, zone_1_hours must be explicit."""
+    t = TariffZones(
+        make_tz(),
+        tariff_zone_1=0.27,
+        tariff_zone_2=0.17,
+        zone_2_hours=list(range(0, 12)),
+    )
     with pytest.raises(RuntimeError, match='zone_1_hours'):
+        t._get_prices_native()
+
+
+def test_zone2_hours_without_price_raises():
+    t = TariffZones(
+        make_tz(),
+        tariff_zone_1=0.27, zone_1_hours=HOURS_PEAK,
+        zone_2_hours=HOURS_OFFPEAK,
+        # tariff_zone_2 intentionally omitted
+    )
+    with pytest.raises(RuntimeError, match='zone_2_hours and tariff_zone_2'):
         t._get_prices_native()
 
 
@@ -207,6 +231,44 @@ def test_get_prices_native_correct_zone_assignment():
         h = (base + datetime.timedelta(hours=rel_hour)).hour
         expected = t.tariff_zone_1 if h in HOURS_PEAK else t.tariff_zone_2
         assert price == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# _get_prices_native — single-zone (static price) mode
+# ---------------------------------------------------------------------------
+
+def test_single_zone_defaults_to_all_hours():
+    """With only tariff_zone_1 set, zone_1_hours defaults to all 24 hours."""
+    t = TariffZones(make_tz(), tariff_zone_1=0.30)
+    prices = t._get_prices_native()
+    assert len(prices) == 48
+    for price in prices.values():
+        assert price == pytest.approx(0.30)
+    assert t.zone_1_hours == list(range(24))
+
+
+def test_single_zone_with_explicit_full_day_hours():
+    """Explicitly configuring zone_1_hours to cover all 24 hours is also valid."""
+    t = TariffZones(
+        make_tz(),
+        tariff_zone_1=0.25,
+        zone_1_hours='0-23',
+    )
+    prices = t._get_prices_native()
+    assert len(prices) == 48
+    for price in prices.values():
+        assert price == pytest.approx(0.25)
+
+
+def test_single_zone_partial_hours_raises():
+    """zone_1 alone with only a subset of hours leaves the rest uncovered."""
+    t = TariffZones(
+        make_tz(),
+        tariff_zone_1=0.25,
+        zone_1_hours='0-11',
+    )
+    with pytest.raises(ValueError, match='not assigned'):
+        t._get_prices_native()
 
 
 # ---------------------------------------------------------------------------
@@ -299,5 +361,31 @@ def test_factory_missing_required_field_raises():
         # zone_2_hours missing
         'tariff_zone_2': 0.17,
     }
-    with pytest.raises(RuntimeError, match='zone_2_hours'):
+    with pytest.raises(RuntimeError, match='tariff_zone_2 and zone_2_hours'):
+        DynamicTariff.create_tarif_provider(config, make_tz(), 0, 0)
+
+
+def test_factory_single_zone_static_price():
+    """tariff_zones with only tariff_zone_1 acts as a static single price."""
+    config = {
+        'type': 'tariff_zones',
+        'tariff_zone_1': 0.30,
+    }
+    provider = DynamicTariff.create_tarif_provider(config, make_tz(), 0, 0)
+    assert isinstance(provider, TariffZones)
+    assert provider.tariff_zone_1 == pytest.approx(0.30)
+    assert provider.tariff_zone_2 is None
+    assert provider.tariff_zone_3 is None
+    prices = provider._get_prices_native()
+    assert len(prices) == 48
+    for price in prices.values():
+        assert price == pytest.approx(0.30)
+
+
+def test_factory_requires_tariff_zone_1():
+    config = {
+        'type': 'tariff_zones',
+        # tariff_zone_1 missing
+    }
+    with pytest.raises(RuntimeError, match='tariff_zone_1'):
         DynamicTariff.create_tarif_provider(config, make_tz(), 0, 0)

--- a/tests/batcontrol/dynamictariff/test_tariffzones.py
+++ b/tests/batcontrol/dynamictariff/test_tariffzones.py
@@ -361,7 +361,7 @@ def test_factory_missing_required_field_raises():
         # zone_2_hours missing
         'tariff_zone_2': 0.17,
     }
-    with pytest.raises(RuntimeError, match='tariff_zone_2 and zone_2_hours'):
+    with pytest.raises(RuntimeError, match='zone_2_hours and tariff_zone_2'):
         DynamicTariff.create_tarif_provider(config, make_tz(), 0, 0)
 
 

--- a/tests/batcontrol/dynamictariff/test_tariffzones.py
+++ b/tests/batcontrol/dynamictariff/test_tariffzones.py
@@ -382,6 +382,19 @@ def test_factory_single_zone_static_price():
         assert price == pytest.approx(0.30)
 
 
+def test_factory_requires_zone_1_hours_when_extra_zones_configured():
+    """With zone 2 configured, zone_1_hours must be provided at factory time."""
+    config = {
+        'type': 'tariff_zones',
+        'tariff_zone_1': 0.27,
+        # zone_1_hours intentionally omitted
+        'tariff_zone_2': 0.17,
+        'zone_2_hours': '0-6,23',
+    }
+    with pytest.raises(RuntimeError, match='zone_1_hours'):
+        DynamicTariff.create_tarif_provider(config, make_tz(), 0, 0)
+
+
 def test_factory_requires_tariff_zone_1():
     config = {
         'type': 'tariff_zones',


### PR DESCRIPTION
## Summary

Converts the `tariff_zones` price mode into a flexible 1-, 2-, or 3-zone provider so it also covers the "static single price" use case from #318. When only `tariff_zone_1` is configured, `zone_1_hours` defaults to all 24 hours and every hour of the day gets the same flat price — which is exactly what a non-dynamic-price user needs for peak-shaving scenarios.

Existing 2-zone and 3-zone configurations are fully backwards-compatible; only the previously-required zone 2 became optional.

## Changes

- `tariffzones.py`: make `tariff_zone_2` / `zone_2_hours` optional (must still be paired together); default `zone_1_hours` to `0-23` when zone 1 is the only configured zone; updated docstrings.
- `dynamictariff.py` factory: require only `tariff_zone_1`; validate zone 2 / zone 3 price+hours pairing with consistent error wording.
- `config/batcontrol_config_dummy.yaml`: document the single-zone static-price mode.
- `tests/.../test_tariffzones.py`: add tests for single-zone default hours, explicit full-day hours, partial-hour rejection, factory single-zone config, missing `tariff_zone_1`, and orphan zone-2 price/hours; adjust pre-existing assertions to the new (clearer) error messages.

Example new static-price config:

```yaml
utility:
  type: tariff_zones
  tariff_zone_1: 0.30   # flat price for the whole day, EUR/kWh incl. vat/fees
```

Refs #318.

## Test plan

- [x] `python -m pytest tests/batcontrol/dynamictariff/` — 77 passed
- [ ] Smoke-check a real single-zone YAML config in a running instance
- [ ] Verify existing 2-zone/3-zone configs still load unchanged