### PR TITLE
mqtt: publish control source state

### DIFF
--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -51,6 +51,9 @@ MODE_LIMIT_BATTERY_CHARGE_RATE = 8  # Limit PV charge, allow discharge
 MODE_AVOID_DISCHARGING = 0
 MODE_FORCE_CHARGING = -1
 
+CONTROL_SOURCE_API = 'api'
+CONTROL_SOURCE_OPTIMIZER = 'optimizer'
+
 logger = logging.getLogger(__name__)
 
 
@@ -132,6 +135,7 @@ class Batcontrol:
         self.api_overwrite = False
         # -1 = charge from grid , 0 = avoid discharge , 8 = limit battery charge, 10 = discharge allowed
         self.last_mode = None
+        self.last_control_source = None
         self.last_charge_rate = 0
         self._limit_battery_charge_rate = -1  # Dynamic battery charge rate limit (-1 = no limit)
         self._evcc_peak_shaving_disabled = False  # Tracks last evcc-disable state for log messages
@@ -681,37 +685,52 @@ class Batcontrol:
         if self.mqtt_api is not None:
             self.mqtt_api.publish_charge_rate(charge_rate)
 
-    def __set_mode(self, mode):
+    def __set_control_source(self, control_source: str):
+        """Set the source that last selected the current control state."""
+        if self.last_control_source == control_source:
+            return
+        self.last_control_source = control_source
+        if self.mqtt_api is not None:
+            self.mqtt_api.publish_control_source(control_source)
+
+    def __set_mode(self, mode, control_source: str = CONTROL_SOURCE_OPTIMIZER):
         """ Set mode and publish to mqtt """
         self.last_mode = mode
         if self.mqtt_api is not None:
             self.mqtt_api.publish_mode(mode)
+        self.__set_control_source(control_source)
         # leaving force charge mode, reset charge rate
         if self.last_charge_rate > 0 and mode != MODE_FORCE_CHARGING:
             self.__set_charge_rate(0)
 
-    def allow_discharging(self):
+    def allow_discharging(self, control_source: str = CONTROL_SOURCE_OPTIMIZER):
         """ Allow unlimited discharging of the battery """
         logger.info('Mode: Allow Discharging')
         self.inverter.set_mode_allow_discharge()
-        self.__set_mode(MODE_ALLOW_DISCHARGING)
+        self.__set_mode(MODE_ALLOW_DISCHARGING, control_source)
 
-    def avoid_discharging(self):
+    def avoid_discharging(self, control_source: str = CONTROL_SOURCE_OPTIMIZER):
         """ Avoid discharging the battery """
         logger.info('Mode: Avoid Discharging')
         self.inverter.set_mode_avoid_discharge()
-        self.__set_mode(MODE_AVOID_DISCHARGING)
+        self.__set_mode(MODE_AVOID_DISCHARGING, control_source)
 
-    def force_charge(self, charge_rate=500):
+    def force_charge(
+            self,
+            charge_rate=500,
+            control_source: str = CONTROL_SOURCE_OPTIMIZER):
         """ Force the battery to charge with a given rate """
         charge_rate = int(min(charge_rate, self.inverter.max_grid_charge_rate))
         logger.info(
             'Mode: grid charging. Charge rate : %d W', charge_rate)
         self.inverter.set_mode_force_charge(charge_rate)
-        self.__set_mode(MODE_FORCE_CHARGING)
+        self.__set_mode(MODE_FORCE_CHARGING, control_source)
         self.__set_charge_rate(charge_rate)
 
-    def limit_battery_charge_rate(self, limit_charge_rate: int = 0):
+    def limit_battery_charge_rate(
+            self,
+            limit_charge_rate: int = 0,
+            control_source: str = CONTROL_SOURCE_OPTIMIZER):
         """ Limit PV charging rate while allowing battery discharge
 
         Args:
@@ -719,7 +738,7 @@ class Batcontrol:
         """
         # If -1, use no limit (don't apply mode 8)
         if limit_charge_rate < 0:
-            self.allow_discharging()
+            self.allow_discharging(control_source)
             return
 
         # Always enforce a non-negative limit
@@ -738,7 +757,7 @@ class Batcontrol:
 
         logger.info('Mode: Limit Battery Charge Rate to %d W, discharge allowed', effective_limit)
         self.inverter.set_mode_limit_battery_charge(effective_limit)
-        self.__set_mode(MODE_LIMIT_BATTERY_CHARGE_RATE)
+        self.__set_mode(MODE_LIMIT_BATTERY_CHARGE_RATE, control_source)
 
         # Publish limit via MQTT
         if self.mqtt_api is not None:
@@ -955,9 +974,9 @@ class Batcontrol:
 
         if mode != self.last_mode:
             if mode == MODE_FORCE_CHARGING:
-                self.force_charge()
+                self.force_charge(control_source=CONTROL_SOURCE_API)
             elif mode == MODE_AVOID_DISCHARGING:
-                self.avoid_discharging()
+                self.avoid_discharging(CONTROL_SOURCE_API)
             elif mode == MODE_LIMIT_BATTERY_CHARGE_RATE:
                 if self._limit_battery_charge_rate < 0:
                     logger.warning(
@@ -965,9 +984,13 @@ class Batcontrol:
                         'limit configured. Set a limit via api_set_limit_battery_charge_rate '
                         'first. Falling back to allow-discharging mode.',
                         mode)
-                self.limit_battery_charge_rate(self._limit_battery_charge_rate)
+                self.limit_battery_charge_rate(
+                    self._limit_battery_charge_rate,
+                    control_source=CONTROL_SOURCE_API)
             elif mode == MODE_ALLOW_DISCHARGING:
-                self.allow_discharging()
+                self.allow_discharging(CONTROL_SOURCE_API)
+        else:
+            self.__set_control_source(CONTROL_SOURCE_API)
 
     def api_set_charge_rate(self, charge_rate: int):
         """ Log and change config charge_rate and activate charging."""
@@ -980,7 +1003,11 @@ class Batcontrol:
         if self.mqtt_api is not None:
             self.mqtt_api.publish_api_override_active(True)
         if charge_rate != self.last_charge_rate:
-            self.force_charge(charge_rate)
+            self.force_charge(
+                charge_rate,
+                control_source=CONTROL_SOURCE_API)
+        else:
+            self.__set_control_source(CONTROL_SOURCE_API)
 
     def api_set_limit_battery_charge_rate(self, limit: int):
         """ Set dynamic battery charge rate limit from external call
@@ -998,7 +1025,9 @@ class Batcontrol:
         # If currently in MODE_LIMIT_BATTERY_CHARGE_RATE, apply immediately.
         # Otherwise, publish the updated requested limit for external clients.
         if self.last_mode == MODE_LIMIT_BATTERY_CHARGE_RATE:
-            self.limit_battery_charge_rate(limit)
+            self.limit_battery_charge_rate(
+                limit,
+                control_source=CONTROL_SOURCE_API)
         elif self.mqtt_api is not None:
             self.mqtt_api.publish_limit_battery_charge_rate(limit)
 

--- a/src/batcontrol/mqtt_api.py
+++ b/src/batcontrol/mqtt_api.py
@@ -23,6 +23,7 @@ The following topics are published:
 - /discharge_blocked        : bool  # Discharge is blocked by other sources
 - /production_offset: production offset percentage (1.0 = 100%, 0.8 = 80%, etc.)
 - /api_override_active: bool indicating whether a temporary external/API override is active
+- /control_source: source that last selected the current control state (api or optimizer)
 
 The following statistical arrays are published as JSON arrays:
 - /FCST/production: forecasted production in W
@@ -55,6 +56,7 @@ TOPIC_MODE = 'mode'
 TOPIC_CHARGE_RATE = 'charge_rate'
 TOPIC_LIMIT_BATTERY_CHARGE_RATE = 'limit_battery_charge_rate'
 TOPIC_API_OVERRIDE_ACTIVE = 'api_override_active'
+TOPIC_CONTROL_SOURCE = 'control_source'
 TOPIC_SET_SUFFIX = '/set'
 
 
@@ -475,6 +477,17 @@ class MqttApi:
                 retain=True
             )
 
+    def publish_control_source(self, source: str) -> None:
+        """ Publish the source that last selected the current control state.
+            /control_source
+        """
+        if self.client.is_connected():
+            self.client.publish(
+                self._topic(TOPIC_CONTROL_SOURCE),
+                source,
+                retain=True
+            )
+
     def publish_peak_shaving_enabled(self, enabled: bool) -> None:
         """ Publish peak shaving enabled status to MQTT
             /peak_shaving/enabled
@@ -659,6 +672,15 @@ class MqttApi:
             self._topic(TOPIC_API_OVERRIDE_ACTIVE),
             entity_category="diagnostic",
             value_template="{% if value == 'true' %}ON{% else %}OFF{% endif %}")
+
+        self.publish_mqtt_discovery_message(
+            "Control Source",
+            "batcontrol_control_source",
+            "sensor",
+            None,
+            None,
+            self._topic(TOPIC_CONTROL_SOURCE),
+            entity_category="diagnostic")
 
         # sensors
         self.publish_mqtt_discovery_message(

--- a/tests/batcontrol/test_core.py
+++ b/tests/batcontrol/test_core.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, call, patch
 
 from batcontrol.core import (
     Batcontrol,
+    CONTROL_SOURCE_API,
+    CONTROL_SOURCE_OPTIMIZER,
     MODE_ALLOW_DISCHARGING,
     MODE_LIMIT_BATTERY_CHARGE_RATE,
 )
@@ -522,6 +524,21 @@ class TestCoreRunDispatch:
         mock_inverter.set_mode_force_charge.assert_not_called()
         mock_inverter.set_mode_avoid_discharge.assert_not_called()
 
+    def test_run_publishes_optimizer_control_source(self, run_dispatch_setup):
+        bc, _mock_inverter, fake_logic = run_dispatch_setup
+        bc.mqtt_api = MagicMock()
+        fake_logic.get_inverter_control_settings.return_value = MagicMock(
+            allow_discharge=True,
+            charge_from_grid=False,
+            charge_rate=0,
+            limit_battery_charge_rate=-1,
+        )
+
+        bc.run()
+
+        assert bc.last_control_source == CONTROL_SOURCE_OPTIMIZER
+        bc.mqtt_api.publish_control_source.assert_called_with(CONTROL_SOURCE_OPTIMIZER)
+
 
 class TestApiOverrideMqttState:
     """API override state should be observable via MQTT."""
@@ -639,6 +656,44 @@ class TestApiOverrideMqttState:
         bc.api_set_charge_rate(1200)
 
         bc.mqtt_api.publish_api_override_active.assert_called_once_with(True)
+
+    def test_api_set_mode_publishes_api_control_source(self, run_dispatch_setup):
+        bc, _mock_inverter, _fake_logic = run_dispatch_setup
+        bc.mqtt_api = MagicMock()
+
+        bc.api_set_mode(MODE_ALLOW_DISCHARGING)
+
+        assert bc.last_control_source == CONTROL_SOURCE_API
+        bc.mqtt_api.publish_control_source.assert_called_once_with(CONTROL_SOURCE_API)
+
+    def test_api_set_charge_rate_publishes_api_control_source(self, run_dispatch_setup):
+        bc, _mock_inverter, _fake_logic = run_dispatch_setup
+        bc.mqtt_api = MagicMock()
+
+        bc.api_set_charge_rate(1200)
+
+        assert bc.last_control_source == CONTROL_SOURCE_API
+        bc.mqtt_api.publish_control_source.assert_called_once_with(CONTROL_SOURCE_API)
+
+    def test_refresh_static_values_does_not_republish_control_source(self, run_dispatch_setup):
+        bc, _mock_inverter, _fake_logic = run_dispatch_setup
+        bc.mqtt_api = MagicMock()
+        bc.last_control_source = CONTROL_SOURCE_API
+
+        bc.refresh_static_values()
+
+        bc.mqtt_api.publish_control_source.assert_not_called()
+
+    def test_api_set_mode_does_not_republish_unchanged_control_source(
+            self, run_dispatch_setup):
+        bc, _mock_inverter, _fake_logic = run_dispatch_setup
+        bc.mqtt_api = MagicMock()
+        bc.last_mode = MODE_ALLOW_DISCHARGING
+        bc.last_control_source = CONTROL_SOURCE_API
+
+        bc.api_set_mode(MODE_ALLOW_DISCHARGING)
+
+        bc.mqtt_api.publish_control_source.assert_not_called()
 
     def test_run_clears_override_and_publishes_inactive_state(self, run_dispatch_setup):
         bc, _mock_inverter, _fake_logic = run_dispatch_setup

--- a/tests/batcontrol/test_mqtt_api.py
+++ b/tests/batcontrol/test_mqtt_api.py
@@ -52,6 +52,9 @@ def _make_publish_stub():
     api.publish_discharge_blocked = (
         MqttApi.publish_discharge_blocked.__get__(api, MqttApi)
     )
+    api.publish_control_source = (
+        MqttApi.publish_control_source.__get__(api, MqttApi)
+    )
     return api
 
 
@@ -240,6 +243,37 @@ class TestDiscoveryMessages:
             and call.args[5] == 'batcontrol/discharge_blocked'
             and "value | lower == 'true'" in call.kwargs['value_template']
             for call in api.publish_mqtt_discovery_message.call_args_list
+        )
+
+    def test_discovery_includes_control_source_diagnostic_sensor(self):
+        api = _make_discovery_stub()
+
+        api.send_mqtt_discovery_messages()
+
+        assert any(
+            call.args[:3] == (
+                'Control Source',
+                'batcontrol_control_source',
+                'sensor',
+            )
+            and call.args[5] == 'batcontrol/control_source'
+            and call.kwargs['entity_category'] == 'diagnostic'
+            for call in api.publish_mqtt_discovery_message.call_args_list
+        )
+
+
+class TestPublishControlSource:
+    """Control source should publish to its dedicated state topic."""
+
+    def test_publish_control_source_uses_control_source_topic(self):
+        api = _make_publish_stub()
+
+        api.publish_control_source('api')
+
+        api.client.publish.assert_called_once_with(
+            'batcontrol/control_source',
+            'api',
+            retain=True,
         )
 
 


### PR DESCRIPTION
Publishes a diagnostic MQTT state showing whether the current control state was last selected by the optimizer or through batcontrol's MQTT API.