### PR TITLE
energyforecast: migrate to API v2 with 4h refresh interval

### DIFF
--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -128,14 +128,24 @@ utility:
   # zone_2_hours: 0-6,23 # optional: hours assigned to zone 2 (required if tariff_zone_2 is set)
   # tariff_zone_3: 0.2100 # optional third zone price
   # zone_3_hours: 17-20 # optional hours for zone 3 (must not overlap with zone 1 or 2)
-  # apikey: YOUR_API_KEY # MANDATORY for energyforecast and tibber. Uncomment and set if using those providers.
-  # market_zone: DE # optional for energyforecast: DE/LU (both map to DE-LU, default), AT, FR, NL, BE, PL, DK1, DK2
+  # apikey: YOUR_API_KEY # MANDATORY for energyforecast, energyforecast_total_price and tibber.
+  # market_zone: DE # optional for energyforecast/energyforecast_total_price: DE/LU (both map to DE-LU, default), AT, FR, NL, BE, PL, DK1, DK2
+  #
+  # ALTERNATIVE: energyforecast_total_price
+  #   The API computes the full price (dynamic network fees + VAT + markup) in total_ct_kwh.
+  #   batcontrol uses total_ct_kwh as-is -- vat/fees/markup config fields are not needed
+  #   and dynamic_network_fees must not be enabled (the API already includes them).
+  #   Use this if you want the energyforecast.de API to handle all price components.
+  # type: energyforecast_total_price
+  # apikey: YOUR_API_KEY
+  # market_zone: DE  # optional, default: DE
 
 #--------------------------
 #  Dynamic Network Fees (para. 14a EnWG)
 #  Adds time-of-use NT/ST/HT network fees to energy prices.
 #  Only applies to providers that calculate fees locally: awattar, energyforecast.
-#  Not needed for all-inclusive providers: tibber, evcc, tariff_zones.
+#  Not needed for all-inclusive providers: tibber, evcc, tariff_zones,
+#  energyforecast_total_price (the API already includes network fees in total_ct_kwh).
 #  Fee data (NET, excl. VAT) is fetched from dyn-net.batcontrol.software and
 #  added to the price before VAT is applied.
 #  Cache: 12 hours (tariffs change at most quarterly).

--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -129,6 +129,7 @@ utility:
   # tariff_zone_3: 0.2100 # optional third zone price
   # zone_3_hours: 17-20 # optional hours for zone 3 (must not overlap with zone 1 or 2)
   # apikey: YOUR_API_KEY # MANDATORY for energyforecast and tibber. Uncomment and set if using those providers.
+  # market_zone: DE # optional for energyforecast: DE/LU (both map to DE-LU, default), AT, FR, NL, BE, PL, DK1, DK2
 
 #--------------------------
 #  Dynamic Network Fees (para. 14a EnWG)

--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -129,7 +129,7 @@ utility:
   # tariff_zone_3: 0.2100 # optional third zone price
   # zone_3_hours: 17-20 # optional hours for zone 3 (must not overlap with zone 1 or 2)
   # apikey: YOUR_API_KEY # MANDATORY for energyforecast, energyforecast_total_price and tibber.
-  # market_zone: DE # optional for energyforecast/energyforecast_total_price: DE/LU (both map to DE-LU, default), AT, FR, NL, BE, PL, DK1, DK2
+  # market_zone: DE # optional for energyforecast/energyforecast_total_price: DE/LU (both map to DE-LU for the API, default), AT, FR, NL, BE, PL, DK1, DK2
   #
   # ALTERNATIVE: energyforecast_total_price
   #   The API computes the full price (dynamic network fees + VAT + markup) in total_ct_kwh.

--- a/docs/configuration/dynamic-tariff-provider.md
+++ b/docs/configuration/dynamic-tariff-provider.md
@@ -5,6 +5,7 @@ Currently following data providers are available:
 * Two-Tariff Providers (e.g. Octopus)
 * evcc
 * energyforecast.de
+* energyforecast.de (total price mode)
 
 You can chose one and need to adjust the configuration.
 
@@ -139,7 +140,7 @@ The charge rate is not evenly distributed across low-price hours by default.
 
 - For **more even charging** across low-price hours, enable
   `soften_price_difference_on_charging` and set `max_grid_charge_rate` to a
-  modest value (e.g. battery capacity ÷ low-price hours).
+  modest value (e.g. battery capacity / low-price hours).
 - For a **late charging start** (optimise efficiency, keep the battery at
   high SOC for less time), disable `soften_price_difference_on_charging`.
 
@@ -159,25 +160,64 @@ utility:
 ```
 You may need to adjust hostname + port for your setup. If evcc is running under HomeAssistant, you should use either `http://homeassistant:7070/api/tariff/grid` or `http://<homeassistant-ip>:7070/api/tariff/grid`
 
-## energyforecast.de (0.5.6)
-[energyforecast.de](https://www.energyforecast.de) provides a calculated forecast for upcoming prices. Dayahead prices are populated at 14:00 GMT+2, which is after the lunch-drop in prices and prevents a good energy calculation. Based on different values, energyforecast.de calculates a price expectation with a median of 3 cent of. 
-batcontrol uses the 48h forecast only and it is not possible to activate the 96 hour forecast. You need to setup VAT, markup (+ % on energy price) and fees (Netzentgeld) in the configuration. We are not using the calculation provided by energyforecast.de.
-If you like to use this forecast type, please create a login at [energyforecast.de](https://www.energyforecast.de) to aquire an API key.
+## energyforecast.de
 
-```
+[energyforecast.de](https://www.energyforecast.de) provides a multi-day price forecast using
+API v2. The API delivers quarter-hourly data for a plan-dependent horizon (typically several
+days ahead). Day-ahead prices are populated at around 14:00 CET, which provides good coverage
+for next-day planning.
+
+batcontrol fetches the raw market price (`price_ct_kwh`) from the API and calculates the
+final price locally by applying your configured VAT, fees, and markup — the same approach used
+for aWATTar. This gives you full control over the price components.
+
+To use energyforecast.de, create a login at [energyforecast.de](https://www.energyforecast.de)
+to obtain an API key.
+
+```yaml
 utility:
   type: energyforecast
-  apikey:  xxxxxxxxx
+  apikey: xxxxxxxxx
   vat: 0.19     # 19% VAT
-  fees: 0.15    # Depends on you Netzendgeld
-  markup: 0.00  # Depends on you aWATTar contract
+  fees: 0.15    # Your network fees (Netzentgelt), EUR/kWh excl. VAT
+  markup: 0.00  # Optional markup, e.g. supplier margin
+  # market_zone: DE  # optional: DE (default), AT, FR, NL, BE, PL, DK1, DK2
 ```
 
-To enable the paid 96h forecast, use type: energyforecast_96
+The price calculation is: `( price_ct_kwh/100 * (1+markup) + fees ) * (1+vat)`
 
-## Dynamic network fees (§14a EnWG)
+> **Note:** `energyforecast_96` is deprecated. API v2 automatically delivers a
+> multi-day forecast based on your plan -- use `energyforecast` instead.
 
-Batcontrol can add time-of-use network fees (NT/ST/HT zones according to §14a EnWG) on top of the energy prices. This only applies to providers that calculate fees locally: **awattar** and **energyforecast**. All-inclusive providers (tibber, evcc, tariff_zones) already deliver final prices and do not need this.
+## energyforecast.de -- total price mode
+
+If you prefer to let the energyforecast.de API calculate the full price -- including
+dynamic network fees, VAT, and markup -- use `energyforecast_total_price`. In this mode
+batcontrol reads the API's `total_ct_kwh` field directly without any local calculation.
+
+This is useful if:
+
+- You want the API to handle dynamic network fees automatically (including para. 14a EnWG),
+  without configuring them separately in batcontrol.
+- You trust the API's price model and want a simpler local configuration.
+
+```yaml
+utility:
+  type: energyforecast_total_price
+  apikey: xxxxxxxxx
+  # market_zone: DE  # optional: DE (default), AT, FR, NL, BE, PL, DK1, DK2
+```
+
+**Important:** Do not set `vat`, `fees`, or `markup` -- they are ignored for this provider
+type. Do not enable `dynamic_network_fees` either; the API already includes network fees in
+`total_ct_kwh`.
+
+## Dynamic network fees (para. 14a EnWG)
+
+batcontrol can add time-of-use network fees (NT/ST/HT zones according to para. 14a EnWG)
+on top of the energy prices. This only applies to providers that calculate fees locally:
+**awattar** and **energyforecast**. All-inclusive providers (tibber, evcc, tariff_zones,
+and **energyforecast_total_price**) already deliver final prices and do not need this.
 
 The fee data (NET prices, excluding VAT) is fetched from [dyn-net.batcontrol.software](https://dyn-net.batcontrol.software/) and added to the raw energy price before VAT is applied. Data is cached for 12 hours, as tariffs change at most quarterly.
 

--- a/docs/configuration/dynamic-tariff-provider.md
+++ b/docs/configuration/dynamic-tariff-provider.md
@@ -181,7 +181,7 @@ utility:
   vat: 0.19     # 19% VAT
   fees: 0.15    # Your network fees (Netzentgelt), EUR/kWh excl. VAT
   markup: 0.00  # Optional markup, e.g. supplier margin
-  # market_zone: DE  # optional: DE (default), AT, FR, NL, BE, PL, DK1, DK2
+  # market_zone: DE  # optional: DE/LU (default, both map to DE-LU market zone), AT, FR, NL, BE, PL, DK1, DK2
 ```
 
 The price calculation is: `( price_ct_kwh/100 * (1+markup) + fees ) * (1+vat)`
@@ -205,7 +205,7 @@ This is useful if:
 utility:
   type: energyforecast_total_price
   apikey: xxxxxxxxx
-  # market_zone: DE  # optional: DE (default), AT, FR, NL, BE, PL, DK1, DK2
+  # market_zone: DE  # optional: DE/LU (default, both map to DE-LU market zone), AT, FR, NL, BE, PL, DK1, DK2
 ```
 
 **Important:** Do not set `vat`, `fees`, or `markup` -- they are ignored for this provider

--- a/src/batcontrol/dynamictariff/dynamictariff.py
+++ b/src/batcontrol/dynamictariff/dynamictariff.py
@@ -50,8 +50,9 @@ class DynamicTariff:
         provider = config.get('type')
 
         nf_cfg = nf_cfg or {}
+        network_fees_enabled = nf_cfg.get('enabled', False)
         network_fees_fetcher = None
-        if nf_cfg.get('enabled', False):
+        if network_fees_enabled and provider.lower() != 'energyforecast_total_price':
             for field in ('country', 'operator'):
                 if field not in nf_cfg:
                     raise RuntimeError(
@@ -164,6 +165,35 @@ class DynamicTariff:
             selected_tariff.set_price_parameters(vat, fees, markup)
             if network_fees_fetcher is not None:
                 selected_tariff.set_network_fees_fetcher(network_fees_fetcher)
+
+        elif provider.lower() == 'energyforecast_total_price':
+            if 'apikey' not in config:
+                raise RuntimeError(
+                    '[DynTariff] Please include apikey in your configuration file'
+                )
+            for field in ('vat', 'fees', 'markup'):
+                if field in config:
+                    logger.warning(
+                        '[DynTariff] energyforecast_total_price: "%s" is ignored '
+                        '-- the API already includes all charges in total_ct_kwh',
+                        field
+                    )
+            if network_fees_enabled:
+                logger.warning(
+                    '[DynTariff] energyforecast_total_price: dynamic_network_fees '
+                    'is ignored -- the API already includes network fees in total_ct_kwh'
+                )
+            token = config.get('apikey')
+            market_zone = config.get('market_zone', 'DE')
+            selected_tariff = Energyforecast(
+                timezone,
+                token,
+                min_time_between_api_calls,
+                delay_evaluation_by_seconds,
+                target_resolution=target_resolution,
+                market_zone=market_zone,
+                use_total_price=True
+            )
 
         elif provider.lower() == 'tariff_zones':
             # Only tariff_zone_1 is strictly required. A single-zone

--- a/src/batcontrol/dynamictariff/dynamictariff.py
+++ b/src/batcontrol/dynamictariff/dynamictariff.py
@@ -15,6 +15,8 @@ Raises:
     RuntimeError: If required fields are missing in the configuration
                      or if the provider type is unknown.
 """
+import logging
+
 from .awattar import Awattar
 from .tibber import Tibber
 from .evcc import Evcc
@@ -22,6 +24,8 @@ from .energyforecast import Energyforecast
 from .tariffzones import TariffZones
 from .network_fees import NetworkFeesFetcher
 from .dynamictariff_interface import TariffInterface
+
+logger = logging.getLogger(__name__)
 
 
 class DynamicTariff:
@@ -139,8 +143,7 @@ class DynamicTariff:
                         f'[DynTariff] Please include {field} in your configuration file'
                     )
             if provider.lower() == 'energyforecast_96':
-                import logging as _log
-                _log.getLogger(__name__).warning(
+                logger.warning(
                     '[DynTariff] Provider "energyforecast_96" is deprecated. '
                     'API v2 delivers plan-based multi-day forecasts automatically. '
                     'Use "energyforecast" instead.'

--- a/src/batcontrol/dynamictariff/dynamictariff.py
+++ b/src/batcontrol/dynamictariff/dynamictariff.py
@@ -48,6 +48,8 @@ class DynamicTariff:
         """
         selected_tariff = None
         provider = config.get('type')
+        if not provider:
+            raise RuntimeError('[DynamicTariff] Missing required field "type" in utility config')
 
         nf_cfg = nf_cfg or {}
         network_fees_enabled = nf_cfg.get('enabled', False)

--- a/src/batcontrol/dynamictariff/dynamictariff.py
+++ b/src/batcontrol/dynamictariff/dynamictariff.py
@@ -138,22 +138,29 @@ class DynamicTariff:
                     raise RuntimeError(
                         f'[DynTariff] Please include {field} in your configuration file'
                     )
+            if provider.lower() == 'energyforecast_96':
+                import logging as _log
+                _log.getLogger(__name__).warning(
+                    '[DynTariff] Provider "energyforecast_96" is deprecated. '
+                    'API v2 delivers plan-based multi-day forecasts automatically. '
+                    'Use "energyforecast" instead.'
+                )
             vat = float(config.get('vat', 0))
             markup = float(config.get('markup', 0))
             fees = float(config.get('fees', 0))
             token = config.get('apikey')
+            market_zone = config.get('market_zone', 'DE')
             selected_tariff = Energyforecast(
                 timezone,
                 token,
                 min_time_between_api_calls,
                 delay_evaluation_by_seconds,
-                target_resolution=target_resolution
+                target_resolution=target_resolution,
+                market_zone=market_zone
             )
             selected_tariff.set_price_parameters(vat, fees, markup)
             if network_fees_fetcher is not None:
                 selected_tariff.set_network_fees_fetcher(network_fees_fetcher)
-            if provider.lower() == 'energyforecast_96':
-                selected_tariff.upgrade_48h_to_96h()
 
         elif provider.lower() == 'tariff_zones':
             # Only tariff_zone_1 is strictly required. A single-zone

--- a/src/batcontrol/dynamictariff/energyforecast.py
+++ b/src/batcontrol/dynamictariff/energyforecast.py
@@ -14,9 +14,12 @@ Methods:
                 min_time_between_API_calls=0,
                 delay_evaluation_by_seconds=0,
                 target_resolution=60,
-                market_zone='DE'):
+                market_zone='DE',
+                use_total_price=False):
 
         Initializes the Energyforecast class with the specified parameters.
+        market_zone: config value 'DE' (default) is normalized to 'DE-LU' for the API.
+        use_total_price: if True, use total_ct_kwh (API-calculated) instead of price_ct_kwh.
 
     get_raw_data_from_provider(self):
         Fetches raw data from the energyforecast.de API v2.
@@ -46,8 +49,8 @@ class Energyforecast(DynamicTariffBaseclass):
         API v2 delivers complete calendar days (plan-dependent horizon).
         Data is always quarter-hourly; no resolution parameter is needed.
 
-        Supported market zones: DE (default, normalized to DE-LU), LU (normalized to DE-LU),
-        AT, FR, NL, BE, PL, DK1, DK2
+        Supported market zones (config value -> API value):
+        DE (default) -> DE-LU, LU -> DE-LU, AT, FR, NL, BE, PL, DK1, DK2
 
         use_total_price=True: use the API-calculated total_ct_kwh field (which already
         includes dynamic network fees and VAT) instead of price_ct_kwh. In this mode
@@ -160,7 +163,7 @@ class Energyforecast(DynamicTariffBaseclass):
             ).astimezone(self.timezone)
 
             diff = timestamp - current_hour_start
-            rel_interval = int(diff.total_seconds() / interval_seconds)
+            rel_interval = int(diff.total_seconds() // interval_seconds)
 
             if rel_interval >= 0:
                 if self.use_total_price:

--- a/src/batcontrol/dynamictariff/energyforecast.py
+++ b/src/batcontrol/dynamictariff/energyforecast.py
@@ -1,24 +1,23 @@
 """Energyforecast.de Class
 
-This module implements the energyforecast.de API to retrieve dynamic electricity prices.
+This module implements the energyforecast.de API v2 to retrieve dynamic electricity prices.
 It inherits from the DynamicTariffBaseclass.
 
 Classes:
-    Energyforecast: A class to interact with the energyforecast.de API
+    Energyforecast: A class to interact with the energyforecast.de API v2
                     and process electricity prices.
 
 Methods:
     __init__(self,
                 timezone,
-                price_fees: float,
-                price_markup: float,
-                vat: float,
+                token,
+                market_zone='DE-LU',
                 min_time_between_API_calls=0):
 
         Initializes the Energyforecast class with the specified parameters.
 
     get_raw_data_from_provider(self):
-        Fetches raw data from the energyforecast.de API.
+        Fetches raw data from the energyforecast.de API v2.
 
     _get_prices_native(self):
         Processes the raw data to extract and calculate electricity prices.
@@ -30,55 +29,49 @@ from .baseclass import DynamicTariffBaseclass
 
 logger = logging.getLogger(__name__)
 
+# API v2 always returns quarter-hourly data; use 4-hour refresh floor so that
+# 6 daily calls cover the full day with headroom for the forced 12:30 UTC fetch.
+_PROVIDER_MIN_INTERVAL = 4 * 60 * 60  # 14400 s
+
 
 class Energyforecast(DynamicTariffBaseclass):
-    """ Implement energyforecast.de API to get dynamic electricity prices
+    """ Implement energyforecast.de API v2 to get dynamic electricity prices
         Inherits from DynamicTariffBaseclass
 
-        Uses 48-hour forecast window for better day-ahead planning.
+        API v2 delivers complete calendar days (plan-dependent horizon).
+        Data is always quarter-hourly; no resolution parameter is needed.
 
-        Energyforecast API supports both resolutions:
-        - hourly: Hourly prices (60-minute intervals)
-        - quarter_hourly: 15-minute prices
-
-        The native resolution is set based on target_resolution to fetch
-        data at the optimal granularity from the API.
+        Supported market zones: DE-LU (default), AT, FR, NL, BE, PL, DK1, DK2
     """
 
     def __init__(self, timezone, token, min_time_between_API_calls=0,
-                 delay_evaluation_by_seconds=0, target_resolution: int = 60):
+                 delay_evaluation_by_seconds=0, target_resolution: int = 60,
+                 market_zone: str = 'DE'):
         """ Initialize Energyforecast class with parameters """
-        # Energyforecast API supports both resolutions
-        if target_resolution == 15:
-            native_resolution = 15
-            self.api_resolution = "quarter_hourly"
-        else:
-            native_resolution = 60
-            self.api_resolution = "hourly"
+        # Enforce provider-specific minimum refresh interval.
+        effective_interval = max(min_time_between_API_calls, _PROVIDER_MIN_INTERVAL)
 
+        # API v2 always delivers quarter-hourly data.
         super().__init__(
             timezone,
-            min_time_between_API_calls,
+            effective_interval,
             delay_evaluation_by_seconds,
             target_resolution=target_resolution,
-            native_resolution=native_resolution
+            native_resolution=15
         )
-        self.url = 'https://www.energyforecast.de/api/v1/predictions/next_48_hours'
+        self.url = 'https://www.energyforecast.de/api/v2/forecast'
         self.token = token
+        self.market_zone = market_zone
         self.vat = 0
         self.price_fees = 0
         self.price_markup = 0
         self.network_fees_fetcher = None
 
         logger.info(
-            'Energyforecast: Configured to fetch %s data (resolution=%d min)',
-            self.api_resolution,
-            self.native_resolution
+            'Energyforecast: Configured for market_zone=%s, refresh every %d s',
+            self.market_zone,
+            effective_interval
         )
-
-    def upgrade_48h_to_96h(self):
-        """ During initialization, we can upgrade the forecast if user wants 96h horizon """
-        self.url = 'https://www.energyforecast.de/api/v1/predictions/next_96_hours'
 
     def set_price_parameters(
             self, vat: float, price_fees: float, price_markup: float):
@@ -92,65 +85,63 @@ class Energyforecast(DynamicTariffBaseclass):
         self.network_fees_fetcher = fetcher
 
     def get_raw_data_from_provider(self):
-        """ Get raw data from energyforecast.de API and return parsed json """
-        logger.debug('Requesting price forecast from energyforecast.de API (resolution=%s)',
-                     self.api_resolution)
+        """ Get raw data from energyforecast.de API v2 and return parsed json """
+        logger.debug('Requesting price forecast from energyforecast.de API v2 (zone=%s)',
+                     self.market_zone)
         if not self.token:
             raise RuntimeError('[Energyforecast] API token is required')
         try:
-            # Request base prices without provider-side calculations
-            # We apply vat, fees, and markup locally
+            # Request base prices without provider-side calculations;
+            # we apply vat, fees, and markup locally.
             params = {
-                'resolution': self.api_resolution,
                 'token': self.token,
+                'market_zone': self.market_zone,
                 'vat': 0,
                 'fixed_cost_cent': 0
             }
             response = requests.get(self.url, params=params, timeout=30)
             response.raise_for_status()
-            if response.status_code != 200:
-                raise ConnectionError(
-                    f'[Energyforecast] API returned {response}')
         except requests.exceptions.RequestException as e:
             raise ConnectionError(
                 f'[Energyforecast] API request failed: {e}') from e
 
-        response_json = response.json()
-        return {'data': response_json}
+        return response.json()
 
     def _get_prices_native(self) -> dict[int, float]:
-        """Get hour-aligned prices at native resolution.
+        """Get 15-min-aligned prices at native resolution.
 
-        Expected API response format:
-           data: [
-              {
-                "start": "2025-11-11T06:00:35.531Z",
-                "end": "2025-11-11T06:00:35.531Z",
-                "price": 0,
-                "price_origin": "string"
-              }
-            ]
+        Expected API v2 response format:
+           {
+             "generated_at": "...",
+             "valid_until": "...",
+             "data": [
+               {
+                 "start": "2025-11-11T06:00:00+01:00",
+                 "end": "2025-11-11T06:15:00+01:00",
+                 "price_ct_kwh": 12.3456,
+                 "total_ct_kwh": 27.8901,
+                 "price_origin": "market"
+               }
+             ]
+           }
+
+        Prices from the API are in ct/kWh; we convert to EUR/kWh (/100) to
+        stay consistent with the existing fees/markup/vat config values.
 
         Returns:
-            Dict mapping interval index to price value
+            Dict mapping interval index to price value (EUR/kWh)
             Index 0 = start of current hour
-            For 15-min resolution: indices 0-3 represent the current hour
         """
         raw_data = self.get_raw_data()
         data = raw_data.get('data', [])
         now = datetime.datetime.now(self.timezone)
-        # Align to start of current hour
         current_hour_start = now.replace(minute=0, second=0, microsecond=0)
         prices = {}
 
-        # Determine interval duration in seconds
-        interval_seconds = self.native_resolution * 60
+        interval_seconds = self.native_resolution * 60  # 900 s
 
         for item in data:
-            # Parse ISO format timestamp
-            # Python <3.11 does not support 'Z' (UTC) in fromisoformat(),
-            # so we replace it with '+00:00'.
-            # Remove this workaround if only supporting Python 3.11+.
+            # Python <3.11 does not support 'Z' in fromisoformat().
             timestamp = datetime.datetime.fromisoformat(
                 item['start'].replace('Z', '+00:00')
             ).astimezone(self.timezone)
@@ -159,11 +150,12 @@ class Energyforecast(DynamicTariffBaseclass):
             rel_interval = int(diff.total_seconds() / interval_seconds)
 
             if rel_interval >= 0:
-                base_price = item['price']
+                # price_ct_kwh is in ct/kWh; convert to EUR/kWh for consistency
+                # with fees/markup/vat config values.
+                base_price = item['price_ct_kwh'] / 100
                 network_fee = 0.0
                 if self.network_fees_fetcher is not None:
-                    network_fee = self.network_fees_fetcher.get_fee_at(
-                        timestamp)
+                    network_fee = self.network_fees_fetcher.get_fee_at(timestamp)
                 end_price = (
                     (base_price * (1 + self.price_markup) +
                      self.price_fees + network_fee)

--- a/src/batcontrol/dynamictariff/energyforecast.py
+++ b/src/batcontrol/dynamictariff/energyforecast.py
@@ -11,8 +11,10 @@ Methods:
     __init__(self,
                 timezone,
                 token,
-                market_zone='DE',
-                min_time_between_API_calls=0):
+                min_time_between_API_calls=0,
+                delay_evaluation_by_seconds=0,
+                target_resolution=60,
+                market_zone='DE'):
 
         Initializes the Energyforecast class with the specified parameters.
 
@@ -65,7 +67,8 @@ class Energyforecast(DynamicTariffBaseclass):
         )
         self.url = 'https://www.energyforecast.de/api/v2/forecast'
         self.token = token
-        self.market_zone = _MARKET_ZONE_ALIASES.get(market_zone, market_zone)
+        normalized = market_zone.strip().upper()
+        self.market_zone = _MARKET_ZONE_ALIASES.get(normalized, normalized)
         self.vat = 0
         self.price_fees = 0
         self.price_markup = 0
@@ -112,7 +115,7 @@ class Energyforecast(DynamicTariffBaseclass):
         return response.json()
 
     def _get_prices_native(self) -> dict[int, float]:
-        """Get 15-min-aligned prices at native resolution.
+        """Get hour-aligned prices at native (15-min) resolution.
 
         Expected API v2 response format:
            {

--- a/src/batcontrol/dynamictariff/energyforecast.py
+++ b/src/batcontrol/dynamictariff/energyforecast.py
@@ -11,7 +11,7 @@ Methods:
     __init__(self,
                 timezone,
                 token,
-                market_zone='DE-LU',
+                market_zone='DE',
                 min_time_between_API_calls=0):
 
         Initializes the Energyforecast class with the specified parameters.
@@ -44,7 +44,8 @@ class Energyforecast(DynamicTariffBaseclass):
         API v2 delivers complete calendar days (plan-dependent horizon).
         Data is always quarter-hourly; no resolution parameter is needed.
 
-        Supported market zones: DE-LU (default), AT, FR, NL, BE, PL, DK1, DK2
+        Supported market zones: DE (default, normalized to DE-LU), LU (normalized to DE-LU),
+        AT, FR, NL, BE, PL, DK1, DK2
     """
 
     def __init__(self, timezone, token, min_time_between_API_calls=0,

--- a/src/batcontrol/dynamictariff/energyforecast.py
+++ b/src/batcontrol/dynamictariff/energyforecast.py
@@ -48,11 +48,16 @@ class Energyforecast(DynamicTariffBaseclass):
 
         Supported market zones: DE (default, normalized to DE-LU), LU (normalized to DE-LU),
         AT, FR, NL, BE, PL, DK1, DK2
+
+        use_total_price=True: use the API-calculated total_ct_kwh field (which already
+        includes dynamic network fees and VAT) instead of price_ct_kwh. In this mode
+        no local fees/markup/vat calculation is applied and the API is called without
+        vat/fixed_cost_cent overrides so the API computes the full price.
     """
 
     def __init__(self, timezone, token, min_time_between_API_calls=0,
                  delay_evaluation_by_seconds=0, target_resolution: int = 60,
-                 market_zone: str = 'DE'):
+                 market_zone: str = 'DE', use_total_price: bool = False):
         """ Initialize Energyforecast class with parameters """
         # Enforce provider-specific minimum refresh interval.
         effective_interval = max(min_time_between_API_calls, _PROVIDER_MIN_INTERVAL)
@@ -69,15 +74,18 @@ class Energyforecast(DynamicTariffBaseclass):
         self.token = token
         normalized = market_zone.strip().upper()
         self.market_zone = _MARKET_ZONE_ALIASES.get(normalized, normalized)
+        self.use_total_price = use_total_price
         self.vat = 0
         self.price_fees = 0
         self.price_markup = 0
         self.network_fees_fetcher = None
 
         logger.info(
-            'Energyforecast: Configured for market_zone=%s, refresh every %d s',
+            'Energyforecast: Configured for market_zone=%s, refresh every %d s, '
+            'price_mode=%s',
             self.market_zone,
-            effective_interval
+            effective_interval,
+            'total_ct_kwh' if use_total_price else 'price_ct_kwh+local'
         )
 
     def set_price_parameters(
@@ -98,14 +106,12 @@ class Energyforecast(DynamicTariffBaseclass):
         if not self.token:
             raise RuntimeError('[Energyforecast] API token is required')
         try:
-            # Request base prices without provider-side calculations;
-            # we apply vat, fees, and markup locally.
-            params = {
-                'token': self.token,
-                'market_zone': self.market_zone,
-                'vat': 0,
-                'fixed_cost_cent': 0
-            }
+            params = {'token': self.token, 'market_zone': self.market_zone}
+            if not self.use_total_price:
+                # Suppress API-side calculation so we can apply fees/markup/vat locally,
+                # consistent with the other locally-calculating providers (awattar).
+                params['vat'] = 0
+                params['fixed_cost_cent'] = 0
             response = requests.get(self.url, params=params, timeout=30)
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
@@ -157,17 +163,22 @@ class Energyforecast(DynamicTariffBaseclass):
             rel_interval = int(diff.total_seconds() / interval_seconds)
 
             if rel_interval >= 0:
-                # price_ct_kwh is in ct/kWh; convert to EUR/kWh for consistency
-                # with fees/markup/vat config values.
-                base_price = item['price_ct_kwh'] / 100
-                network_fee = 0.0
-                if self.network_fees_fetcher is not None:
-                    network_fee = self.network_fees_fetcher.get_fee_at(timestamp)
-                end_price = (
-                    (base_price * (1 + self.price_markup) +
-                     self.price_fees + network_fee)
-                    * (1 + self.vat)
-                )
+                if self.use_total_price:
+                    # total_ct_kwh already includes dynamic network fees, markup,
+                    # and VAT as calculated by the API. No local calculation needed.
+                    end_price = item['total_ct_kwh'] / 100
+                else:
+                    # price_ct_kwh is in ct/kWh; convert to EUR/kWh and apply
+                    # fees/markup/vat locally, consistent with awattar.
+                    base_price = item['price_ct_kwh'] / 100
+                    network_fee = 0.0
+                    if self.network_fees_fetcher is not None:
+                        network_fee = self.network_fees_fetcher.get_fee_at(timestamp)
+                    end_price = (
+                        (base_price * (1 + self.price_markup) +
+                         self.price_fees + network_fee)
+                        * (1 + self.vat)
+                    )
                 prices[rel_interval] = end_price
 
         logger.debug(

--- a/src/batcontrol/dynamictariff/energyforecast.py
+++ b/src/batcontrol/dynamictariff/energyforecast.py
@@ -33,6 +33,9 @@ logger = logging.getLogger(__name__)
 # 6 daily calls cover the full day with headroom for the forced 12:30 UTC fetch.
 _PROVIDER_MIN_INTERVAL = 4 * 60 * 60  # 14400 s
 
+# Convenience aliases: DE and LU are both served by the DE-LU market zone.
+_MARKET_ZONE_ALIASES = {'DE': 'DE-LU', 'LU': 'DE-LU'}
+
 
 class Energyforecast(DynamicTariffBaseclass):
     """ Implement energyforecast.de API v2 to get dynamic electricity prices
@@ -61,7 +64,7 @@ class Energyforecast(DynamicTariffBaseclass):
         )
         self.url = 'https://www.energyforecast.de/api/v2/forecast'
         self.token = token
-        self.market_zone = market_zone
+        self.market_zone = _MARKET_ZONE_ALIASES.get(market_zone, market_zone)
         self.vat = 0
         self.price_fees = 0
         self.price_markup = 0

--- a/tests/batcontrol/dynamictariff/test_baseclass.py
+++ b/tests/batcontrol/dynamictariff/test_baseclass.py
@@ -392,3 +392,43 @@ class TestDynamicTariffFactory:
         )
 
         assert provider.target_resolution == 60
+
+    def test_factory_energyforecast_total_price(self, timezone):
+        """Test that energyforecast_total_price is created with use_total_price=True"""
+        from batcontrol.dynamictariff.dynamictariff import DynamicTariff
+
+        config = {
+            'type': 'energyforecast_total_price',
+            'apikey': 'test_key',
+        }
+
+        provider = DynamicTariff.create_tarif_provider(
+            config, timezone, 900, 0, target_resolution=15
+        )
+
+        assert provider.use_total_price is True
+        assert provider.target_resolution == 15
+
+    def test_factory_energyforecast_total_price_requires_apikey(self, timezone):
+        """Test that energyforecast_total_price raises without apikey"""
+        from batcontrol.dynamictariff.dynamictariff import DynamicTariff
+
+        config = {'type': 'energyforecast_total_price'}
+
+        with pytest.raises(RuntimeError, match='apikey'):
+            DynamicTariff.create_tarif_provider(config, timezone, 900, 0)
+
+    def test_factory_energyforecast_total_price_no_vat_required(self, timezone):
+        """Test that energyforecast_total_price does not require vat/fees/markup"""
+        from batcontrol.dynamictariff.dynamictariff import DynamicTariff
+
+        config = {
+            'type': 'energyforecast_total_price',
+            'apikey': 'test_key',
+            'market_zone': 'AT',
+        }
+
+        provider = DynamicTariff.create_tarif_provider(config, timezone, 900, 0)
+
+        assert provider.market_zone == 'AT'
+        assert provider.use_total_price is True

--- a/tests/batcontrol/dynamictariff/test_baseclass.py
+++ b/tests/batcontrol/dynamictariff/test_baseclass.py
@@ -332,24 +332,23 @@ class TestEnergyforecastProvider:
         return pytz.timezone('Europe/Berlin')
 
     def test_energyforecast_initialization_hourly(self, timezone):
-        """Test Energyforecast provider initialization with hourly"""
+        """Test Energyforecast provider initialization with hourly target resolution"""
         from batcontrol.dynamictariff.energyforecast import Energyforecast
 
         provider = Energyforecast(timezone, 'test_token', 900, 0,
                                   target_resolution=60)
-        assert provider.native_resolution == 60
+        # API v2 always delivers quarter-hourly; native_resolution is always 15
+        assert provider.native_resolution == 15
         assert provider.target_resolution == 60
-        assert provider.api_resolution == "hourly"
 
     def test_energyforecast_initialization_15min(self, timezone):
-        """Test Energyforecast provider initialization with 15-min"""
+        """Test Energyforecast provider initialization with 15-min target resolution"""
         from batcontrol.dynamictariff.energyforecast import Energyforecast
 
         provider = Energyforecast(timezone, 'test_token', 900, 0,
                                   target_resolution=15)
         assert provider.native_resolution == 15
         assert provider.target_resolution == 15
-        assert provider.api_resolution == "quarter_hourly"
 
 
 class TestDynamicTariffFactory:

--- a/tests/batcontrol/dynamictariff/test_energyforecast.py
+++ b/tests/batcontrol/dynamictariff/test_energyforecast.py
@@ -248,7 +248,7 @@ class TestEnergyforecast(unittest.TestCase):
         self.assertIn('token is required', str(context.exception).lower())
 
     def test_market_zone_default(self):
-        """Test that the default market_zone 'DE' is normalized to 'DE-LU'"""
+        """Test that the config default 'DE' is normalized to 'DE-LU' for the API"""
         energyforecast = Energyforecast(self.timezone, self.token)
         self.assertEqual(energyforecast.market_zone, 'DE-LU')
 

--- a/tests/batcontrol/dynamictariff/test_energyforecast.py
+++ b/tests/batcontrol/dynamictariff/test_energyforecast.py
@@ -3,7 +3,7 @@ import unittest.mock
 import datetime
 import pytz
 from unittest.mock import patch
-from batcontrol.dynamictariff.energyforecast import Energyforecast
+from batcontrol.dynamictariff.energyforecast import Energyforecast, _PROVIDER_MIN_INTERVAL
 
 
 class TestEnergyforecast(unittest.TestCase):
@@ -16,117 +16,109 @@ class TestEnergyforecast(unittest.TestCase):
         self.markup = 0.03
 
     def test_basic_price_extraction(self):
-        """Test basic price extraction from API response"""
+        """Test basic price extraction from API v2 response"""
         energyforecast = Energyforecast(self.timezone, self.token)
         energyforecast.set_price_parameters(self.vat, self.fees, self.markup)
 
-        # Mock raw data - store as dict with 'data' key
+        # Mock raw data with v2 format: price_ct_kwh in ct/kWh
         raw_data = {
             'data': [
                 {
                     'start': '2024-06-20T10:00:00+02:00',
-                    'end': '2024-06-20T11:00:00+02:00',
-                    'price': 0.20,
-                    'price_origin': 'test'
+                    'end': '2024-06-20T10:15:00+02:00',
+                    'price_ct_kwh': 20.0,
+                    'total_ct_kwh': 25.0,
+                    'price_origin': 'market'
                 },
                 {
                     'start': '2024-06-20T11:00:00+02:00',
-                    'end': '2024-06-20T12:00:00+02:00',
-                    'price': 0.25,
-                    'price_origin': 'test'
+                    'end': '2024-06-20T11:15:00+02:00',
+                    'price_ct_kwh': 25.0,
+                    'total_ct_kwh': 30.0,
+                    'price_origin': 'market'
                 },
                 {
                     'start': '2024-06-20T12:00:00+02:00',
-                    'end': '2024-06-20T13:00:00+02:00',
-                    'price': 0.22,
-                    'price_origin': 'test'
+                    'end': '2024-06-20T12:15:00+02:00',
+                    'price_ct_kwh': 22.0,
+                    'total_ct_kwh': 27.0,
+                    'price_origin': 'forecast'
                 }
             ]
         }
         energyforecast.store_raw_data(raw_data)
 
-        # Mock datetime to return a specific time
         with patch('batcontrol.dynamictariff.energyforecast.datetime') as mock_datetime:
-            # Set current time to 10:00 so all prices are in the future
             mock_now = self.timezone.localize(datetime.datetime(2024, 6, 20, 10, 0, 0))
             mock_datetime.datetime.now.return_value = mock_now
             mock_datetime.datetime.fromisoformat = datetime.datetime.fromisoformat
 
             prices = energyforecast._get_prices_native()
 
-        # Verify prices are calculated with fees, markup and vat
-        # Formula: (price * (1 + markup) + fees) * (1 + vat)
+        # price_ct_kwh is divided by 100 before applying markup/fees/vat
         expected_price_0 = (0.20 * (1 + 0.03) + 0.015) * (1 + 0.20)
-        expected_price_1 = (0.25 * (1 + 0.03) + 0.015) * (1 + 0.20)
-        expected_price_2 = (0.22 * (1 + 0.03) + 0.015) * (1 + 0.20)
+        expected_price_4 = (0.25 * (1 + 0.03) + 0.015) * (1 + 0.20)
+        expected_price_8 = (0.22 * (1 + 0.03) + 0.015) * (1 + 0.20)
 
         self.assertAlmostEqual(prices[0], expected_price_0, places=5)
-        self.assertAlmostEqual(prices[1], expected_price_1, places=5)
-        self.assertAlmostEqual(prices[2], expected_price_2, places=5)
+        self.assertAlmostEqual(prices[4], expected_price_4, places=5)
+        self.assertAlmostEqual(prices[8], expected_price_8, places=5)
 
-    def test_48_hour_window(self):
-        """Test that 48-hour forecast window is supported"""
+    def test_quarter_hourly_resolution(self):
+        """Test that API v2 quarter-hourly data is parsed correctly"""
         energyforecast = Energyforecast(self.timezone, self.token)
         energyforecast.set_price_parameters(self.vat, self.fees, self.markup)
 
-        # Create 48 hours of data - use timezone-aware timestamps matching Berlin timezone
+        # Create 2 hours of quarter-hourly data (8 intervals)
         data_list = []
         base_time = self.timezone.localize(datetime.datetime(2024, 6, 20, 10, 0, 0))
-        for hour in range(48):
-            start_time = base_time + datetime.timedelta(hours=hour)
+        for i in range(8):
+            start_time = base_time + datetime.timedelta(minutes=15 * i)
             data_list.append({
                 'start': start_time.isoformat(),
-                'end': (start_time + datetime.timedelta(hours=1)).isoformat(),
-                'price': 0.20 + (hour * 0.001),  # Vary price slightly
-                'price_origin': 'test'
+                'end': (start_time + datetime.timedelta(minutes=15)).isoformat(),
+                'price_ct_kwh': 20.0 + i * 0.5,
+                'total_ct_kwh': 35.0 + i * 0.5,
+                'price_origin': 'market'
             })
 
-        raw_data = {'data': data_list}
-        energyforecast.store_raw_data(raw_data)
+        energyforecast.store_raw_data({'data': data_list})
 
-        # Mock datetime to return a specific time
         with patch('batcontrol.dynamictariff.energyforecast.datetime') as mock_datetime:
-            # Set current time to match the first data point
-            mock_now = base_time
-            mock_datetime.datetime.now.return_value = mock_now
+            mock_datetime.datetime.now.return_value = base_time
             mock_datetime.datetime.fromisoformat = datetime.datetime.fromisoformat
 
             prices = energyforecast._get_prices_native()
 
-        # Should have prices for all 48 hours
-        self.assertEqual(len(prices), 48)
-        # Verify we have consecutive hours from 0 to 47
-        for hour in range(48):
-            self.assertIn(hour, prices, f"Hour {hour} should be present")
+        self.assertEqual(len(prices), 8)
+        for i in range(8):
+            self.assertIn(i, prices)
 
     def test_timezone_handling_utc(self):
         """Test correct timezone handling with UTC timestamps"""
         energyforecast = Energyforecast(self.timezone, self.token)
         energyforecast.set_price_parameters(self.vat, self.fees, self.markup)
 
-        # Use UTC timestamp with 'Z' suffix
         raw_data = {
             'data': [
                 {
-                    'start': '2024-06-20T08:00:00Z',  # UTC time
-                    'end': '2024-06-20T09:00:00Z',
-                    'price': 0.20,
-                    'price_origin': 'test'
+                    'start': '2024-06-20T08:00:00Z',  # UTC = 10:00 Europe/Berlin
+                    'end': '2024-06-20T08:15:00Z',
+                    'price_ct_kwh': 20.0,
+                    'total_ct_kwh': 35.0,
+                    'price_origin': 'market'
                 }
             ]
         }
         energyforecast.store_raw_data(raw_data)
 
-        # Mock datetime to return Europe/Berlin time
         with patch('batcontrol.dynamictariff.energyforecast.datetime') as mock_datetime:
-            # 08:00 UTC = 10:00 Europe/Berlin in summer
             mock_now = self.timezone.localize(datetime.datetime(2024, 6, 20, 10, 0, 0))
             mock_datetime.datetime.now.return_value = mock_now
             mock_datetime.datetime.fromisoformat = datetime.datetime.fromisoformat
 
             prices = energyforecast._get_prices_native()
 
-        # Should have the price at rel_hour 0
         self.assertIn(0, prices)
 
     def test_filter_past_prices(self):
@@ -138,33 +130,36 @@ class TestEnergyforecast(unittest.TestCase):
             'data': [
                 {
                     'start': '2024-06-20T08:00:00+02:00',  # Past
-                    'end': '2024-06-20T09:00:00+02:00',
-                    'price': 0.18,
-                    'price_origin': 'test'
+                    'end': '2024-06-20T08:15:00+02:00',
+                    'price_ct_kwh': 18.0,
+                    'total_ct_kwh': 33.0,
+                    'price_origin': 'market'
                 },
                 {
-                    'start': '2024-06-20T09:00:00+02:00',  # Past
+                    'start': '2024-06-20T09:45:00+02:00',  # Past
                     'end': '2024-06-20T10:00:00+02:00',
-                    'price': 0.19,
-                    'price_origin': 'test'
+                    'price_ct_kwh': 19.0,
+                    'total_ct_kwh': 34.0,
+                    'price_origin': 'market'
                 },
                 {
-                    'start': '2024-06-20T10:00:00+02:00',  # Current/future
-                    'end': '2024-06-20T11:00:00+02:00',
-                    'price': 0.20,
-                    'price_origin': 'test'
+                    'start': '2024-06-20T10:00:00+02:00',  # Current
+                    'end': '2024-06-20T10:15:00+02:00',
+                    'price_ct_kwh': 20.0,
+                    'total_ct_kwh': 35.0,
+                    'price_origin': 'market'
                 },
                 {
-                    'start': '2024-06-20T11:00:00+02:00',  # Future
-                    'end': '2024-06-20T12:00:00+02:00',
-                    'price': 0.21,
-                    'price_origin': 'test'
+                    'start': '2024-06-20T10:15:00+02:00',  # Future
+                    'end': '2024-06-20T10:30:00+02:00',
+                    'price_ct_kwh': 21.0,
+                    'total_ct_kwh': 36.0,
+                    'price_origin': 'forecast'
                 }
             ]
         }
         energyforecast.store_raw_data(raw_data)
 
-        # Mock datetime to return 10:00
         with patch('batcontrol.dynamictariff.energyforecast.datetime') as mock_datetime:
             mock_now = self.timezone.localize(datetime.datetime(2024, 6, 20, 10, 0, 0))
             mock_datetime.datetime.now.return_value = mock_now
@@ -172,7 +167,7 @@ class TestEnergyforecast(unittest.TestCase):
 
             prices = energyforecast._get_prices_native()
 
-        # Should only have future/current prices (rel_hour >= 0)
+        # Only current and future intervals (rel_interval >= 0)
         self.assertEqual(len(prices), 2)
         self.assertIn(0, prices)
         self.assertIn(1, prices)
@@ -189,9 +184,10 @@ class TestEnergyforecast(unittest.TestCase):
             'data': [
                 {
                     'start': '2024-06-20T10:00:00+02:00',
-                    'end': '2024-06-20T11:00:00+02:00',
-                    'price': 0.30,
-                    'price_origin': 'test'
+                    'end': '2024-06-20T10:15:00+02:00',
+                    'price_ct_kwh': 30.0,  # = 0.30 EUR/kWh
+                    'total_ct_kwh': 45.0,
+                    'price_origin': 'market'
                 }
             ]
         }
@@ -204,8 +200,8 @@ class TestEnergyforecast(unittest.TestCase):
 
             prices = energyforecast._get_prices_native()
 
-        # Formula: (price * (1 + markup) + fees) * (1 + vat)
-        # (0.30 * 1.05 + 0.01) * 1.19
+        # base_price = price_ct_kwh / 100 = 0.30
+        # Formula: (0.30 * 1.05 + 0.01) * 1.19
         expected = (0.30 * 1.05 + 0.01) * 1.19
         self.assertAlmostEqual(prices[0], expected, places=5)
 
@@ -214,8 +210,7 @@ class TestEnergyforecast(unittest.TestCase):
         energyforecast = Energyforecast(self.timezone, self.token)
         energyforecast.set_price_parameters(self.vat, self.fees, self.markup)
 
-        raw_data = {'data': []}
-        energyforecast.store_raw_data(raw_data)
+        energyforecast.store_raw_data({'data': []})
 
         with patch('batcontrol.dynamictariff.energyforecast.datetime') as mock_datetime:
             mock_now = self.timezone.localize(datetime.datetime(2024, 6, 20, 10, 0, 0))
@@ -224,27 +219,22 @@ class TestEnergyforecast(unittest.TestCase):
 
             prices = energyforecast._get_prices_native()
 
-        # Should return empty dict
         self.assertEqual(len(prices), 0)
 
-    def test_missing_forecast_key(self):
+    def test_missing_data_key(self):
         """Test handling when 'data' key is missing"""
         energyforecast = Energyforecast(self.timezone, self.token)
         energyforecast.set_price_parameters(self.vat, self.fees, self.markup)
 
-        # Store dict without 'data' key to test error handling
-        raw_data = {}
-        energyforecast.store_raw_data(raw_data)
+        energyforecast.store_raw_data({})
 
         with patch('batcontrol.dynamictariff.energyforecast.datetime') as mock_datetime:
             mock_now = self.timezone.localize(datetime.datetime(2024, 6, 20, 10, 0, 0))
             mock_datetime.datetime.now.return_value = mock_now
             mock_datetime.datetime.fromisoformat = datetime.datetime.fromisoformat
 
-            # Should handle missing 'data' key gracefully
             prices = energyforecast._get_prices_native()
 
-        # Should return empty dict when 'data' key is missing
         self.assertEqual(len(prices), 0)
 
     def test_token_required(self):
@@ -252,11 +242,49 @@ class TestEnergyforecast(unittest.TestCase):
         energyforecast = Energyforecast(self.timezone, None)
         energyforecast.set_price_parameters(self.vat, self.fees, self.markup)
 
-        # Should raise RuntimeError when trying to get data without token
         with self.assertRaises(RuntimeError) as context:
             energyforecast.get_raw_data_from_provider()
 
         self.assertIn('token is required', str(context.exception).lower())
+
+    def test_market_zone_default(self):
+        """Test that market_zone defaults to DE-LU"""
+        energyforecast = Energyforecast(self.timezone, self.token)
+        self.assertEqual(energyforecast.market_zone, 'DE')
+
+    def test_market_zone_custom(self):
+        """Test that custom market_zone is passed to the API request"""
+        energyforecast = Energyforecast(self.timezone, self.token, market_zone='AT')
+        self.assertEqual(energyforecast.market_zone, 'AT')
+
+        with patch('batcontrol.dynamictariff.energyforecast.requests.get') as mock_get:
+            mock_response = unittest.mock.Mock()
+            mock_response.json.return_value = {'data': []}
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            energyforecast.get_raw_data_from_provider()
+
+            call_kwargs = mock_get.call_args
+            params = call_kwargs[1]['params'] if 'params' in call_kwargs[1] else call_kwargs[0][1]
+            self.assertEqual(params['market_zone'], 'AT')
+
+    def test_refresh_interval_floor(self):
+        """Test that refresh interval is at least 4 hours"""
+        ef_default = Energyforecast(self.timezone, self.token, min_time_between_API_calls=0)
+        self.assertEqual(ef_default.min_time_between_updates, _PROVIDER_MIN_INTERVAL)
+
+        ef_short = Energyforecast(self.timezone, self.token, min_time_between_API_calls=60)
+        self.assertEqual(ef_short.min_time_between_updates, _PROVIDER_MIN_INTERVAL)
+
+        longer = _PROVIDER_MIN_INTERVAL + 3600
+        ef_long = Energyforecast(self.timezone, self.token, min_time_between_API_calls=longer)
+        self.assertEqual(ef_long.min_time_between_updates, longer)
+
+    def test_api_v2_url(self):
+        """Test that the v2 API endpoint is used"""
+        energyforecast = Energyforecast(self.timezone, self.token)
+        self.assertIn('/api/v2/forecast', energyforecast.url)
 
 
 if __name__ == '__main__':

--- a/tests/batcontrol/dynamictariff/test_energyforecast.py
+++ b/tests/batcontrol/dynamictariff/test_energyforecast.py
@@ -248,9 +248,20 @@ class TestEnergyforecast(unittest.TestCase):
         self.assertIn('token is required', str(context.exception).lower())
 
     def test_market_zone_default(self):
-        """Test that market_zone defaults to DE-LU"""
+        """Test that market_zone default 'DE' is normalized to 'DE-LU'"""
         energyforecast = Energyforecast(self.timezone, self.token)
-        self.assertEqual(energyforecast.market_zone, 'DE')
+        self.assertEqual(energyforecast.market_zone, 'DE-LU')
+
+    def test_market_zone_aliases(self):
+        """Test that DE and LU are both normalized to DE-LU"""
+        ef_de = Energyforecast(self.timezone, self.token, market_zone='DE')
+        self.assertEqual(ef_de.market_zone, 'DE-LU')
+
+        ef_lu = Energyforecast(self.timezone, self.token, market_zone='LU')
+        self.assertEqual(ef_lu.market_zone, 'DE-LU')
+
+        ef_delu = Energyforecast(self.timezone, self.token, market_zone='DE-LU')
+        self.assertEqual(ef_delu.market_zone, 'DE-LU')
 
     def test_market_zone_custom(self):
         """Test that custom market_zone is passed to the API request"""

--- a/tests/batcontrol/dynamictariff/test_energyforecast.py
+++ b/tests/batcontrol/dynamictariff/test_energyforecast.py
@@ -248,7 +248,7 @@ class TestEnergyforecast(unittest.TestCase):
         self.assertIn('token is required', str(context.exception).lower())
 
     def test_market_zone_default(self):
-        """Test that market_zone default 'DE' is normalized to 'DE-LU'"""
+        """Test that the default market_zone 'DE' is normalized to 'DE-LU'"""
         energyforecast = Energyforecast(self.timezone, self.token)
         self.assertEqual(energyforecast.market_zone, 'DE-LU')
 

--- a/tests/batcontrol/dynamictariff/test_energyforecast.py
+++ b/tests/batcontrol/dynamictariff/test_energyforecast.py
@@ -253,12 +253,15 @@ class TestEnergyforecast(unittest.TestCase):
         self.assertEqual(energyforecast.market_zone, 'DE-LU')
 
     def test_market_zone_aliases(self):
-        """Test that DE and LU are both normalized to DE-LU"""
+        """Test that DE and LU (and lowercase variants) are normalized to DE-LU"""
         ef_de = Energyforecast(self.timezone, self.token, market_zone='DE')
         self.assertEqual(ef_de.market_zone, 'DE-LU')
 
         ef_lu = Energyforecast(self.timezone, self.token, market_zone='LU')
         self.assertEqual(ef_lu.market_zone, 'DE-LU')
+
+        ef_lower = Energyforecast(self.timezone, self.token, market_zone='de')
+        self.assertEqual(ef_lower.market_zone, 'DE-LU')
 
         ef_delu = Energyforecast(self.timezone, self.token, market_zone='DE-LU')
         self.assertEqual(ef_delu.market_zone, 'DE-LU')
@@ -276,9 +279,7 @@ class TestEnergyforecast(unittest.TestCase):
 
             energyforecast.get_raw_data_from_provider()
 
-            call_kwargs = mock_get.call_args
-            params = call_kwargs[1]['params'] if 'params' in call_kwargs[1] else call_kwargs[0][1]
-            self.assertEqual(params['market_zone'], 'AT')
+            self.assertEqual(mock_get.call_args.kwargs['params']['market_zone'], 'AT')
 
     def test_refresh_interval_floor(self):
         """Test that refresh interval is at least 4 hours"""

--- a/tests/batcontrol/dynamictariff/test_energyforecast.py
+++ b/tests/batcontrol/dynamictariff/test_energyforecast.py
@@ -298,6 +298,93 @@ class TestEnergyforecast(unittest.TestCase):
         energyforecast = Energyforecast(self.timezone, self.token)
         self.assertIn('/api/v2/forecast', energyforecast.url)
 
+    def test_total_price_uses_total_ct_kwh(self):
+        """Test that use_total_price=True reads total_ct_kwh instead of price_ct_kwh"""
+        ef = Energyforecast(self.timezone, self.token, use_total_price=True)
+
+        raw_data = {
+            'data': [
+                {
+                    'start': '2024-06-20T10:00:00+02:00',
+                    'end': '2024-06-20T10:15:00+02:00',
+                    'price_ct_kwh': 20.0,
+                    'total_ct_kwh': 35.0,
+                    'price_origin': 'market'
+                }
+            ]
+        }
+        ef.store_raw_data(raw_data)
+
+        with patch('batcontrol.dynamictariff.energyforecast.datetime') as mock_datetime:
+            mock_now = self.timezone.localize(datetime.datetime(2024, 6, 20, 10, 0, 0))
+            mock_datetime.datetime.now.return_value = mock_now
+            mock_datetime.datetime.fromisoformat = datetime.datetime.fromisoformat
+
+            prices = ef._get_prices_native()
+
+        # Must use total_ct_kwh (35.0 ct = 0.35 EUR), not price_ct_kwh (20.0 ct)
+        self.assertAlmostEqual(prices[0], 0.35, places=5)
+
+    def test_total_price_no_local_calculation(self):
+        """Test that use_total_price=True does not apply local fees/markup/vat"""
+        ef = Energyforecast(self.timezone, self.token, use_total_price=True)
+        ef.set_price_parameters(vat=0.19, price_fees=0.10, price_markup=0.05)
+
+        raw_data = {
+            'data': [
+                {
+                    'start': '2024-06-20T10:00:00+02:00',
+                    'end': '2024-06-20T10:15:00+02:00',
+                    'price_ct_kwh': 20.0,
+                    'total_ct_kwh': 35.0,
+                    'price_origin': 'market'
+                }
+            ]
+        }
+        ef.store_raw_data(raw_data)
+
+        with patch('batcontrol.dynamictariff.energyforecast.datetime') as mock_datetime:
+            mock_now = self.timezone.localize(datetime.datetime(2024, 6, 20, 10, 0, 0))
+            mock_datetime.datetime.now.return_value = mock_now
+            mock_datetime.datetime.fromisoformat = datetime.datetime.fromisoformat
+
+            prices = ef._get_prices_native()
+
+        # total_ct_kwh / 100 = 0.35, no local vat/fees/markup applied
+        self.assertAlmostEqual(prices[0], 0.35, places=5)
+
+    def test_total_price_api_call_without_overrides(self):
+        """Test that use_total_price=True does not send vat=0/fixed_cost_cent=0"""
+        ef = Energyforecast(self.timezone, self.token, use_total_price=True)
+
+        with patch('batcontrol.dynamictariff.energyforecast.requests.get') as mock_get:
+            mock_response = unittest.mock.Mock()
+            mock_response.json.return_value = {'data': []}
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            ef.get_raw_data_from_provider()
+
+            params = mock_get.call_args.kwargs['params']
+            self.assertNotIn('vat', params)
+            self.assertNotIn('fixed_cost_cent', params)
+
+    def test_default_mode_api_call_has_overrides(self):
+        """Test that default mode (use_total_price=False) still sends vat=0/fixed_cost_cent=0"""
+        ef = Energyforecast(self.timezone, self.token)
+
+        with patch('batcontrol.dynamictariff.energyforecast.requests.get') as mock_get:
+            mock_response = unittest.mock.Mock()
+            mock_response.json.return_value = {'data': []}
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            ef.get_raw_data_from_provider()
+
+            params = mock_get.call_args.kwargs['params']
+            self.assertEqual(params.get('vat'), 0)
+            self.assertEqual(params.get('fixed_cost_cent'), 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/batcontrol/dynamictariff/test_network_fees.py
+++ b/tests/batcontrol/dynamictariff/test_network_fees.py
@@ -191,11 +191,11 @@ class TestNetworkFeesIntegration(unittest.TestCase):
         raw_data = {'data': [{
             'start': fixed_ts.isoformat(),
             'end': (fixed_ts + datetime.timedelta(hours=1)).isoformat(),
-            'price': 0.10
+            'price_ct_kwh': 10.0  # 10 ct/kWh = 0.10 EUR/kWh
         }]}
         ef.store_raw_data(raw_data)
 
-        base = 0.10
+        base = 0.10  # price_ct_kwh / 100
         expected = (base + 0.005 + network_fee) * 1.19
 
         with patch('batcontrol.dynamictariff.energyforecast.datetime') as mock_dt:
@@ -225,7 +225,7 @@ class TestNetworkFeesIntegration(unittest.TestCase):
         raw_data = {'data': [
             {'start': (fixed_ts + datetime.timedelta(minutes=15 * i)).isoformat(),
              'end': (fixed_ts + datetime.timedelta(minutes=15 * (i + 1))).isoformat(),
-             'price': 0.10 + 0.01 * i}
+             'price_ct_kwh': (0.10 + 0.01 * i) * 100}  # ct/kWh, code divides by 100
             for i in range(4)
         ]}
         ef.store_raw_data(raw_data)
@@ -253,7 +253,7 @@ class TestNetworkFeesIntegration(unittest.TestCase):
         raw_data = {'data': [{
             'start': fixed_ts.isoformat(),
             'end': (fixed_ts + datetime.timedelta(hours=1)).isoformat(),
-            'price': 0.10
+            'price_ct_kwh': 10.0  # 10 ct/kWh = 0.10 EUR/kWh
         }]}
         ef.store_raw_data(raw_data)
 


### PR DESCRIPTION
## Summary

- Switch endpoint from `/api/v1/predictions/next_48_hours` to `/api/v2/forecast`
- API v2 always delivers quarter-hourly data — remove `resolution` parameter, set `native_resolution=15` unconditionally
- Remove `upgrade_48h_to_96h()`; v2 returns plan-based multi-day forecasts automatically — deprecate `energyforecast_96` provider name with a warning
- Add optional `market_zone` config parameter (default: `DE`); supports AT, FR, NL, BE, PL, DK1, DK2
- Price unit change: v1 `price` was EUR/kWh, v2 `price_ct_kwh` is ct/kWh → divide by 100, existing `fees`/`markup`/`vat` configs stay compatible
- Enforce 4h minimum refresh interval via `max()`, matching the `solarprognose` pattern (forced 12:30 UTC refresh still applies on top)

## Test plan

- [x] All 12 unit tests pass (`pytest tests/batcontrol/dynamictariff/test_energyforecast.py`)
- [x] New tests cover: quarter-hourly parsing, market_zone default/custom, refresh interval floor, v2 URL
- [x] Obsolete v1-only tests removed (`test_48_hour_window`, v1 `price` field references)
- [x] Run with a real `demo_token` against the live API to verify response parsing

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)