### PR TITLE
Remove legacy hours_list/hour_N sensor formats, keep evcc only (#314)

### DIFF
--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -164,7 +164,7 @@ pvinstallations:
   # - name: HA Solar ML Forecast
   #   base_url: ws://homeassistant.local:8123  # Your HomeAssistant URL
   #   api_token: eyJ...                           # Long-lived access token from HA Profile
-  #   entity_id: sensor.solar_forecast_ml_prognose_nachste_stunde  # Forecast sensor entity
+  #   entity_id: sensor.solar_forecast_ml_evcc_solar_prognose  # Forecast sensor entity
   #   sensor_unit: auto                           # Options: 'auto' (detect), 'Wh', or 'kWh'
   #   cache_ttl_hours: 24.0                       # Cache duration in hours
 

--- a/scripts/test_solar_forecast_ha_ml.py
+++ b/scripts/test_solar_forecast_ha_ml.py
@@ -1,7 +1,7 @@
 """Test script to fetch solar forecast data from HomeAssistant via WebSocket
 
 This script demonstrates how to connect to HomeAssistant and fetch solar forecast
-data from the sensor.solar_forecast_ml_prognose_nachste_stunde sensor.
+data from the sensor.solar_forecast_ml_evcc_solar_prognose sensor.
 """
 
 import asyncio
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # Configuration
 BASE_URL = "http://homeassistant.local:8123"
 API_TOKEN = ""
-ENTITY_ID = "sensor.solar_forecast_ml_prognose_nachste_stunde"
+ENTITY_ID = "sensor.solar_forecast_ml_evcc_solar_prognose"
 
 
 async def websocket_connect(base_url: str, api_token: str):

--- a/src/batcontrol/forecastsolar/forecast_homeassistant_ml.py
+++ b/src/batcontrol/forecastsolar/forecast_homeassistant_ml.py
@@ -461,7 +461,7 @@ class ForecastSolarHomeAssistantML(ForecastSolarBaseclass):
         end_str = entry.get("end")
         value = entry.get("value")
 
-        # evcc entries require start, end and value — entries missing any of
+        # evcc entries require start, end and value - entries missing any of
         # these fields are not valid and must be skipped.
         if start_str is None or end_str is None or value is None:
             return None
@@ -560,7 +560,7 @@ class ForecastSolarHomeAssistantML(ForecastSolarBaseclass):
         Only the evcc Solar Forecast format is supported: a 'forecast' list
         with {start, end, value} entries (e.g. emitted by
         sensor.solar_forecast_ml_evcc_solar_prognose). Entries must include
-        all three fields — start, end and value — otherwise they are skipped.
+        all three fields - start, end and value - otherwise they are skipped.
         Absolute timestamps are mapped to hour offsets relative to the
         current hour.
 

--- a/src/batcontrol/forecastsolar/forecast_homeassistant_ml.py
+++ b/src/batcontrol/forecastsolar/forecast_homeassistant_ml.py
@@ -4,9 +4,8 @@ This module provides solar forecasting using ML-based forecast data from
 HomeAssistant Solar Forecast ML integration (HACS).
 
 Based on HACS integration: https://zara-toorox.github.io/
-Supported sensors:
-  - sensor.solar_forecast_ml_prognose_nachste_stunde  (hours_list / hour_N format)
-  - sensor.solar_forecast_ml_evcc_solar_prognose      (forecast list with start/end/value)
+Supported sensor:
+  - sensor.solar_forecast_ml_evcc_solar_prognose  (forecast list with start/end/value)
 
 """
 
@@ -452,16 +451,19 @@ class ForecastSolarHomeAssistantML(ForecastSolarBaseclass):
         """Parse a single evcc-style forecast entry dict.
 
         Args:
-            entry: Dict with at least 'start' and 'value' keys.
+            entry: Dict with 'start', 'end' and 'value' keys.
             current_hour: Timezone-aware datetime truncated to the current hour.
 
         Returns:
             (hour_offset, wh_value) tuple, or None if the entry should be skipped.
         """
         start_str = entry.get("start")
+        end_str = entry.get("end")
         value = entry.get("value")
 
-        if start_str is None or value is None:
+        # evcc entries require start, end and value — entries missing any of
+        # these fields are not valid and must be skipped.
+        if start_str is None or end_str is None or value is None:
             return None
 
         # Normalize UTC 'Z' suffix for Python 3.9/3.10 fromisoformat compatibility
@@ -485,11 +487,11 @@ class ForecastSolarHomeAssistantML(ForecastSolarBaseclass):
         wh_value = float(value) * self.unit_conversion_factor
         return hour_offset, wh_value
 
-    def _parse_forecast_format1(
+    def _parse_forecast_evcc(
         self,
         forecast_list: list
     ) -> Dict[int, float]:
-        """Parse Format 1: evcc 'forecast' list with {start, end, value} entries.
+        """Parse evcc 'forecast' list with {start, end, value} entries.
 
         Entries whose 'start' timestamp is before the current hour are skipped.
         Timestamps are converted to hour offsets relative to the current hour.
@@ -549,101 +551,18 @@ class ForecastSolarHomeAssistantML(ForecastSolarBaseclass):
 
         return forecast_dict
 
-    def _parse_forecast_hours_list(self, hours_list: list) -> Dict[int, float]:
-        """Parse Format 2: hours_list array with {time, kwh} entries.
-
-        Args:
-            hours_list: List of dicts from the 'hours_list' attribute.
-
-        Returns:
-            Dict mapping hour index (0-based) to generation in Wh.
-            Empty dict if no valid entries found.
-        """
-        forecast_dict: Dict[int, float] = {}
-        logger_ha_details.debug(
-            "Parsing forecast from hours_list (%d entries)", len(hours_list))
-
-        for hour_idx, entry in enumerate(hours_list):
-            if not isinstance(entry, dict):
-                logger_ha_details.debug(
-                    "Skipping non-dict entry in hours_list: %s", entry)
-                continue
-
-            kwh_value = entry.get("kwh")
-            if kwh_value is None:
-                logger_ha_details.debug(
-                    "Skipping entry without 'kwh' key: %s", entry)
-                continue
-
-            try:
-                kwh_value = float(kwh_value)
-                wh_value = kwh_value * self.unit_conversion_factor
-                forecast_dict[hour_idx] = wh_value
-                logger_ha_details.debug(
-                    "Hour %d: %.2f kWh -> %.2f Wh", hour_idx, kwh_value, wh_value)
-            except (ValueError, TypeError) as exc:
-                logger_ha_details.debug(
-                    "Skipping invalid kWh value in hours_list: %s (error: %s)",
-                    kwh_value, exc)
-
-        if not forecast_dict:
-            logger_ha_details.warning("hours_list present but no valid entries parsed")
-        return forecast_dict
-
-    def _parse_forecast_hour_n(self, attributes: dict) -> Dict[int, float]:
-        """Parse Format 3 (fallback): hour_1, hour_2, ... attributes.
-
-        Args:
-            attributes: Full sensor attributes dict.
-
-        Returns:
-            Dict mapping hour index (0-based) to generation in Wh.
-        """
-        forecast_dict: Dict[int, float] = {}
-        logger_ha_details.debug("Trying fallback hour_N attribute format")
-        hour_idx = 1
-        while True:
-            hour_key = f"hour_{hour_idx}"
-            if hour_key not in attributes:
-                break
-
-            kwh_value = attributes.get(hour_key)
-            if kwh_value is None:
-                logger_ha_details.debug("Skipping missing %s", hour_key)
-                hour_idx += 1
-                continue
-
-            try:
-                kwh_value = float(kwh_value)
-                wh_value = kwh_value * self.unit_conversion_factor
-                # hour_idx is 1-based in attributes, 0-based in forecast_dict
-                hour_time_key = f"hour_{hour_idx}_time"
-                forecast_dict[hour_idx - 1] = wh_value
-                logger_ha_details.debug(
-                    "Hour %d (%s): %.2f kWh -> %.2f Wh",
-                    hour_idx - 1, attributes.get(hour_time_key, "?"),
-                    kwh_value, wh_value)
-            except (ValueError, TypeError) as exc:
-                logger_ha_details.debug(
-                    "Skipping invalid kWh value for %s: %s (error: %s)",
-                    hour_key, kwh_value, exc)
-
-            hour_idx += 1
-        return forecast_dict
-
     def _parse_forecast_from_attributes(
         self,
         attributes: dict
     ) -> Dict[int, float]:
-        """Parse forecast data from sensor attributes
+        """Parse forecast data from sensor attributes.
 
-        Supports multiple formats:
-        1. Primary: forecast array with {start, end, value} objects (evcc Solar Forecast style)
-           - Uses absolute timestamps; values are mapped to hour offsets from now
-           - Typically used with sensor.solar_forecast_ml_evcc_solar_prognose
-        2. Secondary: hours_list array with {time, kwh} objects
-           - Used with sensor.solar_forecast_ml_prognose_nachste_stunde
-        3. Fallback: hour_1, hour_2, ... attributes
+        Only the evcc Solar Forecast format is supported: a 'forecast' list
+        with {start, end, value} entries (e.g. emitted by
+        sensor.solar_forecast_ml_evcc_solar_prognose). Entries must include
+        all three fields — start, end and value — otherwise they are skipped.
+        Absolute timestamps are mapped to hour offsets relative to the
+        current hour.
 
         Args:
             attributes: Sensor attributes dict from HomeAssistant
@@ -654,38 +573,25 @@ class ForecastSolarHomeAssistantML(ForecastSolarBaseclass):
         Raises:
             ValueError: If no valid forecast data found
         """
-        # Format 1: forecast list with {start, end, value} - evcc Solar Forecast style
         forecast_list = attributes.get("forecast")
         if forecast_list and isinstance(forecast_list, list):
             has_expected_entry = any(
-                isinstance(entry, dict) and "start" in entry and "value" in entry
+                isinstance(entry, dict)
+                and "start" in entry
+                and "end" in entry
+                and "value" in entry
                 for entry in forecast_list
             )
             if has_expected_entry:
-                result = self._parse_forecast_format1(forecast_list)
+                result = self._parse_forecast_evcc(forecast_list)
                 if result:
                     return result
 
-        # Format 2: hours_list (existing primary format)
-        hours_list = attributes.get("hours_list")
-        if hours_list and isinstance(hours_list, list) and len(hours_list) > 0:
-            result = self._parse_forecast_hours_list(hours_list)
-            if result:
-                return result
-
-        # Format 3 (fallback): hour_1, hour_2, ... attributes
-        forecast_dict = self._parse_forecast_hour_n(attributes)
-
-        if not forecast_dict:
-            raise ValueError(
-                "Could not parse any forecast data from sensor attributes. "
-                "Expected one of: "
-                "(1) 'forecast' list with {start, value} entries "
-                "(evcc Solar-Prognose format, e.g. sensor.solar_forecast_ml_evcc_solar_prognose); "
-                "(2) 'hours_list' array with {kwh} entries; "
-                "(3) 'hour_N' attributes. "
-                "If using the evcc format, check that the 'forecast' list contains "
-                "future entries (past-only entries are skipped)."
-            )
-
-        return forecast_dict
+        raise ValueError(
+            "Could not parse any forecast data from sensor attributes. "
+            "Expected a 'forecast' list with {start, end, value} entries "
+            "(evcc Solar-Prognose format, e.g. "
+            "sensor.solar_forecast_ml_evcc_solar_prognose). "
+            "Check that the 'forecast' list contains future entries "
+            "(past-only entries are skipped)."
+        )

--- a/tests/test_forecast_solar_homeassistant_ml.py
+++ b/tests/test_forecast_solar_homeassistant_ml.py
@@ -39,20 +39,23 @@ def pv_installations():
 def ha_entity_state(timezone):
     """Provide sample HomeAssistant entity state in evcc Solar-Prognose format.
 
-    Produces a rolling 14-hour forecast starting at the current hour (in the
-    test timezone, Europe/Berlin) so that the baseclass length validation
-    (>= 12 consecutive intervals) is satisfied regardless of when the tests
-    run.
+    The fixture freezes the provider module's ``datetime.datetime.now`` at a
+    fixed reference hour and builds a 14-hour forecast anchored at the same
+    instant. This keeps the fixture and the parser on the exact same "now"
+    and makes the offset mapping deterministic (no flakiness at hour or DST
+    boundaries).
+
+    April 2, 2026 is safely past the DST spring-forward in Europe/Berlin
+    (March 29), matching the reference hour used elsewhere in this file.
     """
-    now = datetime.datetime.now(timezone).replace(
-        minute=0, second=0, microsecond=0)
+    fixed_now = timezone.localize(datetime.datetime(2026, 4, 2, 10, 0, 0))
     forecast = []
     # Values chosen so forecast[0] == 879.0, forecast[1] == 1265.0, ... (in Wh)
     wh_values = [879.0, 1265.0, 1688.0, 1571.0, 1578.0, 990.0, 489.0,
                  268.0, 17.0, 17.0, 17.0, 17.0, 17.0, 17.0]
     for offset, wh in enumerate(wh_values):
-        start = now + datetime.timedelta(hours=offset)
-        end = now + datetime.timedelta(hours=offset + 1)
+        start = fixed_now + datetime.timedelta(hours=offset)
+        end = fixed_now + datetime.timedelta(hours=offset + 1)
         # Use isoformat() so the offset is rendered as '+02:00' (with colon).
         # Python 3.9/3.10's fromisoformat() rejects the '+0200' form that
         # strftime('%z') emits.
@@ -62,7 +65,7 @@ def ha_entity_state(timezone):
             "value": wh,
         })
 
-    return {
+    entity_state = {
         "entity_id": "sensor.solar_forecast_ml_evcc_solar_prognose",
         "state": f"{len(forecast)} slots",
         "attributes": {
@@ -73,6 +76,14 @@ def ha_entity_state(timezone):
         "last_changed": "2026-02-05T08:00:44.824837+00:00",
         "last_updated": "2026-02-05T08:00:44.824837+00:00"
     }
+
+    with patch(
+        'src.batcontrol.forecastsolar.forecast_homeassistant_ml.datetime'
+    ) as mock_dt:
+        mock_dt.datetime.now.return_value = fixed_now
+        # Keep the real fromisoformat so the parser can still decode strings.
+        mock_dt.datetime.fromisoformat = datetime.datetime.fromisoformat
+        yield entity_state
 
 
 @pytest.fixture
@@ -479,7 +490,7 @@ class TestEdgeCases:
                 "value": value,
             }
 
-        # Values interpreted as kWh — conversion factor 1000 applied.
+        # Values interpreted as kWh - conversion factor 1000 applied.
         attributes = {"forecast": [_slot(0, 100.0), _slot(1, 50.5)]}
 
         forecast = provider._parse_forecast_from_attributes(attributes)
@@ -652,11 +663,11 @@ class TestEvccForecastFormat:
                 # Invalid start timestamp
                 {"start": "not-a-date",
                     "end": self._hour_str(timezone, 2), "value": 500.0},
-                # Missing 'end' key → skipped (end is required)
+                # Missing 'end' key -> skipped (end is required)
                 {"start": self._hour_str(timezone, 2), "value": 2000.0},
-                # Missing start → skipped
+                # Missing start -> skipped
                 {"end": self._hour_str(timezone, 3), "value": 300.0},
-                # Missing value → skipped
+                # Missing value -> skipped
                 {"start": self._hour_str(timezone, 4),
                  "end": self._hour_str(timezone, 5)},
                 # Another valid entry
@@ -668,9 +679,9 @@ class TestEvccForecastFormat:
         forecast = provider._parse_forecast_from_attributes(attributes)
 
         assert forecast[0] == 1000.0      # valid entry at offset 0
-        assert 2 not in forecast or forecast[2] == 0.0  # skipped (no end)
+        assert forecast[2] == 0.0         # skipped (no end), zero-filled
         assert forecast[6] == 3000.0      # valid entry at offset 6
-        # Zero-filled gaps between 0 and 6 → consecutive keys 0..6
+        # Zero-filled gaps between 0 and 6 -> consecutive keys 0..6
         assert len(forecast) == 7
         for hour in range(7):
             assert hour in forecast

--- a/tests/test_forecast_solar_homeassistant_ml.py
+++ b/tests/test_forecast_solar_homeassistant_ml.py
@@ -36,41 +36,36 @@ def pv_installations():
 
 
 @pytest.fixture
-def ha_entity_state():
-    """Provide sample HomeAssistant entity state"""
+def ha_entity_state(timezone):
+    """Provide sample HomeAssistant entity state in evcc Solar-Prognose format.
+
+    Produces a rolling 14-hour forecast starting at the current hour (in the
+    test timezone, Europe/Berlin) so that the baseclass length validation
+    (>= 12 consecutive intervals) is satisfied regardless of when the tests
+    run.
+    """
+    now = datetime.datetime.now(timezone).replace(
+        minute=0, second=0, microsecond=0)
+    forecast = []
+    # Values chosen so forecast[0] == 879.0, forecast[1] == 1265.0, ... (in Wh)
+    wh_values = [879.0, 1265.0, 1688.0, 1571.0, 1578.0, 990.0, 489.0,
+                 268.0, 17.0, 17.0, 17.0, 17.0, 17.0, 17.0]
+    for offset, wh in enumerate(wh_values):
+        start = now + datetime.timedelta(hours=offset)
+        end = now + datetime.timedelta(hours=offset + 1)
+        forecast.append({
+            "start": start.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "end": end.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "value": wh,
+        })
+
     return {
-        "entity_id": "sensor.solar_forecast_ml_prognose_nachste_stunde",
-        "state": "0.879",
+        "entity_id": "sensor.solar_forecast_ml_evcc_solar_prognose",
+        "state": f"{len(forecast)} slots",
         "attributes": {
-            "state_class": "total",
-            "hour_1": 0.879,
-            "hour_1_time": "10:00",
-            "hour_2": 1.265,
-            "hour_2_time": "11:00",
-            "hour_3": 1.688,
-            "hour_3_time": "12:00",
-            "total_upcoming": 8.83,
-            "hours_count": 14,
-            "hours_list": [
-                {"time": "10:00", "kwh": 0.879},
-                {"time": "11:00", "kwh": 1.265},
-                {"time": "12:00", "kwh": 1.688},
-                {"time": "13:00", "kwh": 1.571},
-                {"time": "14:00", "kwh": 1.578},
-                {"time": "15:00", "kwh": 0.99},
-                {"time": "16:00", "kwh": 0.489},
-                {"time": "17:00", "kwh": 0.268},
-                {"time": "18:00", "kwh": 0.017},
-                {"time": "19:00", "kwh": 0.017},
-                {"time": "20:00", "kwh": 0.017},
-                {"time": "21:00", "kwh": 0.017},
-                {"time": "22:00", "kwh": 0.017},
-                {"time": "23:00", "kwh": 0.017},
-            ],
-            "unit_of_measurement": "kWh",
-            "device_class": "energy",
-            "icon": "mdi:clock-fast",
-            "friendly_name": "Solar Forecast ML"
+            "forecast": forecast,
+            "icon": "mdi:ev-station",
+            "friendly_name": "Solar Forecast ML evcc Solar-Prognose"
         },
         "last_changed": "2026-02-05T08:00:44.824837+00:00",
         "last_updated": "2026-02-05T08:00:44.824837+00:00"
@@ -159,142 +154,70 @@ class TestInitialization:
 class TestParsing:
     """Tests for forecast data parsing"""
 
-    def test_parse_hours_list_format(self, pv_installations, timezone, ha_entity_state):
-        """Test parsing primary hours_list format"""
+    def test_parse_evcc_format_from_fixture(
+            self, pv_installations, timezone, ha_entity_state):
+        """Test parsing the evcc forecast list from the shared fixture."""
         provider = ForecastSolarHomeAssistantML(
             pvinstallations=pv_installations,
             timezone=timezone,
             base_url="http://homeassistant.local:8123",
             api_token="test_token",
-            entity_id="sensor.solar_forecast",
-            sensor_unit="kWh"
+            entity_id="sensor.solar_forecast_ml_evcc_solar_prognose",
+            sensor_unit="Wh"
         )
 
         attributes = ha_entity_state["attributes"]
         forecast = provider._parse_forecast_from_attributes(attributes)
 
         assert len(forecast) == 14
-        assert forecast[0] == 879.0  # 0.879 kWh * 1000
-        assert forecast[1] == 1265.0  # 1.265 kWh * 1000
-        assert forecast[2] == 1688.0  # 1.688 kWh * 1000
+        assert forecast[0] == 879.0
+        assert forecast[1] == 1265.0
+        assert forecast[2] == 1688.0
 
-    def test_parse_hours_list_with_wh_unit(self, pv_installations, timezone, ha_entity_state):
-        """Test parsing hours_list with Wh unit (no conversion)"""
+    def test_parse_empty_forecast_list_raises_error(self, pv_installations, timezone):
+        """Test parsing empty forecast list raises error."""
         provider = ForecastSolarHomeAssistantML(
             pvinstallations=pv_installations,
             timezone=timezone,
             base_url="http://homeassistant.local:8123",
             api_token="test_token",
-            entity_id="sensor.solar_forecast",
+            entity_id="sensor.solar_forecast_ml_evcc_solar_prognose",
             sensor_unit="Wh"
         )
 
-        # Modify attributes to have Wh values
-        attributes = ha_entity_state["attributes"]
-        attributes["hours_list"] = [
-            # Already in Wh (renamed to kwh for test)
-            {"time": "10:00", "kwh": 879.0},
-            {"time": "11:00", "kwh": 1265.0},
-        ]
-
-        forecast = provider._parse_forecast_from_attributes(attributes)
-
-        assert forecast[0] == 879.0  # Already Wh
-        assert forecast[1] == 1265.0
-
-    def test_parse_fallback_hour_n_format(self, pv_installations, timezone):
-        """Test fallback hour_N attribute parsing"""
-        provider = ForecastSolarHomeAssistantML(
-            pvinstallations=pv_installations,
-            timezone=timezone,
-            base_url="http://homeassistant.local:8123",
-            api_token="test_token",
-            entity_id="sensor.solar_forecast",
-            sensor_unit="kWh"
-        )
-
-        attributes = {
-            "hour_1": 0.879,
-            "hour_1_time": "10:00",
-            "hour_2": 1.265,
-            "hour_2_time": "11:00",
-            "hour_3": 1.688,
-            "hour_3_time": "12:00",
-        }
-
-        forecast = provider._parse_forecast_from_attributes(attributes)
-
-        assert len(forecast) == 3
-        assert forecast[0] == 879.0  # hour_1 -> index 0
-        assert forecast[1] == 1265.0  # hour_2 -> index 1
-        assert forecast[2] == 1688.0  # hour_3 -> index 2
-
-    def test_parse_empty_hours_list_raises_error(self, pv_installations, timezone):
-        """Test parsing empty hours_list raises error"""
-        provider = ForecastSolarHomeAssistantML(
-            pvinstallations=pv_installations,
-            timezone=timezone,
-            base_url="http://homeassistant.local:8123",
-            api_token="test_token",
-            entity_id="sensor.solar_forecast",
-            sensor_unit="kWh"
-        )
-
-        attributes = {"hours_list": []}
+        attributes = {"forecast": []}
 
         with pytest.raises(ValueError, match="Could not parse any forecast data"):
             provider._parse_forecast_from_attributes(attributes)
 
-    def test_parse_missing_kwh_values_skipped(self, pv_installations, timezone):
-        """Test entries with missing kwh values are skipped"""
+    def test_parse_unsupported_formats_raise_error(self, pv_installations, timezone):
+        """Legacy hours_list / hour_N formats are no longer supported."""
         provider = ForecastSolarHomeAssistantML(
             pvinstallations=pv_installations,
             timezone=timezone,
             base_url="http://homeassistant.local:8123",
             api_token="test_token",
-            entity_id="sensor.solar_forecast",
+            entity_id="sensor.solar_forecast_ml_evcc_solar_prognose",
             sensor_unit="kWh"
         )
 
-        attributes = {
-            "hours_list": [
-                {"time": "10:00", "kwh": 0.879},
-                {"time": "11:00"},  # Missing kwh
-                {"time": "12:00", "kwh": 1.688},
-            ]
-        }
+        # Legacy hours_list is ignored
+        with pytest.raises(ValueError, match="Could not parse any forecast data"):
+            provider._parse_forecast_from_attributes({
+                "hours_list": [
+                    {"time": "10:00", "kwh": 0.879},
+                    {"time": "11:00", "kwh": 1.265},
+                ]
+            })
 
-        forecast = provider._parse_forecast_from_attributes(attributes)
-
-        assert len(forecast) == 2
-        assert forecast[0] == 879.0
-        assert forecast[2] == 1688.0
-        assert 1 not in forecast
-
-    def test_parse_invalid_kwh_values_skipped(self, pv_installations, timezone):
-        """Test entries with invalid kwh values are skipped"""
-        provider = ForecastSolarHomeAssistantML(
-            pvinstallations=pv_installations,
-            timezone=timezone,
-            base_url="http://homeassistant.local:8123",
-            api_token="test_token",
-            entity_id="sensor.solar_forecast",
-            sensor_unit="kWh"
-        )
-
-        attributes = {
-            "hours_list": [
-                {"time": "10:00", "kwh": 0.879},
-                {"time": "11:00", "kwh": "invalid"},  # Invalid kwh
-                {"time": "12:00", "kwh": 1.688},
-            ]
-        }
-
-        forecast = provider._parse_forecast_from_attributes(attributes)
-
-        assert len(forecast) == 2
-        assert forecast[0] == 879.0
-        assert forecast[2] == 1688.0
+        # Legacy hour_N attributes are ignored
+        with pytest.raises(ValueError, match="Could not parse any forecast data"):
+            provider._parse_forecast_from_attributes({
+                "hour_1": 0.879,
+                "hour_1_time": "10:00",
+                "hour_2": 1.265,
+                "hour_2_time": "11:00",
+            })
 
 
 # Tests for caching
@@ -329,8 +252,8 @@ class TestCaching:
             timezone=timezone,
             base_url="http://homeassistant.local:8123",
             api_token="test_token",
-            entity_id="sensor.solar_forecast",
-            sensor_unit="kWh"
+            entity_id="sensor.solar_forecast_ml_evcc_solar_prognose",
+            sensor_unit="Wh"
         )
 
         # Store raw data via baseclass
@@ -498,23 +421,29 @@ class TestEdgeCases:
         assert provider.base_url == "http://homeassistant.local:8123"
 
     def test_zero_forecast_values_accepted(self, pv_installations, timezone):
-        """Test zero forecast values are accepted"""
+        """Test zero forecast values are accepted (evcc format, Wh)."""
         provider = ForecastSolarHomeAssistantML(
             pvinstallations=pv_installations,
             timezone=timezone,
             base_url="http://homeassistant.local:8123",
             api_token="test_token",
-            entity_id="sensor.solar_forecast",
-            sensor_unit="kWh"
+            entity_id="sensor.solar_forecast_ml_evcc_solar_prognose",
+            sensor_unit="Wh"
         )
 
-        attributes = {
-            "hours_list": [
-                {"time": "10:00", "kwh": 0.0},
-                {"time": "11:00", "kwh": 0.0},
-                {"time": "12:00", "kwh": 1.688},
-            ]
-        }
+        now = datetime.datetime.now(timezone).replace(
+            minute=0, second=0, microsecond=0)
+
+        def _slot(offset, value):
+            start = now + datetime.timedelta(hours=offset)
+            end = start + datetime.timedelta(hours=1)
+            return {
+                "start": start.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                "end": end.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                "value": value,
+            }
+
+        attributes = {"forecast": [_slot(0, 0.0), _slot(1, 0.0), _slot(2, 1688.0)]}
 
         forecast = provider._parse_forecast_from_attributes(attributes)
 
@@ -523,22 +452,30 @@ class TestEdgeCases:
         assert forecast[2] == 1688.0
 
     def test_large_forecast_values(self, pv_installations, timezone):
-        """Test large forecast values are handled"""
+        """Test large forecast values are handled (evcc format, kWh)."""
         provider = ForecastSolarHomeAssistantML(
             pvinstallations=pv_installations,
             timezone=timezone,
             base_url="http://homeassistant.local:8123",
             api_token="test_token",
-            entity_id="sensor.solar_forecast",
+            entity_id="sensor.solar_forecast_ml_evcc_solar_prognose",
             sensor_unit="kWh"
         )
 
-        attributes = {
-            "hours_list": [
-                {"time": "10:00", "kwh": 100.0},  # 100 kWh
-                {"time": "11:00", "kwh": 50.5},
-            ]
-        }
+        now = datetime.datetime.now(timezone).replace(
+            minute=0, second=0, microsecond=0)
+
+        def _slot(offset, value):
+            start = now + datetime.timedelta(hours=offset)
+            end = start + datetime.timedelta(hours=1)
+            return {
+                "start": start.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                "end": end.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                "value": value,
+            }
+
+        # Values interpreted as kWh — conversion factor 1000 applied.
+        attributes = {"forecast": [_slot(0, 100.0), _slot(1, 50.5)]}
 
         forecast = provider._parse_forecast_from_attributes(attributes)
 
@@ -698,7 +635,8 @@ class TestEvccForecastFormat:
         assert forecast[0] == 7835.0
 
     def test_parse_forecast_list_invalid_entries_skipped(self, pv_installations, timezone):
-        """Test that entries with invalid start timestamps or missing values are skipped"""
+        """Test that entries with invalid start timestamps or missing required
+        fields (start/end/value) are skipped."""
         provider = self._make_provider_wh(pv_installations, timezone)
 
         attributes = {
@@ -709,27 +647,35 @@ class TestEvccForecastFormat:
                 # Invalid start timestamp
                 {"start": "not-a-date",
                     "end": self._hour_str(timezone, 2), "value": 500.0},
-                # Valid (no 'end' key is fine)
+                # Missing 'end' key → skipped (end is required)
                 {"start": self._hour_str(timezone, 2), "value": 2000.0},
                 # Missing start → skipped
                 {"end": self._hour_str(timezone, 3), "value": 300.0},
                 # Missing value → skipped
                 {"start": self._hour_str(timezone, 4),
                  "end": self._hour_str(timezone, 5)},
+                # Another valid entry
+                {"start": self._hour_str(timezone, 6), "end": self._hour_str(timezone, 7),
+                 "value": 3000.0},
             ]
         }
 
         forecast = provider._parse_forecast_from_attributes(attributes)
 
-        assert forecast[0] == 1000.0   # valid entry at offset 0
-        assert forecast[1] == 0.0      # zero-filled gap between 0 and 2
-        assert forecast[2] == 2000.0   # valid entry at offset 2
-        assert 4 not in forecast        # missing value → not in result, beyond max_offset
-        # offsets 0..2 (max valid offset) are present; offset 4 is never added
-        assert len([k for k in forecast if k >= 0]) == 3
+        assert forecast[0] == 1000.0      # valid entry at offset 0
+        assert 2 not in forecast or forecast[2] == 0.0  # skipped (no end)
+        assert forecast[6] == 3000.0      # valid entry at offset 6
+        # Zero-filled gaps between 0 and 6 → consecutive keys 0..6
+        assert len(forecast) == 7
+        for hour in range(7):
+            assert hour in forecast
+        # Offsets with only invalid/skipped entries must be 0.0
+        for hour in (1, 2, 3, 4, 5):
+            assert forecast[hour] == 0.0
 
-    def test_parse_forecast_list_priority_over_hours_list(self, pv_installations, timezone):
-        """Test that 'forecast' list takes priority over 'hours_list' when both are present"""
+    def test_parse_forecast_list_ignores_legacy_formats(self, pv_installations, timezone):
+        """Legacy 'hours_list' / 'hour_N' attributes are ignored; only the
+        evcc 'forecast' list is consulted."""
         provider = self._make_provider_wh(pv_installations, timezone)
 
         attributes = {
@@ -740,12 +686,14 @@ class TestEvccForecastFormat:
             "hours_list": [
                 {"time": "10:00", "kwh": 9.0},
                 {"time": "11:00", "kwh": 9.0},
-            ]
+            ],
+            "hour_1": 9.0,
+            "hour_1_time": "10:00",
         }
 
         forecast = provider._parse_forecast_from_attributes(attributes)
 
-        # forecast list wins
+        # Only the evcc 'forecast' list contributes to the result
         assert forecast[0] == 111.0
         assert len(forecast) == 1
 

--- a/tests/test_forecast_solar_homeassistant_ml.py
+++ b/tests/test_forecast_solar_homeassistant_ml.py
@@ -53,9 +53,12 @@ def ha_entity_state(timezone):
     for offset, wh in enumerate(wh_values):
         start = now + datetime.timedelta(hours=offset)
         end = now + datetime.timedelta(hours=offset + 1)
+        # Use isoformat() so the offset is rendered as '+02:00' (with colon).
+        # Python 3.9/3.10's fromisoformat() rejects the '+0200' form that
+        # strftime('%z') emits.
         forecast.append({
-            "start": start.strftime("%Y-%m-%dT%H:%M:%S%z"),
-            "end": end.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "start": start.isoformat(),
+            "end": end.isoformat(),
             "value": wh,
         })
 
@@ -437,9 +440,10 @@ class TestEdgeCases:
         def _slot(offset, value):
             start = now + datetime.timedelta(hours=offset)
             end = start + datetime.timedelta(hours=1)
+            # isoformat() renders '+02:00' which is required by Python 3.9/3.10
             return {
-                "start": start.strftime("%Y-%m-%dT%H:%M:%S%z"),
-                "end": end.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                "start": start.isoformat(),
+                "end": end.isoformat(),
                 "value": value,
             }
 
@@ -468,9 +472,10 @@ class TestEdgeCases:
         def _slot(offset, value):
             start = now + datetime.timedelta(hours=offset)
             end = start + datetime.timedelta(hours=1)
+            # isoformat() renders '+02:00' which is required by Python 3.9/3.10
             return {
-                "start": start.strftime("%Y-%m-%dT%H:%M:%S%z"),
-                "end": end.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                "start": start.isoformat(),
+                "end": end.isoformat(),
                 "value": value,
             }
 


### PR DESCRIPTION
## Summary

Closes #314.

Drops the legacy `hours_list` and `hour_N` attribute parsers from the HomeAssistant Solar Forecast ML provider and keeps only the evcc Solar-Prognose format, which is the only variant we want to support going forward (0.8.0). Entries in the evcc `forecast` list must now carry all three fields — `start`, `end` **and** `value` — to be considered valid; entries missing any of them are skipped.

### Changes

- **`src/batcontrol/forecastsolar/forecast_homeassistant_ml.py`**
  - Removed `_parse_forecast_hours_list` and `_parse_forecast_hour_n`.
  - Renamed `_parse_forecast_format1` → `_parse_forecast_evcc`.
  - `_parse_forecast_evcc_entry` now requires `start`, `end` and `value`.
  - `_parse_forecast_from_attributes` only inspects the evcc `forecast` list and raises a clearer `ValueError` when no usable data is present.
  - Updated module docstring to list only the supported sensor.
- **`config/batcontrol_config_dummy.yaml`** — default `entity_id` now points at `sensor.solar_forecast_ml_evcc_solar_prognose`.
- **`scripts/test_solar_forecast_ha_ml.py`** — same default `ENTITY_ID` update.
- **`tests/test_forecast_solar_homeassistant_ml.py`**
  - `ha_entity_state` fixture rewritten to emit the evcc format (rolling 14-hour window anchored at the current hour in the test timezone).
  - Removed the hours_list / hour_N tests; added coverage asserting those legacy formats now raise `ValueError`.
  - Updated the "invalid entries skipped" test so a missing `end` field is treated as invalid.
  - Converted remaining edge-case tests (zero values, large values, cache retrieval) to the evcc format.

## Test plan

- [x] `python -m pytest tests/test_forecast_solar_homeassistant_ml.py` — 29/29 pass
- [x] Full suite still green for everything touched by this change (the 14 pre-existing errors in `test_production_offset.py`, `test_core.py`, `test_inverter_factory.py` are unrelated to this PR and reproduce on `main`).

https://claude.ai/code/session_01CFyp1at1u49PAZf8nVQUim