### PR TITLE
inverter: add fronius modbus backup safety

### DIFF
--- a/src/batcontrol/inverter/fronius_modbus/__init__.py
+++ b/src/batcontrol/inverter/fronius_modbus/__init__.py
@@ -1,4 +1,9 @@
+from .grid_status import FroniusModbusGridStatusReader
 from .inverter import FroniusModbusInverter
 from .tcp_transport import FroniusModbusTcpTransport
 
-__all__ = ["FroniusModbusInverter", "FroniusModbusTcpTransport"]
+__all__ = [
+    "FroniusModbusGridStatusReader",
+    "FroniusModbusInverter",
+    "FroniusModbusTcpTransport",
+]

--- a/src/batcontrol/inverter/fronius_modbus/control.py
+++ b/src/batcontrol/inverter/fronius_modbus/control.py
@@ -1,10 +1,20 @@
+import logging
+
 from .commands import (
     build_allow_discharge_register_writes,
     build_avoid_discharge_register_writes,
     build_force_charge_register_writes,
     build_limit_battery_charge_register_writes,
 )
+from .grid_status import FroniusModbusGridStatus
 from .types import FroniusModbusTransport
+
+logger = logging.getLogger(__name__)
+
+ON_GRID_STATUSES = {
+    FroniusModbusGridStatus.ON_GRID,
+    FroniusModbusGridStatus.ON_GRID_OPERATING,
+}
 
 
 class FroniusModbusControl:
@@ -13,13 +23,16 @@ class FroniusModbusControl:
         transport: FroniusModbusTransport,
         max_charge_rate: float,
         revert_seconds: int = 0,
+        grid_status_reader=None,
     ):
         self.transport = transport
         self.max_charge_rate = max_charge_rate
         self.revert_seconds = revert_seconds
+        self.grid_status_reader = grid_status_reader
 
     def set_mode_force_charge(self, rate_watts: float):
-        self.transport.write_registers(
+        self._write_restrictive_mode(
+            "force_charge",
             build_force_charge_register_writes(
                 rate_watts,
                 self.max_charge_rate,
@@ -28,7 +41,8 @@ class FroniusModbusControl:
         )
 
     def set_mode_avoid_discharge(self):
-        self.transport.write_registers(
+        self._write_restrictive_mode(
+            "avoid_discharge",
             build_avoid_discharge_register_writes(
                 revert_seconds=self.revert_seconds,
             )
@@ -38,10 +52,43 @@ class FroniusModbusControl:
         self.transport.write_registers(build_allow_discharge_register_writes())
 
     def set_mode_limit_battery_charge(self, rate_watts: float):
-        self.transport.write_registers(
+        self._write_restrictive_mode(
+            "limit_battery_charge",
             build_limit_battery_charge_register_writes(
                 rate_watts,
                 self.max_charge_rate,
                 revert_seconds=self.revert_seconds,
             )
         )
+
+    def _write_restrictive_mode(self, mode_name: str, writes):
+        if self._is_restrictive_mode_allowed(mode_name):
+            self.transport.write_registers(writes)
+            return
+
+        self.transport.write_registers(build_allow_discharge_register_writes())
+
+    def _is_restrictive_mode_allowed(self, mode_name: str) -> bool:
+        if self.grid_status_reader is None:
+            return True
+
+        try:
+            status_read = self.grid_status_reader.read_grid_status()
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "Skipping Fronius Modbus %s because grid status could not be read: %s",
+                mode_name,
+                exc,
+            )
+            return False
+
+        grid_status = getattr(status_read, "status", status_read)
+        if grid_status in ON_GRID_STATUSES:
+            return True
+
+        logger.warning(
+            "Skipping Fronius Modbus %s while grid status is %s; restoring allow-discharge mode",
+            mode_name,
+            getattr(grid_status, "value", grid_status),
+        )
+        return False

--- a/src/batcontrol/inverter/fronius_modbus/grid_status.py
+++ b/src/batcontrol/inverter/fronius_modbus/grid_status.py
@@ -1,0 +1,111 @@
+"""Read and infer Fronius grid connection status via SunSpec Modbus."""
+
+from dataclasses import dataclass
+from enum import Enum
+
+from .reads import unsigned_to_signed_16
+from .types import FroniusModbusTransport
+
+COMMON_MODEL_START = 40071
+COMMON_MODEL_FREQUENCY_COUNT = 16
+FREQUENCY_REGISTER_OFFSET = 14
+FREQUENCY_SCALE_FACTOR_OFFSET = 15
+
+GRID_FREQUENCY_HZ = 50.0
+GRID_FREQUENCY_TOLERANCE_HZ = 0.2
+INVERTER_OPERATING_FREQUENCY_TOLERANCE_HZ = 5.0
+
+
+class FroniusModbusGridStatus(Enum):
+    """Condensed Fronius grid status inferred from meter/inverter frequency."""
+
+    OFF_GRID = "off_grid"
+    OFF_GRID_OPERATING = "off_grid_operating"
+    ON_GRID = "on_grid"
+    ON_GRID_OPERATING = "on_grid_operating"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class FroniusModbusGridStatusRead:
+    """Grid-status read result with the frequencies used for inference."""
+
+    status: FroniusModbusGridStatus
+    inverter_frequency_hz: float
+    meter_frequency_hz: float
+
+
+def _scaled_frequency(raw_value: int, raw_scale_factor: int) -> float:
+    value = unsigned_to_signed_16(raw_value)
+    scale_factor = unsigned_to_signed_16(raw_scale_factor)
+    return value * (10 ** scale_factor)
+
+
+def _is_near_grid_frequency(frequency_hz: float) -> bool:
+    lower_bound = GRID_FREQUENCY_HZ - GRID_FREQUENCY_TOLERANCE_HZ
+    upper_bound = GRID_FREQUENCY_HZ + GRID_FREQUENCY_TOLERANCE_HZ
+    return lower_bound <= frequency_hz <= upper_bound
+
+
+def _is_inverter_operating_frequency(frequency_hz: float) -> bool:
+    lower_bound = GRID_FREQUENCY_HZ - INVERTER_OPERATING_FREQUENCY_TOLERANCE_HZ
+    upper_bound = GRID_FREQUENCY_HZ + INVERTER_OPERATING_FREQUENCY_TOLERANCE_HZ
+    return lower_bound <= frequency_hz <= upper_bound
+
+
+def infer_grid_status(
+    inverter_frequency_hz: float,
+    meter_frequency_hz: float,
+) -> FroniusModbusGridStatus:
+    """Infer grid status from inverter and meter line frequency.
+
+    This mirrors the approach used by the external Home Assistant
+    ``fronius_modbus`` integration: the meter frequency indicates whether the
+    public grid is present; inverter frequency indicates whether the inverter is
+    operating while isolated from the grid.
+    """
+    meter_online = _is_near_grid_frequency(meter_frequency_hz)
+    inverter_on_grid = _is_near_grid_frequency(inverter_frequency_hz)
+
+    if meter_online and inverter_on_grid:
+        return FroniusModbusGridStatus.ON_GRID_OPERATING
+    if not meter_online and _is_inverter_operating_frequency(inverter_frequency_hz):
+        return FroniusModbusGridStatus.OFF_GRID_OPERATING
+    if inverter_frequency_hz < 1:
+        if meter_online:
+            return FroniusModbusGridStatus.ON_GRID
+        if meter_frequency_hz < 1:
+            return FroniusModbusGridStatus.OFF_GRID
+    return FroniusModbusGridStatus.UNKNOWN
+
+
+class FroniusModbusGridStatusReader:
+    """Read inverter/meter frequency and infer Fronius grid status."""
+
+    def __init__(
+        self,
+        inverter_transport: FroniusModbusTransport,
+        meter_transport: FroniusModbusTransport,
+    ):
+        self.inverter_transport = inverter_transport
+        self.meter_transport = meter_transport
+
+    def read_grid_status(self) -> FroniusModbusGridStatusRead:
+        inverter_frequency = self._read_frequency(self.inverter_transport)
+        meter_frequency = self._read_frequency(self.meter_transport)
+        return FroniusModbusGridStatusRead(
+            status=infer_grid_status(inverter_frequency, meter_frequency),
+            inverter_frequency_hz=inverter_frequency,
+            meter_frequency_hz=meter_frequency,
+        )
+
+    def _read_frequency(self, transport: FroniusModbusTransport) -> float:
+        register_read = transport.read_registers(
+            COMMON_MODEL_START,
+            COMMON_MODEL_FREQUENCY_COUNT,
+        )
+        values = register_read.values
+        return _scaled_frequency(
+            values[FREQUENCY_REGISTER_OFFSET],
+            values[FREQUENCY_SCALE_FACTOR_OFFSET],
+        )

--- a/src/batcontrol/inverter/fronius_modbus/inverter.py
+++ b/src/batcontrol/inverter/fronius_modbus/inverter.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from ..baseclass import DEFAULT_MAX_SOC, DEFAULT_MIN_SOC, InverterBaseclass
 from .control import FroniusModbusControl
@@ -17,6 +18,8 @@ class FroniusModbusInverter(InverterBaseclass):
         min_soc: float = DEFAULT_MIN_SOC,
         max_soc: float = DEFAULT_MAX_SOC,
         revert_seconds: int = 0,
+        grid_status_reader=None,
+        extra_transports: Optional[list[FroniusModbusTransport]] = None,
     ):
         super().__init__({})
         self.transport = transport
@@ -27,8 +30,10 @@ class FroniusModbusInverter(InverterBaseclass):
             transport,
             max_charge_rate=max_charge_rate,
             revert_seconds=revert_seconds,
+            grid_status_reader=grid_status_reader,
         )
         self.storage_reader = FroniusModbusStorageReader(transport)
+        self.extra_transports = extra_transports or []
 
     def set_mode_force_charge(self, chargerate: float):
         self.control.set_mode_force_charge(chargerate)
@@ -75,6 +80,10 @@ class FroniusModbusInverter(InverterBaseclass):
             close = getattr(self.transport, "close", None)
             if close is not None:
                 close()
+            for transport in self.extra_transports:
+                close = getattr(transport, "close", None)
+                if close is not None:
+                    close()
 
     def activate_mqtt(self, api_mqtt_api: object):
         pass

--- a/src/batcontrol/inverter/inverter.py
+++ b/src/batcontrol/inverter/inverter.py
@@ -1,7 +1,9 @@
 """ Factory for inverter providers """
 
 import logging
+from contextlib import suppress
 from .baseclass import DEFAULT_MAX_SOC, DEFAULT_MIN_SOC
+from .fronius_modbus import FroniusModbusGridStatusReader
 from .fronius_modbus import FroniusModbusInverter
 from .fronius_modbus import FroniusModbusTcpTransport
 from .inverter_interface import InverterInterface
@@ -62,19 +64,43 @@ class Inverter:
             }
             inverter=MqttInverter(iv_config)
         elif config['type'].lower() == 'fronius-modbus':
-            transport = FroniusModbusTcpTransport(
-                config['address'],
-                port=config.get('port', 502),
-                unit_id=config.get('unit_id', 1),
-            )
-            inverter = FroniusModbusInverter(
-                transport,
-                max_charge_rate=config['max_grid_charge_rate'],
-                capacity=config['capacity'],
-                min_soc=config.get('min_soc', DEFAULT_MIN_SOC),
-                max_soc=config.get('max_soc', DEFAULT_MAX_SOC),
-                revert_seconds=config.get('revert_seconds', 0),
-            )
+            transport = None
+            extra_transports = []
+            try:
+                transport = FroniusModbusTcpTransport(
+                    config['address'],
+                    port=config.get('port', 502),
+                    unit_id=config.get('unit_id', 1),
+                )
+                grid_status_reader = None
+                if config.get('backup_mode_safety_enabled', False):
+                    meter_transport = FroniusModbusTcpTransport(
+                        config['address'],
+                        port=config.get('port', 502),
+                        unit_id=config.get('meter_unit_id', 200),
+                    )
+                    extra_transports.append(meter_transport)
+                    grid_status_reader = FroniusModbusGridStatusReader(
+                        transport,
+                        meter_transport,
+                    )
+                inverter = FroniusModbusInverter(
+                    transport,
+                    max_charge_rate=config['max_grid_charge_rate'],
+                    capacity=config['capacity'],
+                    min_soc=config.get('min_soc', DEFAULT_MIN_SOC),
+                    max_soc=config.get('max_soc', DEFAULT_MAX_SOC),
+                    revert_seconds=config.get('revert_seconds', 0),
+                    grid_status_reader=grid_status_reader,
+                    extra_transports=extra_transports,
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                for opened_transport in [transport, *extra_transports]:
+                    close = getattr(opened_transport, 'close', None)
+                    if close is not None:
+                        with suppress(Exception):
+                            close()
+                raise
         else:
             raise RuntimeError(f'[Inverter] Unknown inverter type {config["type"]}')
 

--- a/tests/batcontrol/inverter/test_fronius_modbus_control.py
+++ b/tests/batcontrol/inverter/test_fronius_modbus_control.py
@@ -1,3 +1,5 @@
+import pytest
+
 from batcontrol.inverter.fronius_modbus.commands import (
     build_allow_discharge_register_writes,
     build_avoid_discharge_register_writes,
@@ -5,6 +7,7 @@ from batcontrol.inverter.fronius_modbus.commands import (
     build_limit_battery_charge_register_writes,
 )
 from batcontrol.inverter.fronius_modbus.control import FroniusModbusControl
+from batcontrol.inverter.fronius_modbus.grid_status import FroniusModbusGridStatus
 from batcontrol.inverter.fronius_modbus.types import RegisterWrite
 
 
@@ -81,3 +84,96 @@ def test_revert_seconds_defaults_to_zero():
     assert transport.writes == [
         build_force_charge_register_writes(3000, 5000, revert_seconds=0)
     ]
+
+
+class StubGridStatusReader:
+    def __init__(self, status=None, error=None):
+        self.status = status
+        self.error = error
+        self.read_count = 0
+
+    def read_grid_status(self):
+        self.read_count += 1
+        if self.error is not None:
+            raise self.error
+        return self.status
+
+
+@pytest.mark.parametrize(
+    "grid_status",
+    [
+        FroniusModbusGridStatus.ON_GRID,
+        FroniusModbusGridStatus.ON_GRID_OPERATING,
+    ],
+)
+def test_restrictive_modes_write_normally_when_grid_status_is_on_grid(grid_status):
+    transport = RecordingModbusTransport()
+    grid_status_reader = StubGridStatusReader(grid_status)
+    control = FroniusModbusControl(
+        transport,
+        max_charge_rate=5000,
+        revert_seconds=900,
+        grid_status_reader=grid_status_reader,
+    )
+
+    control.set_mode_avoid_discharge()
+
+    assert transport.writes == [build_avoid_discharge_register_writes(revert_seconds=900)]
+    assert grid_status_reader.read_count == 1
+
+
+def test_restrictive_modes_fail_open_to_allow_discharge_when_off_grid():
+    transport = RecordingModbusTransport()
+    control = FroniusModbusControl(
+        transport,
+        max_charge_rate=5000,
+        revert_seconds=900,
+        grid_status_reader=StubGridStatusReader(FroniusModbusGridStatus.OFF_GRID_OPERATING),
+    )
+
+    control.set_mode_avoid_discharge()
+
+    assert transport.writes == [build_allow_discharge_register_writes()]
+
+
+def test_force_charge_fails_open_to_allow_discharge_when_grid_status_is_unknown():
+    transport = RecordingModbusTransport()
+    control = FroniusModbusControl(
+        transport,
+        max_charge_rate=5000,
+        revert_seconds=900,
+        grid_status_reader=StubGridStatusReader(FroniusModbusGridStatus.UNKNOWN),
+    )
+
+    control.set_mode_force_charge(3000)
+
+    assert transport.writes == [build_allow_discharge_register_writes()]
+
+
+def test_limit_battery_charge_fails_open_when_grid_status_reader_fails():
+    transport = RecordingModbusTransport()
+    control = FroniusModbusControl(
+        transport,
+        max_charge_rate=5000,
+        revert_seconds=900,
+        grid_status_reader=StubGridStatusReader(error=RuntimeError("read failed")),
+    )
+
+    control.set_mode_limit_battery_charge(2000)
+
+    assert transport.writes == [build_allow_discharge_register_writes()]
+
+
+def test_allow_discharge_does_not_require_grid_status():
+    transport = RecordingModbusTransport()
+    grid_status_reader = StubGridStatusReader(error=RuntimeError("read failed"))
+    control = FroniusModbusControl(
+        transport,
+        max_charge_rate=5000,
+        grid_status_reader=grid_status_reader,
+    )
+
+    control.set_mode_allow_discharge()
+
+    assert transport.writes == [build_allow_discharge_register_writes()]
+    assert grid_status_reader.read_count == 0

--- a/tests/batcontrol/inverter/test_fronius_modbus_factory.py
+++ b/tests/batcontrol/inverter/test_fronius_modbus_factory.py
@@ -133,3 +133,93 @@ def test_factory_accepts_legacy_max_charge_rate_alias_for_fronius_modbus(mocker)
     mock_transport_cls.assert_called_once_with("192.168.1.100", port=502, unit_id=1)
     assert isinstance(inverter, FroniusModbusInverter)
     assert inverter.control.max_charge_rate == 4200
+
+
+def test_factory_wires_optional_fronius_modbus_backup_mode_safety(mocker):
+    inverter_transport = mocker.MagicMock()
+    meter_transport = mocker.MagicMock()
+    mock_transport_cls = mocker.patch(
+        "batcontrol.inverter.inverter.FroniusModbusTcpTransport",
+        autospec=True,
+        side_effect=[inverter_transport, meter_transport],
+    )
+    grid_status_reader = mocker.MagicMock()
+    mock_grid_status_reader_cls = mocker.patch(
+        "batcontrol.inverter.inverter.FroniusModbusGridStatusReader",
+        autospec=True,
+        return_value=grid_status_reader,
+    )
+
+    config = {
+        "type": "fronius-modbus",
+        "address": "192.168.1.100",
+        "port": 1502,
+        "unit_id": 3,
+        "meter_unit_id": 203,
+        "capacity": 10000,
+        "max_grid_charge_rate": 5000,
+        "backup_mode_safety_enabled": True,
+    }
+
+    inverter = Inverter.create_inverter(config)
+
+    assert mock_transport_cls.call_args_list == [
+        mocker.call("192.168.1.100", port=1502, unit_id=3),
+        mocker.call("192.168.1.100", port=1502, unit_id=203),
+    ]
+    mock_grid_status_reader_cls.assert_called_once_with(
+        inverter_transport,
+        meter_transport,
+    )
+    assert inverter.control.grid_status_reader is grid_status_reader
+    assert inverter.extra_transports == [meter_transport]
+
+
+def test_factory_defaults_fronius_modbus_meter_unit_id_for_backup_mode_safety(mocker):
+    mock_transport_cls = mocker.patch(
+        "batcontrol.inverter.inverter.FroniusModbusTcpTransport",
+        autospec=True,
+        side_effect=[mocker.MagicMock(), mocker.MagicMock()],
+    )
+    mocker.patch(
+        "batcontrol.inverter.inverter.FroniusModbusGridStatusReader",
+        autospec=True,
+        return_value=mocker.MagicMock(),
+    )
+
+    config = {
+        "type": "fronius-modbus",
+        "address": "192.168.1.100",
+        "capacity": 10000,
+        "max_grid_charge_rate": 5000,
+        "backup_mode_safety_enabled": True,
+    }
+
+    Inverter.create_inverter(config)
+
+    assert mock_transport_cls.call_args_list == [
+        mocker.call("192.168.1.100", port=502, unit_id=1),
+        mocker.call("192.168.1.100", port=502, unit_id=200),
+    ]
+
+
+def test_factory_closes_primary_transport_when_backup_meter_transport_fails(mocker):
+    inverter_transport = mocker.MagicMock()
+    mocker.patch(
+        "batcontrol.inverter.inverter.FroniusModbusTcpTransport",
+        autospec=True,
+        side_effect=[inverter_transport, RuntimeError("meter unavailable")],
+    )
+
+    config = {
+        "type": "fronius-modbus",
+        "address": "192.168.1.100",
+        "capacity": 10000,
+        "max_grid_charge_rate": 5000,
+        "backup_mode_safety_enabled": True,
+    }
+
+    with pytest.raises(RuntimeError, match="meter unavailable"):
+        Inverter.create_inverter(config)
+
+    inverter_transport.close.assert_called_once_with()

--- a/tests/batcontrol/inverter/test_fronius_modbus_grid_status.py
+++ b/tests/batcontrol/inverter/test_fronius_modbus_grid_status.py
@@ -1,0 +1,99 @@
+import pytest
+
+from batcontrol.inverter.fronius_modbus.grid_status import (
+    GRID_FREQUENCY_HZ,
+    GRID_FREQUENCY_TOLERANCE_HZ,
+    FroniusModbusGridStatus,
+    FroniusModbusGridStatusReader,
+    infer_grid_status,
+)
+from batcontrol.inverter.fronius_modbus.types import RegisterRead
+
+
+class RecordingModbusTransport:
+    def __init__(self, values):
+        self.values = values
+        self.read_requests = []
+
+    def read_registers(self, register: int, count: int) -> RegisterRead:
+        self.read_requests.append((register, count))
+        return RegisterRead(start_register=register, values=self.values)
+
+
+def common_model_frequency_registers(raw_frequency: int, scale_factor: int = 65534):
+    values = [0] * 16
+    values[14] = raw_frequency
+    values[15] = scale_factor
+    return values
+
+
+def test_infers_on_grid_operating_from_meter_and_inverter_frequency():
+    assert infer_grid_status(
+        inverter_frequency_hz=49.91,
+        meter_frequency_hz=49.90,
+    ) == FroniusModbusGridStatus.ON_GRID_OPERATING
+
+
+def test_infers_off_grid_operating_when_meter_is_offline_and_inverter_is_running():
+    assert infer_grid_status(
+        inverter_frequency_hz=53.0,
+        meter_frequency_hz=0.0,
+    ) == FroniusModbusGridStatus.OFF_GRID_OPERATING
+
+
+def test_infers_on_grid_when_meter_is_online_and_inverter_is_sleeping():
+    assert infer_grid_status(
+        inverter_frequency_hz=0.0,
+        meter_frequency_hz=49.90,
+    ) == FroniusModbusGridStatus.ON_GRID
+
+
+def test_infers_off_grid_when_meter_and_inverter_are_offline():
+    assert infer_grid_status(
+        inverter_frequency_hz=0.0,
+        meter_frequency_hz=0.0,
+    ) == FroniusModbusGridStatus.OFF_GRID
+
+
+def test_infers_unknown_when_frequency_combination_is_not_understood():
+    assert infer_grid_status(
+        inverter_frequency_hz=60.0,
+        meter_frequency_hz=49.90,
+    ) == FroniusModbusGridStatus.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "boundary_frequency",
+    [
+        GRID_FREQUENCY_HZ - GRID_FREQUENCY_TOLERANCE_HZ,
+        GRID_FREQUENCY_HZ + GRID_FREQUENCY_TOLERANCE_HZ,
+    ],
+)
+def test_infers_on_grid_operating_at_grid_frequency_tolerance_boundaries(
+    boundary_frequency,
+):
+    assert infer_grid_status(
+        inverter_frequency_hz=boundary_frequency,
+        meter_frequency_hz=boundary_frequency,
+    ) == FroniusModbusGridStatus.ON_GRID_OPERATING
+
+
+def test_grid_status_reader_reads_common_model_frequencies():
+    inverter_transport = RecordingModbusTransport(
+        common_model_frequency_registers(4991)
+    )
+    meter_transport = RecordingModbusTransport(
+        common_model_frequency_registers(4990)
+    )
+    reader = FroniusModbusGridStatusReader(
+        inverter_transport,
+        meter_transport,
+    )
+
+    status = reader.read_grid_status()
+
+    assert status.status == FroniusModbusGridStatus.ON_GRID_OPERATING
+    assert status.inverter_frequency_hz == pytest.approx(49.91)
+    assert status.meter_frequency_hz == pytest.approx(49.90)
+    assert inverter_transport.read_requests == [(40071, 16)]
+    assert meter_transport.read_requests == [(40071, 16)]

--- a/tests/batcontrol/inverter/test_fronius_modbus_inverter.py
+++ b/tests/batcontrol/inverter/test_fronius_modbus_inverter.py
@@ -394,3 +394,31 @@ def test_shutdown_closes_transport_even_if_reset_to_auto_fails():
 
     assert transport.events == ["write", "close"]
     assert transport.close_count == 1
+
+
+def test_inverter_passes_grid_status_reader_to_control_layer():
+    transport = RecordingModbusTransport()
+    grid_status_reader = object()
+
+    inverter = FroniusModbusInverter(
+        transport,
+        max_charge_rate=5000,
+        grid_status_reader=grid_status_reader,
+    )
+
+    assert inverter.control.grid_status_reader is grid_status_reader
+
+
+def test_shutdown_closes_extra_transports():
+    transport = RecordingModbusTransport()
+    meter_transport = RecordingModbusTransport()
+    inverter = FroniusModbusInverter(
+        transport,
+        max_charge_rate=5000,
+        extra_transports=[meter_transport],
+    )
+
+    inverter.shutdown()
+
+    assert transport.close_count == 1
+    assert meter_transport.close_count == 1


### PR DESCRIPTION
Adds an opt-in safety guard for `fronius-modbus`.

When `backup_mode_safety_enabled` is true, restrictive Modbus writes are only sent while grid status is confidently on-grid. If status is off-grid, unknown, or unreadable, batcontrol fails open by restoring allow-discharge mode.

Addresses #286.