### PR TITLE
Update Docker image references from muexx to mastr950

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ docker run -d \
   --name batcontrol \
   -v /path/to/config:/app/config \
   -v /path/to/logs:/app/logs \
-  muexx/batcontrol:latest
+  mastr950/batcontrol:latest
 ```
 
 ### Docker-compose example
@@ -190,7 +190,7 @@ version: '3.8'
 
 services:
   batcontrol:
-    image: muexx/batcontrol:latest
+    image: mastr950/batcontrol:latest
     volumes:
       - ./config:/app/config
       - ./logs:/app/logs
@@ -211,7 +211,7 @@ docker run -d \
   -v /path/to/config:/app/config \
   -v /path/to/logs:/app/logs \
   -e TZ=Europe/Berlin \
-  muexx/batcontrol:latest
+  mastr950/batcontrol:latest
 ```
 
 #### Docker-compose example
@@ -223,7 +223,7 @@ version: '3.8'
 
 services:
   batcontrol:
-    image: muexx/batcontrol:latest
+    image: mastr950/batcontrol:latest
     volumes:
       - ./config:/app/config
       - ./logs:/app/logs


### PR DESCRIPTION
## Summary
Updates all Docker image references in the README documentation from the `muexx/batcontrol` registry to `mastr950/batcontrol`, reflecting a change in the Docker Hub namespace/maintainer.

## Changes
- Updated Docker image references in all code examples:
  - Basic Docker run example
  - Docker-compose example
  - Docker run example with timezone configuration
  - Docker-compose example with timezone configuration

All four occurrences of `muexx/batcontrol:latest` have been replaced with `mastr950/batcontrol:latest` to ensure users pull from the correct registry.

## Notes
This is a documentation-only change affecting README examples. No source code or functionality is modified.

https://claude.ai/code/session_01QxmdmZEMbLQHjpgro1yURH