### PR TITLE
mqtt: expose limit battery charge rate in discovery

### DIFF
--- a/src/batcontrol/mqtt_api.py
+++ b/src/batcontrol/mqtt_api.py
@@ -528,6 +528,21 @@ class MqttApi:
             initial_value=10000)
 
         self.publish_mqtt_discovery_message(
+            "Limit Battery Charge Rate",
+            "batcontrol_limit_battery_charge_rate",
+            "number",
+            "power",
+            "W",
+            self.base_topic +
+            "/limit_battery_charge_rate",
+            self.base_topic +
+            "/limit_battery_charge_rate/set",
+            entity_category="config",
+            min_value=-1,
+            max_value=10000,
+            initial_value=-1)
+
+        self.publish_mqtt_discovery_message(
             "Always Allow Discharge Limit",
             "batcontrol_always_allow_discharge_limit",
             "number",

--- a/tests/batcontrol/test_mqtt_api.py
+++ b/tests/batcontrol/test_mqtt_api.py
@@ -119,6 +119,34 @@ class TestModeDiscovery:
 class TestDiscoveryMessages:
     """Discovery should expose key externally visible runtime state."""
 
+    def test_discovery_includes_limit_battery_charge_rate_number(self):
+        api = MagicMock(spec=MqttApi)
+        api.base_topic = 'batcontrol'
+        api.publish_mqtt_discovery_message = MagicMock()
+        api.send_mqtt_discovery_for_mode = MagicMock()
+        api.send_mqtt_discovery_messages = (
+            MqttApi.send_mqtt_discovery_messages.__get__(api, MqttApi)
+        )
+
+        api.send_mqtt_discovery_messages()
+
+        assert any(
+            call.args[:3] == (
+                'Limit Battery Charge Rate',
+                'batcontrol_limit_battery_charge_rate',
+                'number',
+            )
+            and call.args[3] == 'power'
+            and call.args[4] == 'W'
+            and call.args[5] == 'batcontrol/limit_battery_charge_rate'
+            and call.args[6] == 'batcontrol/limit_battery_charge_rate/set'
+            and call.kwargs['entity_category'] == 'config'
+            and call.kwargs['min_value'] == -1
+            and call.kwargs['max_value'] == 10000
+            and call.kwargs['initial_value'] == -1
+            for call in api.publish_mqtt_discovery_message.call_args_list
+        )
+
     def test_discovery_includes_api_override_active_binary_sensor(self):
         api = MagicMock(spec=MqttApi)
         api.base_topic = 'batcontrol'


### PR DESCRIPTION
This exposes the existing `limit_battery_charge_rate` MQTT control as a Home Assistant-discovered number entity, so the mode-8 control path is also configurable from the discovered HA surface.