### PR TITLE
logic: support minimum grid charge soc

### DIFF
--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -18,6 +18,7 @@ battery_control:
                                  #    _rel helps to avoid charging at high prices with less efficiency
   always_allow_discharge_limit: 0.90 # 0.00 to 1.00 above this SOC limit using energy from the battery is always allowed
   max_charging_from_grid_limit: 0.89 # 0.00 to 1.00 charging from the grid is only allowed until this SOC limit
+  # min_grid_charge_soc: 0.55        # optional 0.00 to 1.00 target to preserve/charge before expensive slots
   min_recharge_amount: 100           # in Wh, start & minimum amount of energy to recharge the battery
 
 #--------------------------
@@ -32,6 +33,7 @@ battery_control_expert:
   round_price_digits: 4 # round price to n digits after the comma
   production_offset_percent: 1.0 # Adjust production forecast by a percentage (1.0 = 100%, 0.8 = 80%, etc.)
                                  # Useful for winter mode when solar panels are covered with snow
+  preserve_min_grid_charge_soc: false # If true, also preserve min_grid_charge_soc as reserved energy during cheap/pre-expensive slots
 
 #--------------------------
 #  Peak Shaving

--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -57,6 +57,29 @@ CONTROL_SOURCE_OPTIMIZER = 'optimizer'
 logger = logging.getLogger(__name__)
 
 
+def _parse_optional_ratio(value, config_key: str) -> Optional[float]:
+    """Parse an optional 0..1 ratio config value."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{config_key} must be numeric between 0 and 1 or None, "
+            f"got {type(value).__name__}"
+        )
+    try:
+        ratio = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{config_key} must be numeric between 0 and 1 or None, "
+            f"got {value!r}"
+        ) from exc
+    if not 0 <= ratio <= 1:
+        raise ValueError(
+            f"{config_key} must be between 0 and 1 or None, got {value!r}"
+        )
+    return ratio
+
+
 @dataclass
 class PeakShavingConfig:
     """ Holds peak shaving configuration parameters, initialized from the config dict. """
@@ -277,6 +300,21 @@ class Batcontrol:
             'min_price_difference', 0.05)
         self.min_price_difference_rel = self.batconfig.get(
             'min_price_difference_rel', 0)
+        self.min_grid_charge_soc = _parse_optional_ratio(
+            self.batconfig.get('min_grid_charge_soc', None),
+            'battery_control.min_grid_charge_soc'
+        )
+        self.preserve_min_grid_charge_soc = False
+        if (self.min_grid_charge_soc is not None
+                and self.min_grid_charge_soc > self.max_charging_from_grid_limit):
+            logger.warning(
+                'min_grid_charge_soc (%.2f) is above '
+                'max_charging_from_grid_limit (%.2f); grid charging cannot '
+                'reach the minimum SoC target. Increase '
+                'max_charging_from_grid_limit or lower min_grid_charge_soc.',
+                self.min_grid_charge_soc,
+                self.max_charging_from_grid_limit
+            )
 
         self.round_price_digits = 4
         self.production_offset_percent = 1.0  # Default: no offset
@@ -290,6 +328,9 @@ class Batcontrol:
             self.production_offset_percent = battery_control_expert.get(
                 'production_offset_percent',
                 self.production_offset_percent)
+            self.preserve_min_grid_charge_soc = battery_control_expert.get(
+                'preserve_min_grid_charge_soc',
+                self.preserve_min_grid_charge_soc)
 
         self.general_logic = CommonLogic.get_instance(
             charge_rate_multiplier=self.batconfig.get(
@@ -633,6 +674,8 @@ class Batcontrol:
             self.min_price_difference,
             self.min_price_difference_rel,
             self.get_max_capacity(),
+            min_grid_charge_soc=self.min_grid_charge_soc,
+            preserve_min_grid_charge_soc=self.preserve_min_grid_charge_soc,
             peak_shaving_enabled=peak_shaving_config_enabled and not evcc_disable_peak_shaving,
             peak_shaving_allow_full_after=self.peak_shaving_config.allow_full_battery_after,
             peak_shaving_mode=self.peak_shaving_config.mode,
@@ -928,6 +971,9 @@ class Batcontrol:
                 self.get_always_allow_discharge_limit())
             self.mqtt_api.publish_max_charging_from_grid_limit(
                 self.max_charging_from_grid_limit)
+            if self.min_grid_charge_soc is not None:
+                self.mqtt_api.publish_min_grid_charge_soc(
+                    self.min_grid_charge_soc)
             #
             self.mqtt_api.publish_min_price_difference(
                 self.min_price_difference)

--- a/src/batcontrol/logic/common.py
+++ b/src/batcontrol/logic/common.py
@@ -5,6 +5,7 @@ It includes the handling of:
   - charge_rate multiplier
   """
 import logging
+from typing import Optional
 
 
 # Minimum charge rate to controlling loops between charging and
@@ -113,6 +114,43 @@ class CommonLogic:
             round(self.min_charge_energy, 0),
             round(needed_energy, 0))
         return False
+
+    def apply_min_grid_charge_soc_target(self, recharge_energy: float,
+                                         stored_energy: float,
+                                         min_grid_charge_soc: Optional[float]) -> float:
+        """Apply an optional minimum SoC target to grid recharge energy."""
+        if min_grid_charge_soc is None:
+            return recharge_energy
+
+        target_energy = self.max_capacity * min_grid_charge_soc
+        soc_recharge_energy = max(0.0, target_energy - stored_energy)
+        if soc_recharge_energy > recharge_energy:
+            logger.debug(
+                'Recharge increased to meet min_grid_charge_soc %.1f%%: %.1f Wh',
+                min_grid_charge_soc * 100,
+                soc_recharge_energy
+            )
+        return max(recharge_energy, soc_recharge_energy)
+
+    def apply_min_grid_charge_soc_reserve(self, reserved_energy: float,
+                                          stored_energy: float,
+                                          stored_usable_energy: float,
+                                          min_grid_charge_soc: Optional[float],
+                                          active: bool) -> float:
+        """Apply an optional minimum SoC target to protected reserve energy."""
+        if min_grid_charge_soc is None or not active:
+            return reserved_energy
+
+        min_soc_energy = max(0.0, stored_energy - stored_usable_energy)
+        target_energy = self.max_capacity * min_grid_charge_soc
+        target_usable_energy = max(0.0, target_energy - min_soc_energy)
+        if target_usable_energy > reserved_energy:
+            logger.debug(
+                'Reserve increased to meet min_grid_charge_soc %.1f%%: %.1f Wh',
+                min_grid_charge_soc * 100,
+                target_usable_energy
+            )
+        return max(reserved_energy, target_usable_energy)
 
     def calculate_charge_rate(self, charge_rate: float) -> int:
         """ Calculate the charge rate based on the charge rate multiplier.

--- a/src/batcontrol/logic/default.py
+++ b/src/batcontrol/logic/default.py
@@ -304,6 +304,25 @@ class DefaultLogic(LogicInterface):
             # add_remaining required_energy to reserved_storage
             reserved_storage += required_energy
 
+        min_grid_charge_soc_active = (
+            self.calculation_parameters.preserve_min_grid_charge_soc
+            and reserved_storage > 0
+            and self.__has_grid_charge_soc_price_signal(
+                consumption,
+                prices,
+                max_slots,
+                current_price,
+                min_dynamic_price_difference
+            )
+        )
+        reserved_storage = self.common.apply_min_grid_charge_soc_reserve(
+            reserved_storage,
+            calc_input.stored_energy,
+            calc_input.stored_usable_energy,
+            self.calculation_parameters.min_grid_charge_soc,
+            min_grid_charge_soc_active
+        )
+
         self.calculation_output.reserved_energy = reserved_storage
 
         if len(higher_price_slots) > 0:
@@ -338,6 +357,19 @@ class DefaultLogic(LogicInterface):
             reserved_storage
         )
 
+        return False
+
+    def __has_grid_charge_soc_price_signal(self, consumption: np.ndarray,
+                                           prices: dict,
+                                           max_slots: int,
+                                           current_price: float,
+                                           min_dynamic_price_difference: float) -> bool:
+        """Return True when a future price justifies preserving a grid-charge SoC target."""
+        for slot in range(max_slots):
+            future_price = prices[slot]
+            if (consumption[slot] > 0
+                    and future_price > current_price + min_dynamic_price_difference):
+                return True
         return False
 
  # %%
@@ -428,6 +460,12 @@ class DefaultLogic(LogicInterface):
             recharge_energy = 0.0
             self.calculation_output.required_recharge_energy = recharge_energy
             return recharge_energy
+
+        recharge_energy = self.common.apply_min_grid_charge_soc_target(
+            recharge_energy,
+            calc_input.stored_energy,
+            self.calculation_parameters.min_grid_charge_soc
+        )
 
         free_capacity = calc_input.free_capacity
 

--- a/src/batcontrol/logic/logic_interface.py
+++ b/src/batcontrol/logic/logic_interface.py
@@ -26,6 +26,12 @@ class CalculationParameters:
     min_price_difference: float
     min_price_difference_rel: float
     max_capacity: float # Maximum capacity of the battery in Wh (excludes MAX_SOC)
+    # Optional minimum SoC target used when grid charging is already economical.
+    # None disables the target. Values are ratios from 0.0 to 1.0.
+    min_grid_charge_soc: Optional[float] = None
+    # Expert option: also preserve the target as reserved energy during
+    # cheap/pre-expensive windows.
+    preserve_min_grid_charge_soc: bool = False
     # Peak shaving parameters
     peak_shaving_enabled: bool = False
     peak_shaving_allow_full_after: int = 14  # Hour (0-23)
@@ -40,6 +46,18 @@ class CalculationParameters:
     peak_shaving_price_limit: Optional[float] = None
 
     def __post_init__(self):
+        if self.min_grid_charge_soc is not None:
+            if (isinstance(self.min_grid_charge_soc, bool)
+                    or not isinstance(self.min_grid_charge_soc, (int, float))):
+                raise ValueError(
+                    f"min_grid_charge_soc must be numeric between 0 and 1 or None, "
+                    f"got {type(self.min_grid_charge_soc).__name__}"
+                )
+            if not 0 <= self.min_grid_charge_soc <= 1:
+                raise ValueError(
+                    f"min_grid_charge_soc must be between 0 and 1 or None, "
+                    f"got {self.min_grid_charge_soc}"
+                )
         if not 0 <= self.peak_shaving_allow_full_after <= 23:
             raise ValueError(
                 f"peak_shaving_allow_full_after must be 0-23, "

--- a/src/batcontrol/logic/next.py
+++ b/src/batcontrol/logic/next.py
@@ -594,6 +594,25 @@ class NextLogic(LogicInterface):
             # add_remaining required_energy to reserved_storage
             reserved_storage += required_energy
 
+        min_grid_charge_soc_active = (
+            self.calculation_parameters.preserve_min_grid_charge_soc
+            and reserved_storage > 0
+            and self._has_grid_charge_soc_price_signal(
+                consumption,
+                prices,
+                max_slots,
+                current_price,
+                min_dynamic_price_difference
+            )
+        )
+        reserved_storage = self.common.apply_min_grid_charge_soc_reserve(
+            reserved_storage,
+            calc_input.stored_energy,
+            calc_input.stored_usable_energy,
+            self.calculation_parameters.min_grid_charge_soc,
+            min_grid_charge_soc_active
+        )
+
         self.calculation_output.reserved_energy = reserved_storage
 
         if len(higher_price_slots) > 0:
@@ -623,6 +642,19 @@ class NextLogic(LogicInterface):
             reserved_storage
         )
 
+        return False
+
+    def _has_grid_charge_soc_price_signal(self, consumption: np.ndarray,
+                                          prices: dict,
+                                          max_slots: int,
+                                          current_price: float,
+                                          min_dynamic_price_difference: float) -> bool:
+        """Return True when a future price justifies preserving a grid-charge SoC target."""
+        for slot in range(max_slots):
+            future_price = prices[slot]
+            if (consumption[slot] > 0
+                    and future_price > current_price + min_dynamic_price_difference):
+                return True
         return False
 
     # ------------------------------------------------------------------ #
@@ -713,6 +745,12 @@ class NextLogic(LogicInterface):
             recharge_energy = 0.0
             self.calculation_output.required_recharge_energy = recharge_energy
             return recharge_energy
+
+        recharge_energy = self.common.apply_min_grid_charge_soc_target(
+            recharge_energy,
+            calc_input.stored_energy,
+            self.calculation_parameters.min_grid_charge_soc
+        )
 
         free_capacity = calc_input.free_capacity
 

--- a/src/batcontrol/mqtt_api.py
+++ b/src/batcontrol/mqtt_api.py
@@ -9,6 +9,8 @@ The following topics are published:
 - /mode: operational mode (-1 = charge from grid, 0 = avoid discharge, 8 = limit battery charge, 10 = discharge allowed)
 - /max_charging_from_grid_limit: charge limit in 0.1-1
 - /max_charging_from_grid_limit_percent: charge limit in %
+- /min_grid_charge_soc: optional minimum grid-charge target in 0.0-1.0
+- /min_grid_charge_soc_percent: optional minimum grid-charge target in %
 - /always_allow_discharge_limit: always discharge limit in 0.1-1
 - /always_allow_discharge_limit_percent: always discharge limit in %
 - /always_allow_discharge_limit_capacity: always discharge limit in Wh
@@ -386,6 +388,21 @@ class MqttApi:
                 f'{charge_limit:.2f}'
             )
 
+    def publish_min_grid_charge_soc(self, min_grid_charge_soc: float) -> None:
+        """ Publish the optional minimum grid-charge SoC target to MQTT
+            /min_grid_charge_soc_percent
+            /min_grid_charge_soc as digit.
+        """
+        if self.client.is_connected():
+            self.client.publish(
+                self.base_topic + '/min_grid_charge_soc_percent',
+                f'{min_grid_charge_soc * 100:.0f}'
+            )
+            self.client.publish(
+                self.base_topic + '/min_grid_charge_soc',
+                f'{min_grid_charge_soc:.2f}'
+            )
+
     def publish_min_price_difference(
             self, min_price_difference: float) -> None:
         """ Publish the minimum price difference to MQTT found in config
@@ -594,6 +611,16 @@ class MqttApi:
             max_value=1.0,
             step_value=0.1,
             initial_value=0.9)
+
+        self.publish_mqtt_discovery_message(
+            "Minimum Grid Charge SOC",
+            "batcontrol_min_grid_charge_soc",
+            "sensor",
+            "battery",
+            "%",
+            self.base_topic +
+            "/min_grid_charge_soc_percent",
+            entity_category="diagnostic")
 
         self.publish_mqtt_discovery_message(
             "Min Price Difference",

--- a/tests/batcontrol/logic/test_default.py
+++ b/tests/batcontrol/logic/test_default.py
@@ -219,6 +219,208 @@ class TestDefaultLogic(unittest.TestCase):
         self.assertIn(expected_stored_usable_energy, log_output)
         self.assertIn('charge_rate=', log_output)
 
+    def test_min_grid_charge_soc_increases_recharge_energy(self):
+        """Minimum grid-charge SoC raises recharge need when battery is below target."""
+        self.logic.set_calculation_parameters(CalculationParameters(
+            max_charging_from_grid_limit=0.79,
+            min_price_difference=0.05,
+            min_price_difference_rel=0.2,
+            max_capacity=self.max_capacity,
+            min_grid_charge_soc=0.55,
+        ))
+        stored_energy = 2000
+        stored_usable_energy, free_capacity = self._calculate_battery_values(
+            stored_energy, self.max_capacity
+        )
+        calc_input = CalculationInput(
+            consumption=np.array([1000, 2000, 1500]),
+            production=np.array([0, 0, 0]),
+            prices={0: 0.20, 1: 0.35, 2: 0.30},
+            stored_energy=stored_energy,
+            stored_usable_energy=stored_usable_energy,
+            free_capacity=free_capacity,
+        )
+
+        calc_timestamp = datetime.datetime(2025, 6, 20, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        self.assertTrue(self.logic.calculate(calc_input, calc_timestamp))
+        calc_output = self.logic.get_calculation_output()
+
+        # Targeting 55% on a 10 kWh battery from 2 kWh stored requires 3.5 kWh,
+        # plus the existing minimum recharge buffer.
+        self.assertAlmostEqual(calc_output.required_recharge_energy, 3600.0)
+
+    def test_min_grid_charge_soc_below_current_soc_does_not_increase_recharge(self):
+        """Minimum grid-charge SoC below current SoC keeps existing behavior."""
+        self.logic.set_calculation_parameters(CalculationParameters(
+            max_charging_from_grid_limit=0.79,
+            min_price_difference=0.05,
+            min_price_difference_rel=0.2,
+            max_capacity=self.max_capacity,
+            min_grid_charge_soc=0.10,
+        ))
+        stored_energy = 2000
+        stored_usable_energy, free_capacity = self._calculate_battery_values(
+            stored_energy, self.max_capacity
+        )
+        calc_input = CalculationInput(
+            consumption=np.array([1000, 2000, 1500]),
+            production=np.array([0, 0, 0]),
+            prices={0: 0.20, 1: 0.35, 2: 0.30},
+            stored_energy=stored_energy,
+            stored_usable_energy=stored_usable_energy,
+            free_capacity=free_capacity,
+        )
+
+        calc_timestamp = datetime.datetime(2025, 6, 20, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        self.assertTrue(self.logic.calculate(calc_input, calc_timestamp))
+        calc_output = self.logic.get_calculation_output()
+
+        self.assertAlmostEqual(calc_output.required_recharge_energy, 2100.0)
+
+    def test_min_grid_charge_soc_blocks_discharge_during_cheap_window(self):
+        """Expert option preserves battery before future expensive demand."""
+        self.logic.set_calculation_parameters(CalculationParameters(
+            max_charging_from_grid_limit=0.79,
+            min_price_difference=0.05,
+            min_price_difference_rel=0.2,
+            max_capacity=self.max_capacity,
+            min_grid_charge_soc=0.55,
+            preserve_min_grid_charge_soc=True,
+        ))
+        stored_energy = 5000
+        stored_usable_energy, free_capacity = self._calculate_battery_values(
+            stored_energy, self.max_capacity
+        )
+        calc_input = CalculationInput(
+            consumption=np.array([1000, 1000, 2000]),
+            production=np.array([0, 0, 0]),
+            prices={0: 0.10, 1: 0.11, 2: 0.30},
+            stored_energy=stored_energy,
+            stored_usable_energy=stored_usable_energy,
+            free_capacity=free_capacity,
+        )
+
+        calc_timestamp = datetime.datetime(2025, 6, 20, 22, 0, 0, tzinfo=datetime.timezone.utc)
+        self.assertTrue(self.logic.calculate(calc_input, calc_timestamp))
+        result = self.logic.get_inverter_control_settings()
+        calc_output = self.logic.get_calculation_output()
+
+        self.assertFalse(result.allow_discharge)
+        self.assertTrue(result.charge_from_grid)
+        self.assertGreater(calc_output.required_recharge_energy, 0)
+        self.assertGreater(calc_output.reserved_energy, 2000)
+
+    def test_min_grid_charge_soc_does_not_block_discharge_by_default(self):
+        """Minimum grid-charge SoC reserve preservation is opt-in."""
+        self.logic.set_calculation_parameters(CalculationParameters(
+            max_charging_from_grid_limit=0.79,
+            min_price_difference=0.05,
+            min_price_difference_rel=0.2,
+            max_capacity=self.max_capacity,
+            min_grid_charge_soc=0.55,
+        ))
+        stored_energy = 5000
+        stored_usable_energy, free_capacity = self._calculate_battery_values(
+            stored_energy, self.max_capacity
+        )
+        calc_input = CalculationInput(
+            consumption=np.array([1000, 1000, 2000]),
+            production=np.array([0, 0, 0]),
+            prices={0: 0.10, 1: 0.11, 2: 0.30},
+            stored_energy=stored_energy,
+            stored_usable_energy=stored_usable_energy,
+            free_capacity=free_capacity,
+        )
+
+        calc_timestamp = datetime.datetime(2025, 6, 20, 22, 0, 0, tzinfo=datetime.timezone.utc)
+        self.assertTrue(self.logic.calculate(calc_input, calc_timestamp))
+        result = self.logic.get_inverter_control_settings()
+
+        self.assertTrue(result.allow_discharge)
+        self.assertFalse(result.charge_from_grid)
+
+    def test_min_grid_charge_soc_allows_discharge_above_target(self):
+        """Minimum grid-charge SoC allows discharging energy above the target."""
+        self.logic.set_calculation_parameters(CalculationParameters(
+            max_charging_from_grid_limit=0.79,
+            min_price_difference=0.05,
+            min_price_difference_rel=0.2,
+            max_capacity=self.max_capacity,
+            min_grid_charge_soc=0.55,
+            preserve_min_grid_charge_soc=True,
+        ))
+        stored_energy = 6000
+        stored_usable_energy, free_capacity = self._calculate_battery_values(
+            stored_energy, self.max_capacity
+        )
+        calc_input = CalculationInput(
+            consumption=np.array([1000, 1000, 2000]),
+            production=np.array([0, 0, 0]),
+            prices={0: 0.10, 1: 0.11, 2: 0.30},
+            stored_energy=stored_energy,
+            stored_usable_energy=stored_usable_energy,
+            free_capacity=free_capacity,
+        )
+
+        calc_timestamp = datetime.datetime(2025, 6, 20, 22, 0, 0, tzinfo=datetime.timezone.utc)
+        self.assertTrue(self.logic.calculate(calc_input, calc_timestamp))
+        result = self.logic.get_inverter_control_settings()
+
+        self.assertTrue(result.allow_discharge)
+        self.assertFalse(result.charge_from_grid)
+
+    def test_min_grid_charge_soc_does_not_block_discharge_at_high_price(self):
+        """Minimum grid-charge SoC does not preserve battery when current price is high."""
+        self.logic.set_calculation_parameters(CalculationParameters(
+            max_charging_from_grid_limit=0.79,
+            min_price_difference=0.05,
+            min_price_difference_rel=0.2,
+            max_capacity=self.max_capacity,
+            min_grid_charge_soc=0.55,
+            preserve_min_grid_charge_soc=True,
+        ))
+        stored_energy = 5000
+        stored_usable_energy, free_capacity = self._calculate_battery_values(
+            stored_energy, self.max_capacity
+        )
+        calc_input = CalculationInput(
+            consumption=np.array([1000, 1000, 2000]),
+            production=np.array([0, 0, 0]),
+            prices={0: 0.30, 1: 0.10, 2: 0.10},
+            stored_energy=stored_energy,
+            stored_usable_energy=stored_usable_energy,
+            free_capacity=free_capacity,
+        )
+
+        calc_timestamp = datetime.datetime(2025, 6, 20, 6, 0, 0, tzinfo=datetime.timezone.utc)
+        self.assertTrue(self.logic.calculate(calc_input, calc_timestamp))
+        result = self.logic.get_inverter_control_settings()
+
+        self.assertTrue(result.allow_discharge)
+        self.assertFalse(result.charge_from_grid)
+
+    def test_min_grid_charge_soc_must_be_ratio(self):
+        """Minimum grid-charge SoC accepts only ratio values."""
+        with self.assertRaises(ValueError):
+            CalculationParameters(
+                max_charging_from_grid_limit=0.79,
+                min_price_difference=0.05,
+                min_price_difference_rel=0.2,
+                max_capacity=self.max_capacity,
+                min_grid_charge_soc=55,
+            )
+
+    def test_min_grid_charge_soc_must_be_numeric(self):
+        """Minimum grid-charge SoC rejects non-numeric values clearly."""
+        with self.assertRaisesRegex(ValueError, "must be numeric"):
+            CalculationParameters(
+                max_charging_from_grid_limit=0.79,
+                min_price_difference=0.05,
+                min_price_difference_rel=0.2,
+                max_capacity=self.max_capacity,
+                min_grid_charge_soc="0.55",
+            )
+
     def test_charge_calculation_when_charging_not_possible_high_soc(self):
         """Test charge calculation when charging is not possible due to high SOC"""
         # Set SOC above charging limit (79%)

--- a/tests/batcontrol/logic/test_min_grid_charge_soc_live_cases.py
+++ b/tests/batcontrol/logic/test_min_grid_charge_soc_live_cases.py
@@ -1,0 +1,153 @@
+"""Regression-style tests based on a real overnight grid-charge scenario."""
+import datetime
+
+import numpy as np
+import pytest
+from pytest import approx
+
+from batcontrol.logic.common import CommonLogic
+from batcontrol.logic.default import DefaultLogic
+from batcontrol.logic.logic_interface import CalculationInput, CalculationParameters
+from batcontrol.logic.next import NextLogic
+
+
+CAPACITY_WH = 10240
+MIN_SOC = 0.10
+MAX_CHARGING_FROM_GRID_LIMIT = 0.89
+MIN_GRID_CHARGE_SOC = 0.55
+CHEAP_PRICE = 0.4635
+EXPENSIVE_PRICE = 0.7018
+
+
+@pytest.fixture(autouse=True)
+def reset_common_logic():
+    """Keep the CommonLogic singleton from leaking settings between cases."""
+    CommonLogic._instance = None
+    yield
+    CommonLogic._instance = None
+
+
+@pytest.mark.parametrize("logic_cls", [DefaultLogic, NextLogic])
+def test_min_grid_charge_soc_preserves_battery_at_start_of_cheap_window(logic_cls):
+    """A fixed target preserves battery instead of discharging through a cheap plateau."""
+    logic = _make_logic(logic_cls)
+    calc_input = _make_input(
+        # Forecast snapshot around 2026-04-28 22:00.
+        production=[0, 0, 0, 0, 0, 0, 0, 129, 570, 1361, 2281, 2579, 2406],
+        consumption=[854, 765, 635, 691, 571, 708, 912, 1208, 1221, 1469, 1237, 1106, 983],
+        prices=[CHEAP_PRICE] * 8 + [EXPENSIVE_PRICE] * 5,
+        soc=34.9,
+    )
+
+    assert logic.calculate(calc_input, datetime.datetime(
+        2026, 4, 28, 22, 0, 0, tzinfo=datetime.timezone.utc))
+    result = logic.get_inverter_control_settings()
+    calc_output = logic.get_calculation_output()
+
+    assert result.allow_discharge is False
+    assert calc_output.reserved_energy == approx(_target_usable_energy())
+
+
+@pytest.mark.parametrize("logic_cls", [DefaultLogic, NextLogic])
+def test_min_grid_charge_soc_charges_at_last_cheap_hour_before_expensive_window(logic_cls):
+    """At the last cheap hour, a fixed target causes grid charging before high prices."""
+    logic = _make_logic(logic_cls)
+    calc_input = _make_input(
+        # Forecast snapshot around 2026-04-29 05:00.
+        production=[128, 541, 1196, 2022, 2615, 2728],
+        consumption=[1208, 1221, 1469, 1237, 1106, 983],
+        prices=[CHEAP_PRICE] + [EXPENSIVE_PRICE] * 5,
+        soc=16.9,
+    )
+
+    assert logic.calculate(calc_input, datetime.datetime(
+        2026, 4, 29, 5, 0, 0, tzinfo=datetime.timezone.utc))
+    result = logic.get_inverter_control_settings()
+    calc_output = logic.get_calculation_output()
+
+    target_recharge_energy = CAPACITY_WH * MIN_GRID_CHARGE_SOC - calc_input.stored_energy
+    assert result.allow_discharge is False
+    assert result.charge_from_grid is True
+    assert result.charge_rate > 0
+    assert calc_output.required_recharge_energy >= target_recharge_energy
+
+
+@pytest.mark.parametrize("logic_cls", [DefaultLogic, NextLogic])
+def test_min_grid_charge_soc_stops_grid_charging_when_gap_is_below_threshold(logic_cls):
+    """When the fixed target is nearly reached, avoid a tiny final grid-charge burst."""
+    logic = _make_logic(logic_cls)
+    calc_input = _make_input(
+        # Similar to 2026-04-29 14:54: target gap was below min_recharge_amount.
+        production=[0, 0],
+        consumption=[1000, 1000],
+        prices=[CHEAP_PRICE, EXPENSIVE_PRICE],
+        soc=54.5,
+    )
+
+    assert logic.calculate(calc_input, datetime.datetime(
+        2026, 4, 29, 14, 54, 0, tzinfo=datetime.timezone.utc))
+    result = logic.get_inverter_control_settings()
+    calc_output = logic.get_calculation_output()
+
+    assert result.allow_discharge is False
+    assert result.charge_from_grid is False
+    assert calc_output.required_recharge_energy == 0.0
+
+
+@pytest.mark.parametrize("logic_cls", [DefaultLogic, NextLogic])
+def test_min_grid_charge_soc_allows_discharge_after_target_when_price_is_high(logic_cls):
+    """After reaching the target, high-price periods can use the preserved battery."""
+    logic = _make_logic(logic_cls)
+    calc_input = _make_input(
+        # Similar to 2026-04-29 15:00 after the battery reached the 55% target.
+        production=[2491, 2118, 1946, 1687, 1234, 664, 179, 0, 0, 0],
+        consumption=[746, 986, 989, 1026, 1361, 1316, 1047, 790, 564, 665],
+        prices=[EXPENSIVE_PRICE] * 7 + [CHEAP_PRICE] * 3,
+        soc=55.1,
+    )
+
+    assert logic.calculate(calc_input, datetime.datetime(
+        2026, 4, 29, 15, 0, 0, tzinfo=datetime.timezone.utc))
+    result = logic.get_inverter_control_settings()
+    calc_output = logic.get_calculation_output()
+
+    assert result.allow_discharge is True
+    assert result.charge_from_grid is False
+    assert calc_output.reserved_energy == 0.0
+
+
+def _make_logic(logic_cls):
+    CommonLogic.get_instance(
+        charge_rate_multiplier=1.1,
+        always_allow_discharge_limit=0.90,
+        max_capacity=CAPACITY_WH,
+        min_charge_energy=100,
+    )
+    logic = logic_cls(timezone=datetime.timezone.utc, interval_minutes=60)
+    logic.set_calculation_parameters(CalculationParameters(
+        max_charging_from_grid_limit=MAX_CHARGING_FROM_GRID_LIMIT,
+        min_price_difference=0.05,
+        min_price_difference_rel=0.10,
+        max_capacity=CAPACITY_WH,
+        min_grid_charge_soc=MIN_GRID_CHARGE_SOC,
+        preserve_min_grid_charge_soc=True,
+        peak_shaving_enabled=False,
+    ))
+    return logic
+
+
+def _make_input(production, consumption, prices, soc):
+    stored_energy = CAPACITY_WH * soc / 100
+    min_soc_energy = CAPACITY_WH * MIN_SOC
+    return CalculationInput(
+        production=np.array(production, dtype=float),
+        consumption=np.array(consumption, dtype=float),
+        prices={slot: price for slot, price in enumerate(prices)},
+        stored_energy=stored_energy,
+        stored_usable_energy=max(0.0, stored_energy - min_soc_energy),
+        free_capacity=CAPACITY_WH - stored_energy,
+    )
+
+
+def _target_usable_energy():
+    return CAPACITY_WH * (MIN_GRID_CHARGE_SOC - MIN_SOC)

--- a/tests/batcontrol/logic/test_peak_shaving.py
+++ b/tests/batcontrol/logic/test_peak_shaving.py
@@ -1073,11 +1073,11 @@ class TestNextLogicGridRechargeLogging(unittest.TestCase):
             peak_shaving_enabled=False,
         ))
 
-    def test_grid_recharge_decision_is_logged(self):
-        """NextLogic logs the shared grid recharge decision summary."""
+    def _make_grid_charge_input(self):
+        """Build an input that triggers grid charging."""
         stored_energy = 2000
         stored_usable_energy = stored_energy - self.max_capacity * 0.05
-        calc_input = CalculationInput(
+        return CalculationInput(
             consumption=np.array([1000, 2000, 1500]),
             production=np.array([0, 0, 0]),
             prices={0: 0.20, 1: 0.35, 2: 0.30},
@@ -1085,6 +1085,10 @@ class TestNextLogicGridRechargeLogging(unittest.TestCase):
             stored_usable_energy=stored_usable_energy,
             free_capacity=self.max_capacity - stored_energy,
         )
+
+    def test_grid_recharge_decision_is_logged(self):
+        """NextLogic logs the shared grid recharge decision summary."""
+        calc_input = self._make_grid_charge_input()
 
         calc_timestamp = datetime.datetime(2025, 6, 20, 12, 30, 0,
                                            tzinfo=datetime.timezone.utc)
@@ -1095,9 +1099,91 @@ class TestNextLogicGridRechargeLogging(unittest.TestCase):
         self.assertTrue(result.charge_from_grid)
         log_output = '\n'.join(logs.output)
         expected_stored_usable_energy = (
-            f'stored_usable_energy={stored_usable_energy:.1f} Wh'
+            f'stored_usable_energy={calc_input.stored_usable_energy:.1f} Wh'
         )
         self.assertIn('[Rule] Grid recharge decision:', log_output)
         self.assertIn('current_price=0.200', log_output)
         self.assertIn(expected_stored_usable_energy, log_output)
         self.assertIn('charge_rate=', log_output)
+
+    def test_min_grid_charge_soc_increases_recharge_energy(self):
+        """NextLogic applies the optional minimum grid-charge SoC target."""
+        self.logic.set_calculation_parameters(CalculationParameters(
+            max_charging_from_grid_limit=0.79,
+            min_price_difference=0.05,
+            min_price_difference_rel=0.2,
+            max_capacity=self.max_capacity,
+            min_grid_charge_soc=0.55,
+            peak_shaving_enabled=False,
+        ))
+        calc_input = self._make_grid_charge_input()
+        calc_timestamp = datetime.datetime(2025, 6, 20, 12, 0, 0,
+                                           tzinfo=datetime.timezone.utc)
+
+        self.assertTrue(self.logic.calculate(calc_input, calc_timestamp))
+        calc_output = self.logic.get_calculation_output()
+
+        self.assertAlmostEqual(calc_output.required_recharge_energy, 3600.0)
+
+    def test_min_grid_charge_soc_blocks_discharge_during_cheap_window(self):
+        """NextLogic expert option preserves battery before expensive demand."""
+        self.logic.set_calculation_parameters(CalculationParameters(
+            max_charging_from_grid_limit=0.79,
+            min_price_difference=0.05,
+            min_price_difference_rel=0.2,
+            max_capacity=self.max_capacity,
+            min_grid_charge_soc=0.55,
+            preserve_min_grid_charge_soc=True,
+            peak_shaving_enabled=False,
+        ))
+        stored_energy = 5000
+        stored_usable_energy = stored_energy - self.max_capacity * 0.05
+        calc_input = CalculationInput(
+            consumption=np.array([1000, 1000, 2000]),
+            production=np.array([0, 0, 0]),
+            prices={0: 0.10, 1: 0.11, 2: 0.30},
+            stored_energy=stored_energy,
+            stored_usable_energy=stored_usable_energy,
+            free_capacity=self.max_capacity - stored_energy,
+        )
+        calc_timestamp = datetime.datetime(2025, 6, 20, 22, 0, 0,
+                                           tzinfo=datetime.timezone.utc)
+
+        self.assertTrue(self.logic.calculate(calc_input, calc_timestamp))
+        result = self.logic.get_inverter_control_settings()
+        calc_output = self.logic.get_calculation_output()
+
+        self.assertFalse(result.allow_discharge)
+        self.assertTrue(result.charge_from_grid)
+        self.assertGreater(calc_output.required_recharge_energy, 0)
+        self.assertGreater(calc_output.reserved_energy, 2000)
+
+    def test_min_grid_charge_soc_does_not_block_discharge_at_high_price(self):
+        """NextLogic does not preserve battery when current price is high."""
+        self.logic.set_calculation_parameters(CalculationParameters(
+            max_charging_from_grid_limit=0.79,
+            min_price_difference=0.05,
+            min_price_difference_rel=0.2,
+            max_capacity=self.max_capacity,
+            min_grid_charge_soc=0.55,
+            preserve_min_grid_charge_soc=True,
+            peak_shaving_enabled=False,
+        ))
+        stored_energy = 5000
+        stored_usable_energy = stored_energy - self.max_capacity * 0.05
+        calc_input = CalculationInput(
+            consumption=np.array([1000, 1000, 2000]),
+            production=np.array([0, 0, 0]),
+            prices={0: 0.30, 1: 0.10, 2: 0.10},
+            stored_energy=stored_energy,
+            stored_usable_energy=stored_usable_energy,
+            free_capacity=self.max_capacity - stored_energy,
+        )
+        calc_timestamp = datetime.datetime(2025, 6, 20, 6, 0, 0,
+                                           tzinfo=datetime.timezone.utc)
+
+        self.assertTrue(self.logic.calculate(calc_input, calc_timestamp))
+        result = self.logic.get_inverter_control_settings()
+
+        self.assertTrue(result.allow_discharge)
+        self.assertFalse(result.charge_from_grid)

--- a/tests/batcontrol/test_core.py
+++ b/tests/batcontrol/test_core.py
@@ -1,5 +1,6 @@
 """Tests for core batcontrol functionality including MODE_LIMIT_BATTERY_CHARGE_RATE"""
 import datetime
+import logging
 import pytest
 from unittest.mock import MagicMock, call, patch
 
@@ -460,6 +461,103 @@ class TestCoreRunDispatch:
 
         bc.shutdown()
 
+    def _patch_core_dependencies(self, mocker):
+        core_module = "batcontrol.core"
+        mock_inverter = mocker.MagicMock()
+        mock_inverter.max_pv_charge_rate = 3000
+        mock_inverter.get_max_capacity.return_value = 10000
+        mocker.patch(
+            f"{core_module}.tariff_factory.create_tarif_provider",
+            autospec=True,
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            f"{core_module}.inverter_factory.create_inverter",
+            autospec=True,
+            return_value=mock_inverter,
+        )
+        mocker.patch(
+            f"{core_module}.solar_factory.create_solar_provider",
+            autospec=True,
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            f"{core_module}.consumption_factory.create_consumption",
+            autospec=True,
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            f"{core_module}.LogicFactory.create_logic",
+            autospec=True,
+            return_value=mocker.MagicMock(),
+        )
+
+    def test_accepts_min_grid_charge_soc_numeric_string_config(
+            self, mock_config, mocker):
+        mock_config['battery_control']['min_grid_charge_soc'] = '0.55'
+        self._patch_core_dependencies(mocker)
+
+        bc = Batcontrol(mock_config)
+
+        assert bc.min_grid_charge_soc == 0.55
+        bc.shutdown()
+
+    def test_rejects_invalid_min_grid_charge_soc_config(
+            self, mock_config, mocker):
+        mock_config['battery_control']['min_grid_charge_soc'] = 'fifty-five'
+        self._patch_core_dependencies(mocker)
+
+        with pytest.raises(
+                ValueError,
+                match='battery_control.min_grid_charge_soc must be numeric'):
+            Batcontrol(mock_config)
+
+    def test_warns_when_min_grid_charge_soc_exceeds_grid_charge_limit(
+            self, mock_config, mocker, caplog):
+        core_module = "batcontrol.core"
+        mock_config['battery_control']['min_grid_charge_soc'] = 0.85
+        caplog.set_level(logging.WARNING, logger=core_module)
+
+        mock_inverter = mocker.MagicMock()
+        mock_inverter.max_pv_charge_rate = 3000
+        mock_inverter.get_max_capacity.return_value = 10000
+        mocker.patch(
+            f"{core_module}.tariff_factory.create_tarif_provider",
+            autospec=True,
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            f"{core_module}.inverter_factory.create_inverter",
+            autospec=True,
+            return_value=mock_inverter,
+        )
+        mocker.patch(
+            f"{core_module}.solar_factory.create_solar_provider",
+            autospec=True,
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            f"{core_module}.consumption_factory.create_consumption",
+            autospec=True,
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            f"{core_module}.LogicFactory.create_logic",
+            autospec=True,
+            return_value=mocker.MagicMock(),
+        )
+
+        bc = Batcontrol(mock_config)
+
+        assert bc.min_grid_charge_soc == 0.85
+        assert any(
+            'min_grid_charge_soc' in record.message
+            and 'max_charging_from_grid_limit' in record.message
+            and 'grid charging cannot reach' in record.message
+            for record in caplog.records
+        )
+        bc.shutdown()
+
     def test_run_dispatches_allow_discharge(self, run_dispatch_setup):
         bc, mock_inverter, fake_logic = run_dispatch_setup
         fake_logic.get_inverter_control_settings.return_value = MagicMock(
@@ -475,6 +573,22 @@ class TestCoreRunDispatch:
         mock_inverter.set_mode_force_charge.assert_not_called()
         mock_inverter.set_mode_avoid_discharge.assert_not_called()
         mock_inverter.set_mode_limit_battery_charge.assert_not_called()
+
+    def test_run_passes_preserve_min_grid_charge_soc_to_logic(
+            self, run_dispatch_setup):
+        bc, _mock_inverter, fake_logic = run_dispatch_setup
+        bc.preserve_min_grid_charge_soc = True
+        fake_logic.get_inverter_control_settings.return_value = MagicMock(
+            allow_discharge=True,
+            charge_from_grid=False,
+            charge_rate=0,
+            limit_battery_charge_rate=-1,
+        )
+
+        bc.run()
+
+        calc_params = fake_logic.set_calculation_parameters.call_args.args[0]
+        assert calc_params.preserve_min_grid_charge_soc is True
 
     def test_run_dispatches_force_charge(self, run_dispatch_setup):
         bc, mock_inverter, fake_logic = run_dispatch_setup
@@ -737,6 +851,26 @@ class TestApiOverrideMqttState:
         bc.mqtt_api.publish_charge_rate.assert_called_once_with(1200)
         bc.mqtt_api.publish_limit_battery_charge_rate.assert_called_once_with(1800)
         bc.mqtt_api.publish_api_override_active.assert_called_once_with(True)
+
+    def test_refresh_static_values_publishes_min_grid_charge_soc_when_set(
+            self, run_dispatch_setup):
+        bc, _mock_inverter, _fake_logic = run_dispatch_setup
+        bc.mqtt_api = MagicMock()
+        bc.min_grid_charge_soc = 0.55
+
+        bc.refresh_static_values()
+
+        bc.mqtt_api.publish_min_grid_charge_soc.assert_called_once_with(0.55)
+
+    def test_refresh_static_values_skips_min_grid_charge_soc_when_unset(
+            self, run_dispatch_setup):
+        bc, _mock_inverter, _fake_logic = run_dispatch_setup
+        bc.mqtt_api = MagicMock()
+        bc.min_grid_charge_soc = None
+
+        bc.refresh_static_values()
+
+        bc.mqtt_api.publish_min_grid_charge_soc.assert_not_called()
 
     def test_refresh_static_values_skips_unknown_mode(self, run_dispatch_setup):
         bc, _mock_inverter, _fake_logic = run_dispatch_setup

--- a/tests/batcontrol/test_mqtt_api.py
+++ b/tests/batcontrol/test_mqtt_api.py
@@ -55,6 +55,9 @@ def _make_publish_stub():
     api.publish_control_source = (
         MqttApi.publish_control_source.__get__(api, MqttApi)
     )
+    api.publish_min_grid_charge_soc = (
+        MqttApi.publish_min_grid_charge_soc.__get__(api, MqttApi)
+    )
     return api
 
 
@@ -164,6 +167,16 @@ class TestPublishedState:
             'true',
         )
 
+    def test_publish_min_grid_charge_soc_publishes_ratio_and_percent(self):
+        api = _make_publish_stub()
+
+        api.publish_min_grid_charge_soc(0.55)
+
+        assert api.client.publish.call_args_list == [
+            call('batcontrol/min_grid_charge_soc_percent', '55'),
+            call('batcontrol/min_grid_charge_soc', '0.55'),
+        ]
+
 
 class TestModeDiscovery:
     """Mode discovery should expose the full externally supported mode model."""
@@ -257,6 +270,24 @@ class TestDiscoveryMessages:
                 'sensor',
             )
             and call.args[5] == 'batcontrol/control_source'
+            and call.kwargs['entity_category'] == 'diagnostic'
+            for call in api.publish_mqtt_discovery_message.call_args_list
+        )
+
+    def test_discovery_includes_min_grid_charge_soc_sensor(self):
+        api = _make_discovery_stub()
+
+        api.send_mqtt_discovery_messages()
+
+        assert any(
+            call.args[:3] == (
+                'Minimum Grid Charge SOC',
+                'batcontrol_min_grid_charge_soc',
+                'sensor',
+            )
+            and call.args[3] == 'battery'
+            and call.args[4] == '%'
+            and call.args[5] == 'batcontrol/min_grid_charge_soc_percent'
             and call.kwargs['entity_category'] == 'diagnostic'
             for call in api.publish_mqtt_discovery_message.call_args_list
         )


### PR DESCRIPTION
Add optional `battery_control.min_grid_charge_soc` as a ratio target, e.g. `0.55`.

When set, batcontrol grid-charges toward that target when charging is economical. When unset, behavior is unchanged.

An expert option, `battery_control_expert.preserve_min_grid_charge_soc`, can additionally preserve that target as reserved energy during cheap/pre-expensive windows.

Applies to both `DefaultLogic` and `NextLogic`.