### PR TITLE
forecastsolar: increase refresh interval to ~80 min (18 calls/day)

### DIFF
--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -43,9 +43,6 @@ DELAY_EVALUATION_BY_SECONDS = 15  # Delay evaluation for x seconds at every trig
 # Interval between evaluations in seconds
 TIME_BETWEEN_EVALUATIONS = EVALUATIONS_EVERY_MINUTES * 60
 TIME_BETWEEN_UTILITY_API_CALLS = 900  # 15 Minutes
-# 18 calls/day leaves 2 in reserve (providers allow 20/day).
-# Formula: 24h / 18 calls * 60 min/h * 60 s/min
-TIME_BETWEEN_SOLAR_API_CALLS = int(24 / 18 * 60 * 60)  # ~80 min
 MIN_FORECAST_HOURS = 1  # Minimum required forecast hours
 FORECAST_TOLERANCE = 3  # Acceptable tolerance for forecast hours
 
@@ -211,7 +208,7 @@ class Batcontrol:
         self.fc_solar = solar_factory.create_solar_provider(
             self.pvsettings,
             self.timezone,
-            TIME_BETWEEN_SOLAR_API_CALLS,
+            TIME_BETWEEN_UTILITY_API_CALLS,
             DELAY_EVALUATION_BY_SECONDS,
             requested_provider=config.get(
                 'solar_forecast_provider', 'fcsolarapi'),

--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -43,6 +43,9 @@ DELAY_EVALUATION_BY_SECONDS = 15  # Delay evaluation for x seconds at every trig
 # Interval between evaluations in seconds
 TIME_BETWEEN_EVALUATIONS = EVALUATIONS_EVERY_MINUTES * 60
 TIME_BETWEEN_UTILITY_API_CALLS = 900  # 15 Minutes
+# 18 calls/day leaves 2 in reserve (providers allow 20/day).
+# Formula: 24h / 18 calls * 60 min/h * 60 s/min
+TIME_BETWEEN_SOLAR_API_CALLS = int(24 / 18 * 60 * 60)  # ~80 min
 MIN_FORECAST_HOURS = 1  # Minimum required forecast hours
 FORECAST_TOLERANCE = 3  # Acceptable tolerance for forecast hours
 
@@ -208,7 +211,7 @@ class Batcontrol:
         self.fc_solar = solar_factory.create_solar_provider(
             self.pvsettings,
             self.timezone,
-            TIME_BETWEEN_UTILITY_API_CALLS,
+            TIME_BETWEEN_SOLAR_API_CALLS,
             DELAY_EVALUATION_BY_SECONDS,
             requested_provider=config.get(
                 'solar_forecast_provider', 'fcsolarapi'),

--- a/src/batcontrol/forecastsolar/solarprognose.py
+++ b/src/batcontrol/forecastsolar/solarprognose.py
@@ -62,11 +62,11 @@ class SolarPrognose(ForecastSolarBaseclass):
             delay_evaluation_by_seconds: Delay for API evaluation
             target_resolution: Target resolution in minutes (15 or 60)
         """
-        # 18 calls/day leaves 2 in reserve out of the 20 allowed per day.
-        # Ignore the generic interval from core and enforce the provider limit here.
-        min_refresh = int(24 / 18 * 60 * 60)  # ~80 min
+        # Provider allows 20 calls/day; use 18 to leave 2 in reserve (~80 min).
+        # Integer arithmetic avoids float rounding; max() respects larger caller values.
+        _provider_min = 24 * 60 * 60 // 18  # 4800 s
         super().__init__(pvinstallations, timezone,
-                         min_refresh, delay_evaluation_by_seconds,
+                         max(min_time_between_api_calls, _provider_min), delay_evaluation_by_seconds,
                          target_resolution=target_resolution,
                          native_resolution=60)  # SolarPrognose provides hourly data
 

--- a/src/batcontrol/forecastsolar/solarprognose.py
+++ b/src/batcontrol/forecastsolar/solarprognose.py
@@ -62,8 +62,11 @@ class SolarPrognose(ForecastSolarBaseclass):
             delay_evaluation_by_seconds: Delay for API evaluation
             target_resolution: Target resolution in minutes (15 or 60)
         """
+        # 18 calls/day leaves 2 in reserve out of the 20 allowed per day.
+        # Ignore the generic interval from core and enforce the provider limit here.
+        min_refresh = int(24 / 18 * 60 * 60)  # ~80 min
         super().__init__(pvinstallations, timezone,
-                         min_time_between_api_calls, delay_evaluation_by_seconds,
+                         min_refresh, delay_evaluation_by_seconds,
                          target_resolution=target_resolution,
                          native_resolution=60)  # SolarPrognose provides hourly data
 


### PR DESCRIPTION
Providers like fcsolar and solarprognose allow only 20 API calls per
day. The previous setting shared TIME_BETWEEN_UTILITY_API_CALLS (15 min)
with tariff APIs, which could exhaust the daily quota in ~5 hours.

A dedicated TIME_BETWEEN_SOLAR_API_CALLS constant (24/18 * 60 * 60 =
4800 s, ~80 min) limits solar fetches to 18 per day, leaving 2 requests
in reserve for restarts or transient errors.

https://claude.ai/code/session_01Fje2KBxRp5jHNSsSvEFwUp