### PR TITLE
mqtt: expose limit-battery-charge mode in Home Assistant discovery

### DIFF
--- a/src/batcontrol/mqtt_api.py
+++ b/src/batcontrol/mqtt_api.py
@@ -731,6 +731,7 @@ class MqttApi:
         val_templ = (
             "{% if value == '-1' %}Charge from Grid"
             "{% elif value == '0' %}Avoid Discharge"
+            "{% elif value == '8' %}Limit Battery Charge"
             "{% elif value == '10' %}Discharge Allowed"
             "{% else %}Unknown"
             "{% endif %}"
@@ -738,6 +739,7 @@ class MqttApi:
         cmd_templ = (
             "{% if value == 'Charge from Grid' %}-1"
             "{% elif value == 'Avoid Discharge' %}0"
+            "{% elif value == 'Limit Battery Charge' %}8"
             "{% elif value == 'Discharge Allowed' %}10"
             "{% else %}-1"
             "{% endif %}"
@@ -754,6 +756,7 @@ class MqttApi:
             options=[
                 "Charge from Grid",
                 "Avoid Discharge",
+                "Limit Battery Charge",
                 "Discharge Allowed"],
             value_template=val_templ,
             command_template=cmd_templ)

--- a/tests/batcontrol/test_mqtt_api.py
+++ b/tests/batcontrol/test_mqtt_api.py
@@ -89,6 +89,33 @@ class TestHandleMessageBytesDecoding:
         assert received == ['true']
 
 
+class TestModeDiscovery:
+    """Mode discovery should expose the full externally supported mode model."""
+
+    def test_mode_discovery_includes_limit_battery_charge_mode(self):
+        api = MagicMock(spec=MqttApi)
+        api.base_topic = 'batcontrol'
+        api.publish_mqtt_discovery_message = MagicMock()
+        api.send_mqtt_discovery_for_mode = (
+            MqttApi.send_mqtt_discovery_for_mode.__get__(api, MqttApi)
+        )
+
+        api.send_mqtt_discovery_for_mode()
+
+        options = api.publish_mqtt_discovery_message.call_args.kwargs['options']
+        value_template = api.publish_mqtt_discovery_message.call_args.kwargs['value_template']
+        command_template = api.publish_mqtt_discovery_message.call_args.kwargs['command_template']
+
+        assert options == [
+            'Charge from Grid',
+            'Avoid Discharge',
+            'Limit Battery Charge',
+            'Discharge Allowed',
+        ]
+        assert "{% elif value == '8' %}Limit Battery Charge" in value_template
+        assert "{% elif value == 'Limit Battery Charge' %}8" in command_template
+
+
 class TestPeakShavingEnabledApi:
     """Regression test: peak_shaving/enabled must correctly parse the bytes payload."""
 


### PR DESCRIPTION
batcontrol already supports mode `8` (`Limit Battery Charge`), but the MQTT discovery select only exposed the other three modes.

This adds the missing mode to the discovery templates and select options, with a small regression test.