### PR TITLE
logic: nest peak shaving config in calculation parameters

### DIFF
--- a/docs/WIKI_peak_shaving.md
+++ b/docs/WIKI_peak_shaving.md
@@ -160,7 +160,7 @@ The following HA entities are automatically created:
 
 - **Peak Shaving Enabled** - switch entity
 - **Peak Shaving Allow Full After** - number entity (0-23, step 1)
-- **Peak Shaving Price Limit** - number entity (-1.0..1.0, step 0.01); this is the HA auto-discovery slider range, not a hard application limit. `peak_shaving.price_limit` itself accepts any numeric EUR/kWh value via the YAML config or the MQTT setter topic.
+- **Peak Shaving Price Limit** - number entity (-1.0..1.0 EUR/kWh, step 0.01); this is the HA auto-discovery slider range, not a hard application limit. `peak_shaving.price_limit` itself accepts any numeric EUR/kWh value via the YAML config or the MQTT setter topic. The slider range is intentionally tight: the field is a *cheap-slot* threshold, so values approaching 1 EUR/kWh are already an unusually high cutoff in practice — values above that are accepted, but rarely meaningful for peak shaving.
 - **Peak Shaving Mode** - select entity (`time` / `price` / `combined`)
 - **Peak Shaving Charge Limit** - sensor entity (unit: W)
 

--- a/docs/WIKI_peak_shaving.md
+++ b/docs/WIKI_peak_shaving.md
@@ -160,7 +160,7 @@ The following HA entities are automatically created:
 
 - **Peak Shaving Enabled** - switch entity
 - **Peak Shaving Allow Full After** - number entity (0-23, step 1)
-- **Peak Shaving Price Limit** - number entity (-1.0..1.0, step 0.01)
+- **Peak Shaving Price Limit** - number entity (-1.0..1.0, step 0.01); this is the HA auto-discovery slider range, not a hard application limit. `peak_shaving.price_limit` itself accepts any numeric EUR/kWh value via the YAML config or the MQTT setter topic.
 - **Peak Shaving Mode** - select entity (`time` / `price` / `combined`)
 - **Peak Shaving Charge Limit** - sensor entity (unit: W)
 

--- a/docs/WIKI_peak_shaving.md
+++ b/docs/WIKI_peak_shaving.md
@@ -139,6 +139,8 @@ The evcc integration derives `mode` and `connected` topics automatically from th
 |-------|------|----------|-------------|
 | `{base}/peak_shaving/enabled` | bool | Yes | Peak shaving enabled status |
 | `{base}/peak_shaving/allow_full_battery_after` | int | Yes | Target hour (0-23) |
+| `{base}/peak_shaving/price_limit` | float | Yes | Cheap-slot price limit in EUR/kWh; `-1` published when unset |
+| `{base}/peak_shaving/mode` | string | Yes | Active operating mode (`time` / `price` / `combined`) |
 | `{base}/peak_shaving/charge_limit` | int | No | Current charge limit in W (-1 if inactive) |
 
 ### Settable Topics
@@ -147,10 +149,10 @@ The evcc integration derives `mode` and `connected` topics automatically from th
 |-------|---------|-------------|
 | `{base}/peak_shaving/enabled/set` | `true`/`false` | Enable/disable peak shaving |
 | `{base}/peak_shaving/allow_full_battery_after/set` | int 0-23 | Set target hour |
+| `{base}/peak_shaving/price_limit/set` | float | Cheap-slot price limit in EUR/kWh; send `-1` to disable the price component (no slot price <= -1 ever exists) |
+| `{base}/peak_shaving/mode/set` | `time` / `price` / `combined` | Switch operating mode at runtime |
 
-Note: `mode` and `price_limit` are **not** settable at runtime via MQTT.
-Changing either requires editing `batcontrol_config.yaml` and restarting
-batcontrol. See "Known Limitations" below.
+Runtime changes are temporary and not persisted to `batcontrol_config.yaml`.
 
 ### Home Assistant Auto-Discovery
 
@@ -158,6 +160,8 @@ The following HA entities are automatically created:
 
 - **Peak Shaving Enabled** - switch entity
 - **Peak Shaving Allow Full After** - number entity (0-23, step 1)
+- **Peak Shaving Price Limit** - number entity (-1.0..1.0, step 0.01)
+- **Peak Shaving Mode** - select entity (`time` / `price` / `combined`)
 - **Peak Shaving Charge Limit** - sensor entity (unit: W)
 
 ## Known Limitations
@@ -166,6 +170,6 @@ The following HA entities are automatically created:
 
 2. **Code duplication:** `NextLogic` is a copy of `DefaultLogic` with peak shaving added. Once stable, the two could be merged or refactored.
 
-3. **Partial MQTT runtime control:** Only `enabled` and `allow_full_battery_after` can be changed at runtime via MQTT. `mode` and `price_limit` are read from the configuration file once at startup and require a restart to change. If you need to toggle the price component on-the-fly, set `price_limit: -1` in the config so no slots qualify as cheap; the time component continues to work (in `combined` mode) without further changes.
+3. **Persistence:** Runtime changes via MQTT (`enabled`, `allow_full_battery_after`, `price_limit`, `mode`) are not written back to `batcontrol_config.yaml`. After a restart the values from the configuration file take effect again.
 
 4. **`combined` mode without `price_limit`:** When `mode: combined` is configured but `price_limit` is omitted (or `null`), the price component is skipped and the logic falls back to time-only behaviour. A warning is logged so the fallback is visible. To use the price component, set a numeric `price_limit`; to disable peak shaving entirely, set `enabled: false`.

--- a/scripts/simulate_peak_shaving_day.py
+++ b/scripts/simulate_peak_shaving_day.py
@@ -30,6 +30,7 @@ from batcontrol.logic.logic_interface import (
     CalculationInput,
     CalculationParameters,
     InverterControlSettings,
+    PeakShavingConfig,
 )
 from batcontrol.logic.common import CommonLogic
 
@@ -179,9 +180,11 @@ params_shaving = CalculationParameters(
     min_price_difference=0.05,
     min_price_difference_rel=0.2,
     max_capacity=MAX_CAPACITY,
-    peak_shaving_enabled=True,
-    peak_shaving_allow_full_after=TARGET_HOUR,
-    peak_shaving_mode='time',   # pure time-based ramp
+    peak_shaving=PeakShavingConfig(
+        enabled=True,
+        allow_full_battery_after=TARGET_HOUR,
+        mode='time',  # pure time-based ramp
+    ),
 )
 
 # ---------------------------------------------------------------------------
@@ -336,9 +339,11 @@ def run_scenario(target_hour: int, initial_soc_wh: float) -> dict:
         min_price_difference=0.05,
         min_price_difference_rel=0.2,
         max_capacity=MAX_CAPACITY,
-        peak_shaving_enabled=True,
-        peak_shaving_allow_full_after=target_hour,
-        peak_shaving_mode='time',
+        peak_shaving=PeakShavingConfig(
+            enabled=True,
+            allow_full_battery_after=target_hour,
+            mode='time',
+        ),
     )
     logic = NextLogic(timezone=TZ, interval_minutes=INTERVAL_MIN)
     logic.set_calculation_parameters(params)

--- a/scripts/simulate_peak_shaving_price.py
+++ b/scripts/simulate_peak_shaving_price.py
@@ -31,6 +31,7 @@ from batcontrol.logic.next import NextLogic
 from batcontrol.logic.logic_interface import (
     CalculationInput,
     CalculationParameters,
+    PeakShavingConfig,
 )
 from batcontrol.logic.common import CommonLogic
 
@@ -153,10 +154,12 @@ params_price = CalculationParameters(
     min_price_difference=0.05,
     min_price_difference_rel=0.2,
     max_capacity=MAX_CAPACITY,
-    peak_shaving_enabled=True,
-    peak_shaving_allow_full_after=ALLOW_FULL_AFTER,
-    peak_shaving_mode='price',
-    peak_shaving_price_limit=PRICE_LIMIT,
+    peak_shaving=PeakShavingConfig(
+        enabled=True,
+        allow_full_battery_after=ALLOW_FULL_AFTER,
+        mode='price',
+        price_limit=PRICE_LIMIT,
+    ),
 )
 
 # ---------------------------------------------------------------------------

--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -1129,8 +1129,11 @@ class Batcontrol:
         """ Set peak shaving price limit via external API request.
             The change is temporary and will not be written to the config file.
 
-            Negative values are accepted and effectively disable the
-            price-based component (no slot price <= -1 ever exists).
+            Any numeric value is accepted. To disable the price-based
+            component, pass -1 (or any value <= -1): no slot price <= -1
+            ever exists, so the price filter never matches. Values above -1
+            (including small negatives like -0.1) may still match negative
+            tariff slots and are NOT a disable-switch.
         """
         if isinstance(price_limit, bool):
             # bool would silently coerce to 1.0/0.0 via float(); reject it

--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -1132,6 +1132,13 @@ class Batcontrol:
             Negative values are accepted and effectively disable the
             price-based component (no slot price <= -1 ever exists).
         """
+        if isinstance(price_limit, bool):
+            # bool would silently coerce to 1.0/0.0 via float(); reject it
+            # so PeakShavingConfig's bool rejection still applies on this path.
+            logger.warning(
+                'API: Invalid peak_shaving price_limit %r: must be numeric, '
+                'not bool', price_limit)
+            return
         try:
             new_config = dataclasses.replace(
                 self.peak_shaving_config, price_limit=float(price_limit))

--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -16,7 +16,7 @@ import os
 import logging
 import platform
 
-from dataclasses import dataclass
+import dataclasses
 from typing import Optional
 
 import pytz
@@ -29,7 +29,7 @@ from .scheduler import SchedulerThread
 from .logic import Logic as LogicFactory
 from .logic import CalculationInput, CalculationParameters
 from .logic import CommonLogic
-from .logic import PEAK_SHAVING_VALID_MODES
+from .logic import PeakShavingConfig
 
 from .dynamictariff import DynamicTariff as tariff_factory
 from .inverter import Inverter as inverter_factory
@@ -78,75 +78,6 @@ def _parse_optional_ratio(value, config_key: str) -> Optional[float]:
             f"{config_key} must be between 0 and 1 or None, got {value!r}"
         )
     return ratio
-
-
-@dataclass
-class PeakShavingConfig:
-    """ Holds peak shaving configuration parameters, initialized from the config dict. """
-    enabled: bool = False
-    mode: str = 'combined'
-    allow_full_battery_after: int = 14
-    price_limit: Optional[float] = None
-
-    def __post_init__(self):
-        """Validate configuration values and raise ValueError with a clear,
-        config-key-based message on invalid input. Also emit a one-time
-        warning for the ``combined`` + missing ``price_limit`` fallback,
-        so the log message fires at config load (not every evaluation)."""
-        if self.mode not in PEAK_SHAVING_VALID_MODES:
-            raise ValueError(
-                f"peak_shaving.mode must be one of "
-                f"{PEAK_SHAVING_VALID_MODES}, got '{self.mode}'"
-            )
-        if not isinstance(self.allow_full_battery_after, int) \
-                or isinstance(self.allow_full_battery_after, bool):
-            raise ValueError(
-                f"peak_shaving.allow_full_battery_after must be an integer, "
-                f"got {type(self.allow_full_battery_after).__name__}"
-            )
-        if not 0 <= self.allow_full_battery_after <= 23:
-            raise ValueError(
-                f"peak_shaving.allow_full_battery_after must be between "
-                f"0 and 23, got {self.allow_full_battery_after}"
-            )
-        if self.price_limit is not None and (
-                isinstance(self.price_limit, bool)
-                or not isinstance(self.price_limit, (int, float))):
-            raise ValueError(
-                f"peak_shaving.price_limit must be numeric or None, "
-                f"got {type(self.price_limit).__name__}"
-            )
-        if self.enabled and self.mode == 'combined' and self.price_limit is None:
-            logger.warning(
-                "peak_shaving.mode='combined' but no peak_shaving.price_limit "
-                "configured: the price component is disabled; falling back "
-                "to time-only behaviour. Set a numeric price_limit or change "
-                "mode to 'time' to silence this warning."
-            )
-
-    @classmethod
-    def from_config(cls, config: dict) -> 'PeakShavingConfig':
-        """ Create a PeakShavingConfig instance from a configuration dict. """
-        ps = config.get('peak_shaving', {})
-        price_limit_raw = ps.get('price_limit', None)
-        if price_limit_raw is None or isinstance(price_limit_raw, bool):
-            # ``None`` stays ``None``; bool is rejected by __post_init__ with a
-            # key-prefixed message. Skip float() so we do not lose the type info.
-            price_limit = price_limit_raw
-        else:
-            try:
-                price_limit = float(price_limit_raw)
-            except (TypeError, ValueError) as exc:
-                raise ValueError(
-                    f"peak_shaving.price_limit must be numeric or None, "
-                    f"got {price_limit_raw!r}"
-                ) from exc
-        return cls(
-            enabled=ps.get('enabled', False),
-            mode=ps.get('mode', 'combined'),
-            allow_full_battery_after=ps.get('allow_full_battery_after', 14),
-            price_limit=price_limit,
-        )
 
 
 class Batcontrol:
@@ -669,6 +600,12 @@ class Batcontrol:
             # Reset tracking flag when peak shaving is disabled in config.
             self._evcc_peak_shaving_disabled = False
 
+        # evcc may force peak shaving off for a single cycle; the underlying
+        # peak_shaving_config is left untouched.
+        ps_runtime = dataclasses.replace(
+            self.peak_shaving_config,
+            enabled=peak_shaving_config_enabled and not evcc_disable_peak_shaving,
+        )
         calc_parameters = CalculationParameters(
             self.max_charging_from_grid_limit,
             self.min_price_difference,
@@ -676,10 +613,7 @@ class Batcontrol:
             self.get_max_capacity(),
             min_grid_charge_soc=self.min_grid_charge_soc,
             preserve_min_grid_charge_soc=self.preserve_min_grid_charge_soc,
-            peak_shaving_enabled=peak_shaving_config_enabled and not evcc_disable_peak_shaving,
-            peak_shaving_allow_full_after=self.peak_shaving_config.allow_full_battery_after,
-            peak_shaving_mode=self.peak_shaving_config.mode,
-            peak_shaving_price_limit=self.peak_shaving_config.price_limit,
+            peak_shaving=ps_runtime,
         )
 
         self.last_logic_instance = this_logic_run

--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -332,6 +332,16 @@ class Batcontrol:
                     self.api_set_peak_shaving_allow_full_after,
                     int
                 )
+                self.mqtt_api.register_set_callback(
+                    'peak_shaving/price_limit',
+                    self.api_set_peak_shaving_price_limit,
+                    float
+                )
+                self.mqtt_api.register_set_callback(
+                    'peak_shaving/mode',
+                    self.api_set_peak_shaving_mode,
+                    str
+                )
                 # Inverter Callbacks
                 self.inverter.activate_mqtt(self.mqtt_api)
 
@@ -933,6 +943,10 @@ class Batcontrol:
                 self.peak_shaving_config.enabled)
             self.mqtt_api.publish_peak_shaving_allow_full_after(
                 self.peak_shaving_config.allow_full_battery_after)
+            self.mqtt_api.publish_peak_shaving_price_limit(
+                self.peak_shaving_config.price_limit)
+            self.mqtt_api.publish_peak_shaving_mode(
+                self.peak_shaving_config.mode)
             # Trigger Inverter
             self.inverter.refresh_api_values()
 
@@ -1110,3 +1124,43 @@ class Batcontrol:
         self.peak_shaving_config.allow_full_battery_after = hour
         if self.mqtt_api is not None:
             self.mqtt_api.publish_peak_shaving_allow_full_after(hour)
+
+    def api_set_peak_shaving_price_limit(self, price_limit: float):
+        """ Set peak shaving price limit via external API request.
+            The change is temporary and will not be written to the config file.
+
+            Negative values are accepted and effectively disable the
+            price-based component (no slot price <= -1 ever exists).
+        """
+        try:
+            new_config = dataclasses.replace(
+                self.peak_shaving_config, price_limit=float(price_limit))
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                'API: Invalid peak_shaving price_limit %r: %s',
+                price_limit, exc)
+            return
+        logger.info(
+            'API: Setting peak shaving price_limit to %s',
+            new_config.price_limit)
+        self.peak_shaving_config = new_config
+        if self.mqtt_api is not None:
+            self.mqtt_api.publish_peak_shaving_price_limit(
+                new_config.price_limit)
+
+    def api_set_peak_shaving_mode(self, mode: str):
+        """ Set peak shaving operating mode via external API request.
+            The change is temporary and will not be written to the config file.
+        """
+        normalized = (mode or '').strip().lower()
+        try:
+            new_config = dataclasses.replace(
+                self.peak_shaving_config, mode=normalized)
+        except ValueError as exc:
+            logger.warning(
+                'API: Invalid peak_shaving mode %r: %s', mode, exc)
+            return
+        logger.info('API: Setting peak shaving mode to %s', new_config.mode)
+        self.peak_shaving_config = new_config
+        if self.mqtt_api is not None:
+            self.mqtt_api.publish_peak_shaving_mode(new_config.mode)

--- a/src/batcontrol/logic/__init__.py
+++ b/src/batcontrol/logic/__init__.py
@@ -5,6 +5,7 @@ from .logic_interface import (
     CalculationInput,
     CalculationOutput,
     InverterControlSettings,
+    PeakShavingConfig,
     PEAK_SHAVING_VALID_MODES,
 )
 from .common import CommonLogic

--- a/src/batcontrol/logic/logic_interface.py
+++ b/src/batcontrol/logic/logic_interface.py
@@ -1,13 +1,95 @@
+import logging
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 import datetime
 import numpy as np
 
-# Shared tuple of valid peak-shaving operating modes. Defined here so that
-# both CalculationParameters (this module) and PeakShavingConfig
-# (batcontrol.core) can reference a single source of truth.
+logger = logging.getLogger(__name__)
+
+# Shared tuple of valid peak-shaving operating modes.
 PEAK_SHAVING_VALID_MODES = ('time', 'price', 'combined')
+
+
+@dataclass
+class PeakShavingConfig:
+    """ Holds peak shaving configuration parameters, initialized from the config dict.
+
+    Range/type validation runs in ``__post_init__``. The "combined mode without
+    price_limit" fallback warning is emitted in :py:meth:`from_config` only,
+    so it fires once at config load and not on every ``dataclasses.replace``
+    in the per-evaluation build path.
+    """
+    enabled: bool = False
+    mode: str = 'combined'
+    allow_full_battery_after: int = 14
+    price_limit: Optional[float] = None
+
+    def __post_init__(self):
+        """Validate configuration values and raise ValueError with a clear,
+        config-key-based message on invalid input."""
+        if self.mode not in PEAK_SHAVING_VALID_MODES:
+            raise ValueError(
+                f"peak_shaving.mode must be one of "
+                f"{PEAK_SHAVING_VALID_MODES}, got '{self.mode}'"
+            )
+        if not isinstance(self.allow_full_battery_after, int) \
+                or isinstance(self.allow_full_battery_after, bool):
+            raise ValueError(
+                f"peak_shaving.allow_full_battery_after must be an integer, "
+                f"got {type(self.allow_full_battery_after).__name__}"
+            )
+        if not 0 <= self.allow_full_battery_after <= 23:
+            raise ValueError(
+                f"peak_shaving.allow_full_battery_after must be between "
+                f"0 and 23, got {self.allow_full_battery_after}"
+            )
+        if self.price_limit is not None and (
+                isinstance(self.price_limit, bool)
+                or not isinstance(self.price_limit, (int, float))):
+            raise ValueError(
+                f"peak_shaving.price_limit must be numeric or None, "
+                f"got {type(self.price_limit).__name__}"
+            )
+
+    @classmethod
+    def from_config(cls, config: dict) -> 'PeakShavingConfig':
+        """ Create a PeakShavingConfig instance from a configuration dict.
+
+        Emits a one-time warning when peak shaving is enabled in 'combined'
+        mode without a configured ``price_limit``: the price component is
+        disabled in that case and behaviour falls back to time-only.
+        """
+        ps = config.get('peak_shaving', {})
+        price_limit_raw = ps.get('price_limit', None)
+        if price_limit_raw is None or isinstance(price_limit_raw, bool):
+            # ``None`` stays ``None``; bool is rejected by __post_init__ with a
+            # key-prefixed message. Skip float() so we do not lose the type info.
+            price_limit = price_limit_raw
+        else:
+            try:
+                price_limit = float(price_limit_raw)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"peak_shaving.price_limit must be numeric or None, "
+                    f"got {price_limit_raw!r}"
+                ) from exc
+        instance = cls(
+            enabled=ps.get('enabled', False),
+            mode=ps.get('mode', 'combined'),
+            allow_full_battery_after=ps.get('allow_full_battery_after', 14),
+            price_limit=price_limit,
+        )
+        if instance.enabled and instance.mode == 'combined' \
+                and instance.price_limit is None:
+            logger.warning(
+                "peak_shaving.mode='combined' but no peak_shaving.price_limit "
+                "configured: the price component is disabled; falling back "
+                "to time-only behaviour. Set a numeric price_limit or change "
+                "mode to 'time' to silence this warning."
+            )
+        return instance
+
 
 @dataclass
 class CalculationInput:
@@ -32,18 +114,9 @@ class CalculationParameters:
     # Expert option: also preserve the target as reserved energy during
     # cheap/pre-expensive windows.
     preserve_min_grid_charge_soc: bool = False
-    # Peak shaving parameters
-    peak_shaving_enabled: bool = False
-    peak_shaving_allow_full_after: int = 14  # Hour (0-23)
-    # Operating mode:
-    #   'time'     - limit by target hour only (allow_full_battery_after)
-    #   'price'    - limit by cheap-slot reservation only (price_limit required)
-    #   'combined' - both limits active, stricter one wins
-    peak_shaving_mode: str = 'combined'
-    # Slots where price (Euro/kWh) is at or below this value are treated as
-    # cheap PV windows.  -1 or any numeric value accepted; None disables
-    # price-based component.
-    peak_shaving_price_limit: Optional[float] = None
+    # Peak shaving sub-configuration. evcc may set ``enabled=False`` for a
+    # single calculation cycle via ``dataclasses.replace`` in core.py.
+    peak_shaving: PeakShavingConfig = field(default_factory=PeakShavingConfig)
 
     def __post_init__(self):
         if self.min_grid_charge_soc is not None:
@@ -58,23 +131,6 @@ class CalculationParameters:
                     f"min_grid_charge_soc must be between 0 and 1 or None, "
                     f"got {self.min_grid_charge_soc}"
                 )
-        if not 0 <= self.peak_shaving_allow_full_after <= 23:
-            raise ValueError(
-                f"peak_shaving_allow_full_after must be 0-23, "
-                f"got {self.peak_shaving_allow_full_after}"
-            )
-        if self.peak_shaving_mode not in PEAK_SHAVING_VALID_MODES:
-            raise ValueError(
-                f"peak_shaving_mode must be one of "
-                f"{PEAK_SHAVING_VALID_MODES}, "
-                f"got '{self.peak_shaving_mode}'"
-            )
-        if (self.peak_shaving_price_limit is not None
-                and not isinstance(self.peak_shaving_price_limit, (int, float))):
-            raise ValueError(
-                f"peak_shaving_price_limit must be numeric or None, "
-                f"got {type(self.peak_shaving_price_limit).__name__}"
-            )
 
 @dataclass
 class CalculationOutput:

--- a/src/batcontrol/logic/next.py
+++ b/src/batcontrol/logic/next.py
@@ -210,7 +210,7 @@ class NextLogic(LogicInterface):
                 inverter_control_settings.allow_discharge = False
 
         # ----- Peak Shaving Post-Processing ----- #
-        if self.calculation_parameters.peak_shaving_enabled:
+        if self.calculation_parameters.peak_shaving.enabled:
             inverter_control_settings = self._apply_peak_shaving(
                 inverter_control_settings, calc_input, calc_timestamp)
 
@@ -226,7 +226,7 @@ class NextLogic(LogicInterface):
                             ) -> InverterControlSettings:
         """Limit PV charge rate based on the configured peak shaving mode.
 
-        Mode behaviour (peak_shaving_mode):
+        Mode behaviour (peak_shaving.mode):
           'time'     - spread remaining capacity until allow_full_battery_after
           'price'    - reserve capacity for upcoming cheap-price PV slots;
                        inside cheap window, spread if surplus > free capacity
@@ -246,8 +246,8 @@ class NextLogic(LogicInterface):
         Note: evcc checks (charging, connected+pv mode) are handled in
               core.py, not here.
         """
-        mode = self.calculation_parameters.peak_shaving_mode
-        price_limit = self.calculation_parameters.peak_shaving_price_limit
+        mode = self.calculation_parameters.peak_shaving.mode
+        price_limit = self.calculation_parameters.peak_shaving.price_limit
 
         # Price component needs price_limit configured.
         # For 'price' mode: skip entirely (no other component to fall back to).
@@ -269,7 +269,7 @@ class NextLogic(LogicInterface):
             return settings
 
         # Past target hour: skip (applies to all modes)
-        if calc_timestamp.hour >= self.calculation_parameters.peak_shaving_allow_full_after:
+        if calc_timestamp.hour >= self.calculation_parameters.peak_shaving.allow_full_battery_after:
             return settings
 
         # In always_allow_discharge region: skip
@@ -325,7 +325,7 @@ class NextLogic(LogicInterface):
                     mode, settings.limit_battery_charge_rate,
                     price_limit_w if price_limit_w >= 0 else 'off',
                     time_limit_w if time_limit_w >= 0 else 'off',
-                    self.calculation_parameters.peak_shaving_allow_full_after)
+                    self.calculation_parameters.peak_shaving.allow_full_battery_after)
 
         return settings
 
@@ -353,7 +353,7 @@ class NextLogic(LogicInterface):
         Returns:
             int: charge rate limit in W, or -1 if no limit needed.
         """
-        price_limit = self.calculation_parameters.peak_shaving_price_limit
+        price_limit = self.calculation_parameters.peak_shaving.price_limit
         prices = calc_input.prices
         interval_hours = self.interval_minutes / 60.0
 
@@ -453,7 +453,7 @@ class NextLogic(LogicInterface):
             second=0, microsecond=0
         )
         target_time = calc_timestamp.replace(
-            hour=self.calculation_parameters.peak_shaving_allow_full_after,
+            hour=self.calculation_parameters.peak_shaving.allow_full_battery_after,
             minute=0, second=0, microsecond=0
         )
 

--- a/src/batcontrol/mqtt_api.py
+++ b/src/batcontrol/mqtt_api.py
@@ -537,6 +537,34 @@ class MqttApi:
                 str(charge_limit)
             )
 
+    def publish_peak_shaving_price_limit(self, price_limit) -> None:
+        """ Publish peak shaving price limit to MQTT
+            /peak_shaving/price_limit
+
+            Maps an unset (``None``) limit to ``-1`` so the value remains
+            roundtrip-safe with the Home Assistant ``number`` entity, which
+            cannot represent ``None``. Any slot price <= -1 is impossible,
+            so -1 is a natural off-value.
+        """
+        if self.client.is_connected():
+            value = -1.0 if price_limit is None else float(price_limit)
+            self.client.publish(
+                self.base_topic + '/peak_shaving/price_limit',
+                str(value),
+                retain=True
+            )
+
+    def publish_peak_shaving_mode(self, mode: str) -> None:
+        """ Publish peak shaving mode to MQTT
+            /peak_shaving/mode
+        """
+        if self.client.is_connected():
+            self.client.publish(
+                self.base_topic + '/peak_shaving/mode',
+                str(mode),
+                retain=True
+            )
+
     # For depended APIs like the Fronius Inverter classes, which is not
     # directly batcontrol.
     def generic_publish(self, topic: str, value: str) -> None:
@@ -688,6 +716,30 @@ class MqttApi:
             "power",
             "W",
             self.base_topic + "/peak_shaving/charge_limit")
+
+        self.publish_mqtt_discovery_message(
+            "Peak Shaving Price Limit",
+            "batcontrol_peak_shaving_price_limit",
+            "number",
+            "monetary",
+            None,
+            self.base_topic + "/peak_shaving/price_limit",
+            self.base_topic + "/peak_shaving/price_limit/set",
+            entity_category="config",
+            min_value=-1.0,
+            max_value=1.0,
+            step_value=0.01)
+
+        self.publish_mqtt_discovery_message(
+            "Peak Shaving Mode",
+            "batcontrol_peak_shaving_mode",
+            "select",
+            None,
+            None,
+            self.base_topic + "/peak_shaving/mode",
+            self.base_topic + "/peak_shaving/mode/set",
+            entity_category="config",
+            options=["time", "price", "combined"])
 
         # sensors
         self.publish_mqtt_discovery_message(

--- a/src/batcontrol/mqtt_api.py
+++ b/src/batcontrol/mqtt_api.py
@@ -48,6 +48,7 @@ import time
 import json
 import logging
 import importlib.metadata
+from typing import Optional
 import paho.mqtt.client as mqtt
 import numpy as np
 
@@ -537,7 +538,8 @@ class MqttApi:
                 str(charge_limit)
             )
 
-    def publish_peak_shaving_price_limit(self, price_limit) -> None:
+    def publish_peak_shaving_price_limit(
+            self, price_limit: Optional[float]) -> None:
         """ Publish peak shaving price limit to MQTT
             /peak_shaving/price_limit
 

--- a/tests/batcontrol/logic/test_min_grid_charge_soc_live_cases.py
+++ b/tests/batcontrol/logic/test_min_grid_charge_soc_live_cases.py
@@ -131,7 +131,6 @@ def _make_logic(logic_cls):
         max_capacity=CAPACITY_WH,
         min_grid_charge_soc=MIN_GRID_CHARGE_SOC,
         preserve_min_grid_charge_soc=True,
-        peak_shaving_enabled=False,
     ))
     return logic
 

--- a/tests/batcontrol/logic/test_peak_shaving.py
+++ b/tests/batcontrol/logic/test_peak_shaving.py
@@ -18,6 +18,7 @@ from batcontrol.logic.logic_interface import (
     CalculationInput,
     CalculationParameters,
     InverterControlSettings,
+    PeakShavingConfig,
 )
 from batcontrol.logic.common import CommonLogic
 
@@ -41,8 +42,8 @@ class TestPeakShavingAlgorithm(unittest.TestCase):
             min_price_difference=0.05,
             min_price_difference_rel=0.2,
             max_capacity=self.max_capacity,
-            peak_shaving_enabled=True,
-            peak_shaving_allow_full_after=14,
+            peak_shaving=PeakShavingConfig(
+                enabled=True, allow_full_battery_after=14),
         )
         self.logic.set_calculation_parameters(self.params)
 
@@ -210,10 +211,11 @@ class TestPeakShavingDecision(unittest.TestCase):
             min_price_difference=0.05,
             min_price_difference_rel=0.2,
             max_capacity=self.max_capacity,
-            peak_shaving_enabled=True,
-            peak_shaving_allow_full_after=14,
-            peak_shaving_mode='combined',
-            peak_shaving_price_limit=0.05,  # required; tests use high prices so no cheap slots
+            peak_shaving=PeakShavingConfig(
+                enabled=True, allow_full_battery_after=14,
+                mode='combined',
+                # required; tests use high prices so no cheap slots
+                price_limit=0.05),
         )
         self.logic.set_calculation_parameters(self.params)
 
@@ -350,10 +352,9 @@ class TestPeakShavingDecision(unittest.TestCase):
             min_price_difference=0.05,
             min_price_difference_rel=0.2,
             max_capacity=self.max_capacity,
-            peak_shaving_enabled=True,
-            peak_shaving_allow_full_after=14,
-            peak_shaving_mode='combined',
-            peak_shaving_price_limit=None,
+            peak_shaving=PeakShavingConfig(
+                enabled=True, allow_full_battery_after=14,
+                mode='combined', price_limit=None),
         )
         self.logic.set_calculation_parameters(params)
         settings = self._make_settings()
@@ -375,10 +376,9 @@ class TestPeakShavingDecision(unittest.TestCase):
             min_price_difference=0.05,
             min_price_difference_rel=0.2,
             max_capacity=self.max_capacity,
-            peak_shaving_enabled=True,
-            peak_shaving_allow_full_after=14,
-            peak_shaving_mode='price',
-            peak_shaving_price_limit=None,
+            peak_shaving=PeakShavingConfig(
+                enabled=True, allow_full_battery_after=14,
+                mode='price', price_limit=None),
         )
         self.logic.set_calculation_parameters(params)
         settings = self._make_settings()
@@ -440,10 +440,10 @@ class TestPeakShavingDecision(unittest.TestCase):
             min_price_difference=0.05,
             min_price_difference_rel=0.2,
             max_capacity=self.max_capacity,
-            peak_shaving_enabled=True,
-            peak_shaving_allow_full_after=14,
-            peak_shaving_mode='time',
-            peak_shaving_price_limit=None,  # not needed for 'time' mode
+            peak_shaving=PeakShavingConfig(
+                enabled=True, allow_full_battery_after=14,
+                # price_limit not needed for 'time' mode
+                mode='time', price_limit=None),
         )
         self.logic.set_calculation_parameters(params)
         settings = self._make_settings()
@@ -466,10 +466,9 @@ class TestPeakShavingDecision(unittest.TestCase):
             min_price_difference=0.05,
             min_price_difference_rel=0.2,
             max_capacity=self.max_capacity,
-            peak_shaving_enabled=True,
-            peak_shaving_allow_full_after=14,
-            peak_shaving_mode='price',
-            peak_shaving_price_limit=0.05,
+            peak_shaving=PeakShavingConfig(
+                enabled=True, allow_full_battery_after=14,
+                mode='price', price_limit=0.05),
         )
         self.logic.set_calculation_parameters(params)
         settings = self._make_settings()
@@ -499,8 +498,8 @@ class TestPeakShavingDisabled(unittest.TestCase):
             min_price_difference=0.05,
             min_price_difference_rel=0.2,
             max_capacity=self.max_capacity,
-            peak_shaving_enabled=False,
-            peak_shaving_allow_full_after=14,
+            peak_shaving=PeakShavingConfig(
+                enabled=False, allow_full_battery_after=14),
         )
         self.logic.set_calculation_parameters(self.params)
 
@@ -573,144 +572,6 @@ class TestLogicFactory(unittest.TestCase):
         self.assertEqual(logic.round_price_digits, 2)
 
 
-class TestCalculationParametersPeakShaving(unittest.TestCase):
-    """Test CalculationParameters peak shaving fields."""
-
-    def test_defaults(self):
-        """Without peak shaving args -> defaults."""
-        params = CalculationParameters(
-            max_charging_from_grid_limit=0.8,
-            min_price_difference=0.05,
-            min_price_difference_rel=0.1,
-            max_capacity=10000,
-        )
-        self.assertFalse(params.peak_shaving_enabled)
-        self.assertEqual(params.peak_shaving_allow_full_after, 14)
-        self.assertEqual(params.peak_shaving_mode, 'combined')
-
-    def test_explicit_values(self):
-        """With explicit peak shaving args -> stored."""
-        params = CalculationParameters(
-            max_charging_from_grid_limit=0.8,
-            min_price_difference=0.05,
-            min_price_difference_rel=0.1,
-            max_capacity=10000,
-            peak_shaving_enabled=True,
-            peak_shaving_allow_full_after=16,
-        )
-        self.assertTrue(params.peak_shaving_enabled)
-        self.assertEqual(params.peak_shaving_allow_full_after, 16)
-
-    def test_invalid_allow_full_after_too_high(self):
-        """allow_full_battery_after > 23 raises ValueError."""
-        with self.assertRaises(ValueError):
-            CalculationParameters(
-                max_charging_from_grid_limit=0.8,
-                min_price_difference=0.05,
-                min_price_difference_rel=0.1,
-                max_capacity=10000,
-                peak_shaving_allow_full_after=25,
-            )
-
-    def test_invalid_allow_full_after_negative(self):
-        """allow_full_battery_after < 0 raises ValueError."""
-        with self.assertRaises(ValueError):
-            CalculationParameters(
-                max_charging_from_grid_limit=0.8,
-                min_price_difference=0.05,
-                min_price_difference_rel=0.1,
-                max_capacity=10000,
-                peak_shaving_allow_full_after=-1,
-            )
-
-    def test_price_limit_default_is_none(self):
-        """peak_shaving_price_limit defaults to None."""
-        params = CalculationParameters(
-            max_charging_from_grid_limit=0.8,
-            min_price_difference=0.05,
-            min_price_difference_rel=0.1,
-            max_capacity=10000,
-        )
-        self.assertIsNone(params.peak_shaving_price_limit)
-
-    def test_price_limit_explicit_value(self):
-        """Explicit price_limit is stored."""
-        params = CalculationParameters(
-            max_charging_from_grid_limit=0.8,
-            min_price_difference=0.05,
-            min_price_difference_rel=0.1,
-            max_capacity=10000,
-            peak_shaving_price_limit=0.05,
-        )
-        self.assertEqual(params.peak_shaving_price_limit, 0.05)
-
-    def test_price_limit_zero_allowed(self):
-        """price_limit=0 is valid (only free/negative prices count as cheap)."""
-        params = CalculationParameters(
-            max_charging_from_grid_limit=0.8,
-            min_price_difference=0.05,
-            min_price_difference_rel=0.1,
-            max_capacity=10000,
-            peak_shaving_price_limit=0.0,
-        )
-        self.assertEqual(params.peak_shaving_price_limit, 0.0)
-
-    def test_price_limit_negative_one_allowed(self):
-        """price_limit=-1 is valid (effectively disables cheap-slot detection)."""
-        params = CalculationParameters(
-            max_charging_from_grid_limit=0.8,
-            min_price_difference=0.05,
-            min_price_difference_rel=0.1,
-            max_capacity=10000,
-            peak_shaving_price_limit=-1,
-        )
-        self.assertEqual(params.peak_shaving_price_limit, -1)
-
-    def test_price_limit_arbitrary_negative_allowed(self):
-        """Arbitrary negative price_limit is accepted (only numeric check)."""
-        params = CalculationParameters(
-            max_charging_from_grid_limit=0.8,
-            min_price_difference=0.05,
-            min_price_difference_rel=0.1,
-            max_capacity=10000,
-            peak_shaving_price_limit=-0.5,
-        )
-        self.assertEqual(params.peak_shaving_price_limit, -0.5)
-
-    def test_mode_default_is_combined(self):
-        """peak_shaving_mode defaults to 'combined'."""
-        params = CalculationParameters(
-            max_charging_from_grid_limit=0.8,
-            min_price_difference=0.05,
-            min_price_difference_rel=0.1,
-            max_capacity=10000,
-        )
-        self.assertEqual(params.peak_shaving_mode, 'combined')
-
-    def test_mode_valid_values(self):
-        """'time', 'price', 'combined' are all accepted."""
-        for mode in ('time', 'price', 'combined'):
-            params = CalculationParameters(
-                max_charging_from_grid_limit=0.8,
-                min_price_difference=0.05,
-                min_price_difference_rel=0.1,
-                max_capacity=10000,
-                peak_shaving_mode=mode,
-            )
-            self.assertEqual(params.peak_shaving_mode, mode)
-
-    def test_mode_invalid_raises(self):
-        """Unknown mode string raises ValueError."""
-        with self.assertRaises(ValueError):
-            CalculationParameters(
-                max_charging_from_grid_limit=0.8,
-                min_price_difference=0.05,
-                min_price_difference_rel=0.1,
-                max_capacity=10000,
-                peak_shaving_mode='invalid',
-            )
-
-
 class TestPeakShavingPriceBased(unittest.TestCase):
     """Tests for _calculate_peak_shaving_charge_limit_price_based."""
 
@@ -729,10 +590,9 @@ class TestPeakShavingPriceBased(unittest.TestCase):
             min_price_difference=0.05,
             min_price_difference_rel=0.2,
             max_capacity=self.max_capacity,
-            peak_shaving_enabled=True,
-            peak_shaving_allow_full_after=14,
-            peak_shaving_mode='price',
-            peak_shaving_price_limit=0.05,
+            peak_shaving=PeakShavingConfig(
+                enabled=True, allow_full_battery_after=14,
+                mode='price', price_limit=0.05),
         )
         self.logic.set_calculation_parameters(self.params)
 
@@ -856,10 +716,9 @@ class TestPeakShavingPriceBased(unittest.TestCase):
             min_price_difference=0.05,
             min_price_difference_rel=0.2,
             max_capacity=self.max_capacity,
-            peak_shaving_enabled=True,
-            peak_shaving_allow_full_after=14,
-            peak_shaving_mode='combined',
-            peak_shaving_price_limit=0.05,
+            peak_shaving=PeakShavingConfig(
+                enabled=True, allow_full_battery_after=14,
+                mode='combined', price_limit=0.05),
         )
         logic = NextLogic(timezone=datetime.timezone.utc, interval_minutes=60)
         logic.set_calculation_parameters(params_combined)
@@ -965,9 +824,8 @@ class TestPeakShavingMinChargeRate(unittest.TestCase):
             min_price_difference=0.05,
             min_price_difference_rel=0.2,
             max_capacity=self._MAX_CAPACITY,
-            peak_shaving_enabled=True,
-            peak_shaving_allow_full_after=14,
-            peak_shaving_mode='time',
+            peak_shaving=PeakShavingConfig(
+                enabled=True, allow_full_battery_after=14, mode='time'),
         )
         logic.set_calculation_parameters(params)
         return logic
@@ -1070,7 +928,7 @@ class TestNextLogicGridRechargeLogging(unittest.TestCase):
             min_price_difference=0.05,
             min_price_difference_rel=0.2,
             max_capacity=self.max_capacity,
-            peak_shaving_enabled=False,
+            peak_shaving=PeakShavingConfig(enabled=False),
         ))
 
     def _make_grid_charge_input(self):
@@ -1114,7 +972,7 @@ class TestNextLogicGridRechargeLogging(unittest.TestCase):
             min_price_difference_rel=0.2,
             max_capacity=self.max_capacity,
             min_grid_charge_soc=0.55,
-            peak_shaving_enabled=False,
+            peak_shaving=PeakShavingConfig(enabled=False),
         ))
         calc_input = self._make_grid_charge_input()
         calc_timestamp = datetime.datetime(2025, 6, 20, 12, 0, 0,
@@ -1134,7 +992,7 @@ class TestNextLogicGridRechargeLogging(unittest.TestCase):
             max_capacity=self.max_capacity,
             min_grid_charge_soc=0.55,
             preserve_min_grid_charge_soc=True,
-            peak_shaving_enabled=False,
+            peak_shaving=PeakShavingConfig(enabled=False),
         ))
         stored_energy = 5000
         stored_usable_energy = stored_energy - self.max_capacity * 0.05
@@ -1167,7 +1025,7 @@ class TestNextLogicGridRechargeLogging(unittest.TestCase):
             max_capacity=self.max_capacity,
             min_grid_charge_soc=0.55,
             preserve_min_grid_charge_soc=True,
-            peak_shaving_enabled=False,
+            peak_shaving=PeakShavingConfig(enabled=False),
         ))
         stored_energy = 5000
         stored_usable_energy = stored_energy - self.max_capacity * 0.05

--- a/tests/batcontrol/test_core.py
+++ b/tests/batcontrol/test_core.py
@@ -952,7 +952,8 @@ class TestEvccPeakShavingGuard:
         bc.evcc_api = mock_evcc
 
         # Replicate the pre-calculation evcc check from core.py
-        from batcontrol.logic.logic_interface import CalculationParameters
+        from batcontrol.logic.logic_interface import (
+            CalculationParameters, PeakShavingConfig)
         evcc_disable_peak_shaving = (
             bc.evcc_api.evcc_is_charging or
             bc.evcc_api.evcc_ev_expects_pv_surplus
@@ -963,10 +964,12 @@ class TestEvccPeakShavingGuard:
             min_price_difference=0.05,
             min_price_difference_rel=0.0,
             max_capacity=10000,
-            peak_shaving_enabled=peak_shaving_config.get('enabled', False) and not evcc_disable_peak_shaving,
+            peak_shaving=PeakShavingConfig(
+                enabled=peak_shaving_config.get('enabled', False)
+                and not evcc_disable_peak_shaving),
         )
 
-        assert calc_params.peak_shaving_enabled is False
+        assert calc_params.peak_shaving.enabled is False
 
     @patch('batcontrol.core.tariff_factory.create_tarif_provider')
     @patch('batcontrol.core.inverter_factory.create_inverter')
@@ -984,7 +987,8 @@ class TestEvccPeakShavingGuard:
         mock_evcc.evcc_ev_expects_pv_surplus = True
         bc.evcc_api = mock_evcc
 
-        from batcontrol.logic.logic_interface import CalculationParameters
+        from batcontrol.logic.logic_interface import (
+            CalculationParameters, PeakShavingConfig)
         evcc_disable_peak_shaving = (
             bc.evcc_api.evcc_is_charging or
             bc.evcc_api.evcc_ev_expects_pv_surplus
@@ -995,10 +999,12 @@ class TestEvccPeakShavingGuard:
             min_price_difference=0.05,
             min_price_difference_rel=0.0,
             max_capacity=10000,
-            peak_shaving_enabled=peak_shaving_config.get('enabled', False) and not evcc_disable_peak_shaving,
+            peak_shaving=PeakShavingConfig(
+                enabled=peak_shaving_config.get('enabled', False)
+                and not evcc_disable_peak_shaving),
         )
 
-        assert calc_params.peak_shaving_enabled is False
+        assert calc_params.peak_shaving.enabled is False
 
     @patch('batcontrol.core.tariff_factory.create_tarif_provider')
     @patch('batcontrol.core.inverter_factory.create_inverter')
@@ -1016,7 +1022,8 @@ class TestEvccPeakShavingGuard:
         mock_evcc.evcc_ev_expects_pv_surplus = False
         bc.evcc_api = mock_evcc
 
-        from batcontrol.logic.logic_interface import CalculationParameters
+        from batcontrol.logic.logic_interface import (
+            CalculationParameters, PeakShavingConfig)
         evcc_disable_peak_shaving = (
             bc.evcc_api.evcc_is_charging or
             bc.evcc_api.evcc_ev_expects_pv_surplus
@@ -1027,10 +1034,12 @@ class TestEvccPeakShavingGuard:
             min_price_difference=0.05,
             min_price_difference_rel=0.0,
             max_capacity=10000,
-            peak_shaving_enabled=peak_shaving_config.get('enabled', False) and not evcc_disable_peak_shaving,
+            peak_shaving=PeakShavingConfig(
+                enabled=peak_shaving_config.get('enabled', False)
+                and not evcc_disable_peak_shaving),
         )
 
-        assert calc_params.peak_shaving_enabled is True
+        assert calc_params.peak_shaving.enabled is True
 
     @patch('batcontrol.core.tariff_factory.create_tarif_provider')
     @patch('batcontrol.core.inverter_factory.create_inverter')
@@ -1050,7 +1059,8 @@ class TestEvccPeakShavingGuard:
         mock_evcc.evcc_ev_expects_pv_surplus = False
         bc.evcc_api = mock_evcc
 
-        from batcontrol.logic.logic_interface import CalculationParameters
+        from batcontrol.logic.logic_interface import (
+            CalculationParameters, PeakShavingConfig)
         evcc_disable_peak_shaving = (
             bc.evcc_api.evcc_is_charging or
             bc.evcc_api.evcc_ev_expects_pv_surplus
@@ -1061,10 +1071,12 @@ class TestEvccPeakShavingGuard:
             min_price_difference=0.05,
             min_price_difference_rel=0.0,
             max_capacity=10000,
-            peak_shaving_enabled=peak_shaving_config.get('enabled', False) and not evcc_disable_peak_shaving,
+            peak_shaving=PeakShavingConfig(
+                enabled=peak_shaving_config.get('enabled', False)
+                and not evcc_disable_peak_shaving),
         )
 
-        assert calc_params.peak_shaving_enabled is False
+        assert calc_params.peak_shaving.enabled is False
 
 
 if __name__ == '__main__':

--- a/tests/batcontrol/test_mqtt_api.py
+++ b/tests/batcontrol/test_mqtt_api.py
@@ -1,6 +1,8 @@
 """Tests for MqttApi._handle_message, focusing on bytes payload decoding."""
 from unittest.mock import MagicMock, call
 
+from batcontrol.core import Batcontrol
+from batcontrol.logic import PeakShavingConfig
 from batcontrol.mqtt_api import MqttApi
 
 
@@ -349,3 +351,67 @@ class TestPeakShavingEnabledApi:
         api, topic = self._make_api_with_callback()
         api._handle_message(None, None, _make_message(topic, b'OFF'))
         assert self.enabled_values == [False]
+
+
+def _make_bc_stub(initial_config: PeakShavingConfig = None) -> MagicMock:
+    """Stub good enough to invoke Batcontrol.api_set_peak_shaving_* directly.
+
+    Only carries the attributes the setters actually touch.
+    """
+    bc = MagicMock(spec=Batcontrol)
+    bc.peak_shaving_config = (initial_config if initial_config is not None
+                              else PeakShavingConfig())
+    bc.mqtt_api = MagicMock()
+    return bc
+
+
+class TestPeakShavingPriceLimitApi:
+    """Batcontrol.api_set_peak_shaving_price_limit must validate and round-trip."""
+
+    def test_valid_float_updates_and_publishes(self):
+        bc = _make_bc_stub()
+        Batcontrol.api_set_peak_shaving_price_limit(bc, 0.05)
+        assert bc.peak_shaving_config.price_limit == 0.05
+        bc.mqtt_api.publish_peak_shaving_price_limit.assert_called_once_with(0.05)
+
+    def test_negative_one_disables_price_component(self):
+        # -1 is the documented off-value (no slot price <= -1 ever exists).
+        bc = _make_bc_stub()
+        Batcontrol.api_set_peak_shaving_price_limit(bc, -1)
+        assert bc.peak_shaving_config.price_limit == -1.0
+        bc.mqtt_api.publish_peak_shaving_price_limit.assert_called_once_with(-1.0)
+
+    def test_zero_is_accepted(self):
+        bc = _make_bc_stub()
+        Batcontrol.api_set_peak_shaving_price_limit(bc, 0)
+        assert bc.peak_shaving_config.price_limit == 0.0
+
+    def test_invalid_string_keeps_old_value(self):
+        original = PeakShavingConfig(price_limit=0.10)
+        bc = _make_bc_stub(original)
+        Batcontrol.api_set_peak_shaving_price_limit(bc, 'cheap')
+        assert bc.peak_shaving_config is original
+        bc.mqtt_api.publish_peak_shaving_price_limit.assert_not_called()
+
+
+class TestPeakShavingModeApi:
+    """Batcontrol.api_set_peak_shaving_mode must validate and round-trip."""
+
+    def test_each_valid_mode_is_accepted(self):
+        for mode in ('time', 'price', 'combined'):
+            bc = _make_bc_stub()
+            Batcontrol.api_set_peak_shaving_mode(bc, mode)
+            assert bc.peak_shaving_config.mode == mode
+            bc.mqtt_api.publish_peak_shaving_mode.assert_called_once_with(mode)
+
+    def test_uppercase_is_normalised(self):
+        bc = _make_bc_stub()
+        Batcontrol.api_set_peak_shaving_mode(bc, 'TIME')
+        assert bc.peak_shaving_config.mode == 'time'
+
+    def test_invalid_mode_keeps_old_value(self):
+        original = PeakShavingConfig(mode='price')
+        bc = _make_bc_stub(original)
+        Batcontrol.api_set_peak_shaving_mode(bc, 'bogus')
+        assert bc.peak_shaving_config is original
+        bc.mqtt_api.publish_peak_shaving_mode.assert_not_called()

--- a/tests/batcontrol/test_mqtt_api.py
+++ b/tests/batcontrol/test_mqtt_api.py
@@ -393,6 +393,16 @@ class TestPeakShavingPriceLimitApi:
         assert bc.peak_shaving_config is original
         bc.mqtt_api.publish_peak_shaving_price_limit.assert_not_called()
 
+    def test_bool_inputs_are_rejected(self):
+        # float(True)=1.0 / float(False)=0.0 would silently bypass the
+        # explicit bool rejection in PeakShavingConfig.__post_init__.
+        original = PeakShavingConfig(price_limit=0.10)
+        for value in (True, False):
+            bc = _make_bc_stub(original)
+            Batcontrol.api_set_peak_shaving_price_limit(bc, value)
+            assert bc.peak_shaving_config is original
+            bc.mqtt_api.publish_peak_shaving_price_limit.assert_not_called()
+
 
 class TestPeakShavingModeApi:
     """Batcontrol.api_set_peak_shaving_mode must validate and round-trip."""

--- a/tests/batcontrol/test_peak_shaving_config.py
+++ b/tests/batcontrol/test_peak_shaving_config.py
@@ -6,7 +6,7 @@ failing later in ``CalculationParameters.__post_init__``.
 """
 import pytest
 
-from batcontrol.core import PeakShavingConfig
+from batcontrol.logic import PeakShavingConfig
 
 
 class TestPeakShavingConfigValidation:
@@ -144,33 +144,56 @@ class TestPeakShavingConfigFromConfig:
 class TestPeakShavingConfigFallbackWarning:
     """Test the one-time warning for combined-mode + missing price_limit.
 
-    The warning must fire at config load (not during runtime) and only
-    when the misconfiguration would actually be active (enabled=True and
-    mode='combined' with price_limit=None).
+    The warning fires at config load (``from_config``) only -- not in
+    ``__post_init__`` -- so that ``dataclasses.replace`` in the per-cycle
+    build path does not re-emit it on every evaluation.
     """
 
+    LOGGER = 'batcontrol.logic.logic_interface'
+
     def test_combined_without_price_limit_logs_warning(self, caplog):
-        with caplog.at_level('WARNING', logger='batcontrol.core'):
-            PeakShavingConfig(enabled=True, mode='combined', price_limit=None)
+        with caplog.at_level('WARNING', logger=self.LOGGER):
+            PeakShavingConfig.from_config({
+                'peak_shaving': {'enabled': True, 'mode': 'combined'},
+            })
         messages = [r.getMessage() for r in caplog.records
                     if r.levelname == 'WARNING']
         assert any("combined" in m and "price_limit" in m for m in messages)
 
     def test_disabled_combined_without_price_limit_does_not_warn(self, caplog):
         # When peak shaving is disabled there is no user-visible problem.
-        with caplog.at_level('WARNING', logger='batcontrol.core'):
-            PeakShavingConfig(enabled=False, mode='combined', price_limit=None)
+        with caplog.at_level('WARNING', logger=self.LOGGER):
+            PeakShavingConfig.from_config({
+                'peak_shaving': {'enabled': False, 'mode': 'combined'},
+            })
         warnings = [r for r in caplog.records if r.levelname == 'WARNING']
         assert warnings == []
 
     def test_combined_with_price_limit_does_not_warn(self, caplog):
-        with caplog.at_level('WARNING', logger='batcontrol.core'):
-            PeakShavingConfig(enabled=True, mode='combined', price_limit=0.05)
+        with caplog.at_level('WARNING', logger=self.LOGGER):
+            PeakShavingConfig.from_config({
+                'peak_shaving': {
+                    'enabled': True, 'mode': 'combined', 'price_limit': 0.05},
+            })
         warnings = [r for r in caplog.records if r.levelname == 'WARNING']
         assert warnings == []
 
     def test_time_mode_without_price_limit_does_not_warn(self, caplog):
-        with caplog.at_level('WARNING', logger='batcontrol.core'):
-            PeakShavingConfig(enabled=True, mode='time', price_limit=None)
+        with caplog.at_level('WARNING', logger=self.LOGGER):
+            PeakShavingConfig.from_config({
+                'peak_shaving': {'enabled': True, 'mode': 'time'},
+            })
+        warnings = [r for r in caplog.records if r.levelname == 'WARNING']
+        assert warnings == []
+
+    def test_replace_does_not_re_emit_warning(self, caplog):
+        # dataclasses.replace re-runs __post_init__ but must not trigger
+        # the fallback warning on every per-cycle rebuild.
+        import dataclasses
+        cfg = PeakShavingConfig(
+            enabled=True, mode='combined', price_limit=None)
+        with caplog.at_level('WARNING', logger=self.LOGGER):
+            dataclasses.replace(cfg, enabled=False)
+            dataclasses.replace(cfg, enabled=True)
         warnings = [r for r in caplog.records if r.levelname == 'WARNING']
         assert warnings == []


### PR DESCRIPTION
Move PeakShavingConfig from core.py into logic_interface.py and embed it
as a nested field on CalculationParameters, replacing the four flat
peak_shaving_* fields. The evcc enabled-override in core.py now uses
dataclasses.replace, so per-cycle parameter rebuilds no longer rely on
the old flat-field copy pattern.

The combined+price_limit=None fallback warning moves from __post_init__
to from_config so dataclasses.replace in the per-evaluation build path
no longer re-emits it on every cycle.

https://claude.ai/code/session_014dHHuZaGbZckiAZfYJNmfi