### PR TITLE
inverter: expose fronius modbus charge limit

### DIFF
--- a/src/batcontrol/inverter/fronius_modbus/inverter.py
+++ b/src/batcontrol/inverter/fronius_modbus/inverter.py
@@ -26,6 +26,7 @@ class FroniusModbusInverter(InverterBaseclass):
         self.capacity = capacity
         self.min_soc = min_soc
         self.max_soc = max_soc
+        self.max_grid_charge_rate = max_charge_rate
         self.control = FroniusModbusControl(
             transport,
             max_charge_rate=max_charge_rate,

--- a/tests/batcontrol/inverter/test_fronius_modbus_inverter.py
+++ b/tests/batcontrol/inverter/test_fronius_modbus_inverter.py
@@ -112,6 +112,16 @@ def test_inverter_exposes_configured_capacity_limits_for_baseclass_math():
     assert inverter.max_soc == 95
 
 
+def test_inverter_exposes_configured_max_grid_charge_rate():
+    transport = RecordingModbusTransport()
+    inverter = FroniusModbusInverter(
+        transport,
+        max_charge_rate=5000,
+    )
+
+    assert inverter.max_grid_charge_rate == 5000
+
+
 def test_inverter_defaults_to_common_soc_limits():
     transport = RecordingModbusTransport()
     inverter = FroniusModbusInverter(


### PR DESCRIPTION
Fixes Fronius Modbus grid charging by exposing the configured max grid charge rate on the inverter object.

The core clamps force-charge requests via `inverter.max_grid_charge_rate`; without this attribute, the `fronius-modbus` backend crashes when the optimizer requests grid charging.

Tested with:

- `uv run --extra test pytest tests/batcontrol/inverter/test_fronius_modbus_*.py tests/batcontrol/inverter/test_inverter_factory.py tests/batcontrol/test_core.py -q`
