### PR TITLE
mqtt: publish price difference updates immediately

### DIFF
--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -1041,6 +1041,8 @@ class Batcontrol:
         logger.info(
             'API: Setting min price difference to %.3f', min_price_difference)
         self.min_price_difference = min_price_difference
+        if self.mqtt_api is not None:
+            self.mqtt_api.publish_min_price_difference(min_price_difference)
 
     def api_set_min_price_difference_rel(
             self, min_price_difference_rel: float):
@@ -1054,6 +1056,10 @@ class Batcontrol:
             'API: Setting min price rel difference to %.3f',
             min_price_difference_rel)
         self.min_price_difference_rel = min_price_difference_rel
+        if self.mqtt_api is not None:
+            self.mqtt_api.publish_min_price_difference_rel(
+                min_price_difference_rel
+            )
 
     def api_set_production_offset(self, production_offset: float):
         """ Set production offset percentage from external API request.

--- a/tests/batcontrol/test_core.py
+++ b/tests/batcontrol/test_core.py
@@ -650,6 +650,24 @@ class TestApiOverrideMqttState:
         assert bc.api_overwrite is False
         assert bc.mqtt_api.publish_api_override_active.call_args_list[-1] == call(False)
 
+    def test_api_set_min_price_difference_publishes_immediately(self, run_dispatch_setup):
+        bc, _mock_inverter, _fake_logic = run_dispatch_setup
+        bc.mqtt_api = MagicMock()
+
+        bc.api_set_min_price_difference(0.075)
+
+        assert bc.min_price_difference == 0.075
+        bc.mqtt_api.publish_min_price_difference.assert_called_once_with(0.075)
+
+    def test_api_set_min_price_difference_rel_publishes_immediately(self, run_dispatch_setup):
+        bc, _mock_inverter, _fake_logic = run_dispatch_setup
+        bc.mqtt_api = MagicMock()
+
+        bc.api_set_min_price_difference_rel(0.15)
+
+        assert bc.min_price_difference_rel == 0.15
+        bc.mqtt_api.publish_min_price_difference_rel.assert_called_once_with(0.15)
+
     def test_refresh_static_values_publishes_current_control_state(self, run_dispatch_setup):
         bc, _mock_inverter, _fake_logic = run_dispatch_setup
         bc.mqtt_api = MagicMock()


### PR DESCRIPTION
This publishes `min_price_difference` and `min_price_difference_rel` immediately via MQTT when they are changed via the API, instead of waiting for the next refresh cycle.