### PR TITLE
docs: fix typo cleanup in inverter and core messages

### DIFF
--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -25,7 +25,7 @@ battery_control:
 #  See more Details in: https://github.com/MaStr/batcontrol/wiki/battery_control_expert
 #--------------------------
 battery_control_expert:
-  charge_rate_multiplier: 1.1 # Increase (>1) calculated charge rate to compensate charge inefficencies.
+  charge_rate_multiplier: 1.1 # Increase (>1) calculated charge rate to compensate charge inefficiencies.
   soften_price_difference_on_charging: False # enable earlier charging based on a more relaxed calculation
                                              # future_price <= current_price-min_price_difference/soften_price_difference_on_charging_factor
   soften_price_difference_on_charging_factor: 5

--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -404,7 +404,7 @@ class Batcontrol:
             logger.error("Error during initial data fetch: %s", e)
 
     def shutdown(self):
-        """ Shutdown Batcontrol and dependend modules (inverter..) """
+        """ Shutdown Batcontrol and dependent modules (inverter..) """
         logger.info('Shutting down Batcontrol')
         try:
             # Stop scheduler thread
@@ -437,12 +437,12 @@ class Batcontrol:
 
         if time_passed < ERROR_IGNORE_TIME:
             # keep current mode
-            logger.info("An API Error occured %0.fs ago. "
+            logger.info("An API Error occurred %0.fs ago. "
                         "Keeping inverter mode unchanged.", time_passed)
         else:
             # set default mode
             logger.warning(
-                "An API Error occured %0.fs ago. "
+                "An API Error occurred %0.fs ago. "
                 "Setting inverter to default mode (Allow Discharging)",
                 time_passed)
             self.allow_discharging()
@@ -454,7 +454,7 @@ class Batcontrol:
         # Reset some values
         self.__reset_run_data()
 
-        # Verify some constrains:
+        # Verify some constraints:
         #   always_allow_discharge needs to be above max_charging from grid.
         #   if not, it will oscillate between discharging and charging.
         always_allow_discharge_limit = self.general_logic.get_always_allow_discharge_limit()

--- a/src/batcontrol/inverter/inverter.py
+++ b/src/batcontrol/inverter/inverter.py
@@ -59,7 +59,7 @@ class Inverter:
             }
             inverter=MqttInverter(iv_config)
         else:
-            raise RuntimeError(f'[Inverter] Unkown inverter type {config["type"]}')
+            raise RuntimeError(f'[Inverter] Unknown inverter type {config["type"]}')
 
         inverter.inverter_num = Inverter.num_inverters
         Inverter.num_inverters += 1


### PR DESCRIPTION
This fixes the `Unknown` typo noted in https://github.com/MaStr/batcontrol/pull/337#discussion_r3095286070 and cleans up a few adjacent spelling mistakes in nearby user-facing strings/comments.