### PR TITLE
mqtt: refresh current control state

### DIFF
--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -916,6 +916,11 @@ class Batcontrol:
                 self.min_price_difference_rel)
             self.mqtt_api.publish_production_offset(
                 self.production_offset_percent)
+            if self.last_mode is not None:
+                self.mqtt_api.publish_mode(self.last_mode)
+            self.mqtt_api.publish_charge_rate(self.last_charge_rate)
+            self.mqtt_api.publish_limit_battery_charge_rate(
+                self._limit_battery_charge_rate)
             self.mqtt_api.publish_api_override_active(
                 self.api_overwrite)
             #

--- a/tests/batcontrol/test_core.py
+++ b/tests/batcontrol/test_core.py
@@ -644,6 +644,30 @@ class TestApiOverrideMqttState:
         assert bc.api_overwrite is False
         assert bc.mqtt_api.publish_api_override_active.call_args_list[-1] == call(False)
 
+    def test_refresh_static_values_publishes_current_control_state(self, run_dispatch_setup):
+        bc, _mock_inverter, _fake_logic = run_dispatch_setup
+        bc.mqtt_api = MagicMock()
+        bc.last_mode = MODE_LIMIT_BATTERY_CHARGE_RATE
+        bc.last_charge_rate = 1200
+        bc._limit_battery_charge_rate = 1800
+        bc.api_overwrite = True
+
+        bc.refresh_static_values()
+
+        bc.mqtt_api.publish_mode.assert_called_once_with(MODE_LIMIT_BATTERY_CHARGE_RATE)
+        bc.mqtt_api.publish_charge_rate.assert_called_once_with(1200)
+        bc.mqtt_api.publish_limit_battery_charge_rate.assert_called_once_with(1800)
+        bc.mqtt_api.publish_api_override_active.assert_called_once_with(True)
+
+    def test_refresh_static_values_skips_unknown_mode(self, run_dispatch_setup):
+        bc, _mock_inverter, _fake_logic = run_dispatch_setup
+        bc.mqtt_api = MagicMock()
+        bc.last_mode = None
+
+        bc.refresh_static_values()
+
+        bc.mqtt_api.publish_mode.assert_not_called()
+
 
 class TestEvccPeakShavingGuard:
     """Test evcc peak shaving guard in core.py run loop."""


### PR DESCRIPTION
This republishes current control state during `refresh_static_values()`, so MQTT/HA clients can recover `mode`, `charge_rate`, `limit_battery_charge_rate`, and `api_override_active` more cleanly after reconnects or
 restarts.