### PR TITLE
Fix documentation inaccuracies found by verifying against the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ inverter:
   mqtt_password: secret
   base_topic: inverter
   capacity: 10000              # Battery capacity in Wh (required)
-  min_soc: 10                  # Minimum SoC % (default: 10)
-  max_soc: 95                  # Maximum SoC % (default: 95)
+  min_soc: 5                   # Minimum SoC % (default: 5)
+  max_soc: 100                 # Maximum SoC % (default: 100)
   max_grid_charge_rate: 5000   # Maximum charge rate in W (required)
 ```
 

--- a/docs/configuration/consumption-forecast.md
+++ b/docs/configuration/consumption-forecast.md
@@ -103,7 +103,7 @@ consumption_forecast:
     entity_id: sensor.energy_consumption        # Entity ID with consumption data
     sensor_unit: auto                           # Options: 'auto', 'Wh', or 'kWh' (since 0.5.7)
     history_days: "-7;-14;-21"               # Days to look back (negative values)
-    history_weights: "1,1,1"                 # Weight for each history period (1-10)
+    history_weights: "1;1;1"                 # Weight for each history period (1-10)
     cache_ttl_hours: 48.0                      # Cache duration in hours
     multiplier: 1.0                             # Forecast adjustment multiplier
 ```

--- a/docs/configuration/dynamic-tariff-provider.md
+++ b/docs/configuration/dynamic-tariff-provider.md
@@ -19,12 +19,12 @@ utility:
 
 
 ## awattar
-batcontrol provides to different awattar types:
+batcontrol provides two different awattar types:
 
-* `awattar_de`for German aWATTar
+* `awattar_de` for German aWATTar
 * `awattar_at` for Austrian aWATTar
 
-Please chose the corresponding version. For aWATTar you can you this configuration:
+Please choose the corresponding version. For aWATTar you can use this configuration:
 
 ```
 utility:
@@ -157,7 +157,7 @@ utility:
   type: evcc
   url: http://evcc.local:7070/api/tariff/grid
 ```
-You may need to adjust hostname + port for your setup. If evcc is running under HomeAssistant, you should you either `http://homeassistant:7070/api/tariff/grid` or `http://<homeassistant-ip>:7070/api/tariff/grid`
+You may need to adjust hostname + port for your setup. If evcc is running under HomeAssistant, you should use either `http://homeassistant:7070/api/tariff/grid` or `http://<homeassistant-ip>:7070/api/tariff/grid`
 
 ## energyforecast.de (0.5.6)
 [energyforecast.de](https://www.energyforecast.de) provides a calculated forecast for upcoming prices. Dayahead prices are populated at 14:00 GMT+2, which is after the lunch-drop in prices and prevents a good energy calculation. Based on different values, energyforecast.de calculates a price expectation with a median of 3 cent of. 
@@ -174,3 +174,26 @@ utility:
 ```
 
 To enable the paid 96h forecast, use type: energyforecast_96
+
+## Dynamic network fees (§14a EnWG)
+
+Batcontrol can add time-of-use network fees (NT/ST/HT zones according to §14a EnWG) on top of the energy prices. This only applies to providers that calculate fees locally: **awattar** and **energyforecast**. All-inclusive providers (tibber, evcc, tariff_zones) already deliver final prices and do not need this.
+
+The fee data (NET prices, excluding VAT) is fetched from [dyn-net.batcontrol.software](https://dyn-net.batcontrol.software/) and added to the raw energy price before VAT is applied. Data is cached for 12 hours, as tariffs change at most quarterly.
+
+Configure it as a top-level block (next to `utility`):
+
+```yaml
+dynamic_network_fees:
+  enabled: true         # Set to true to activate dynamic network fees
+  country: de           # Country code: de, at, ch
+  operator: syna        # Network operator ID (e.g. syna, westnetz, ggv, ewr-netz)
+  # url: https://dyn-net.batcontrol.software/api/  # Optional: override for self-hosted instance
+```
+
+| Key        | Required | Description                                                        |
+|------------|----------|--------------------------------------------------------------------|
+| `enabled`  | yes      | Master switch, defaults to `false`                                 |
+| `country`  | yes      | Country code (`de`, `at`, `ch`)                                    |
+| `operator` | yes      | Your network operator ID — see [dyn-net.batcontrol.software](https://dyn-net.batcontrol.software/) for available IDs |
+| `url`      | no       | Override the API endpoint, e.g. for a self-hosted instance         |

--- a/docs/configuration/inverter-configuration.md
+++ b/docs/configuration/inverter-configuration.md
@@ -1,7 +1,7 @@
 ## General options
 
 ### max_grid_charge_rate
-This is the uppler limit to charge the battery from grid. Value is WATT. This value should not be above the limit of your inverter.
+This is the upper limit to charge the battery from grid. Value is WATT. This value should not be above the limit of your inverter.
 
 Default:
 ```
@@ -26,7 +26,7 @@ Enable or disable the resilient wrapper for graceful outage handling. When enabl
 
 Default:
 ```
-enable_resilient_wrapper: true
+enable_resilient_wrapper: false
 ```
 
 ### outage_tolerance_minutes

--- a/docs/configuration/solar-forecast.md
+++ b/docs/configuration/solar-forecast.md
@@ -31,7 +31,7 @@ If a solar forecast provider is not available, batcontrol is running on cached v
 ## Forecast.Solar (Default)
 [Forecast Solar](https://forecast.solar/) allows a limited amount of free requests with no subscription or account. 
 
-The minimum configuration block is are:
+The minimum configuration block is:
 
 ```
   - name: Haus #name
@@ -91,7 +91,7 @@ If you run multiple installations with you account or want to split up forecasts
 * item: <location|inverter|module_field>
 * token: <item token>
 
-For further details see: [API description|(https://www.solarprognose.de/web/de/solarprediction/page/api)
+For further details see: [API description](https://www.solarprognose.de/web/de/solarprediction/page/api)
 
 ## Local evcc instance
 evcc is able to collect its own PV forecast, which can be obtained via REST API. batcontrol can make use of that.
@@ -104,7 +104,7 @@ pvinstallations:
     url: http://evcc.local:7070/api/tariff/solar
 
 ```
-If evcc is running under HomeAssistant, you should you either `http://homeassistant:7070/api/tariff/grid` or `http://<homeassistant-ip>:7070/api/tariff/grid`
+If evcc is running under HomeAssistant, you should use either `http://homeassistant:7070/api/tariff/solar` or `http://<homeassistant-ip>:7070/api/tariff/solar`
 
 ## HomeAssistant Solar Forecast ML
 The [HomeAssistant Solar Forecast ML](https://zara-toorox.github.io/) integration (available via HACS) provides machine learning-based solar forecasts directly from your HomeAssistant instance. This provider requires the HACS integration to be installed first.

--- a/docs/features/peak-shaving.md
+++ b/docs/features/peak-shaving.md
@@ -44,14 +44,16 @@ peak_shaving:
 
 ### MQTT Runtime Control
 
-Two parameters can be changed at runtime via MQTT without restarting batcontrol:
+All four parameters can be changed at runtime via MQTT without restarting batcontrol:
 
 | Topic | Accepts | Description |
 |-------|---------|-------------|
 | `{base}/peak_shaving/enabled/set` | `true` / `false` | Enable or disable peak shaving |
 | `{base}/peak_shaving/allow_full_battery_after/set` | int 0-23 | Change the target hour |
+| `{base}/peak_shaving/mode/set` | `time` / `price` / `combined` | Change the algorithm mode |
+| `{base}/peak_shaving/price_limit/set` | float | Change the price threshold in EUR/kWh; send `-1` to disable the price component |
 
-`mode` and `price_limit` are read-only at runtime and require a configuration change with restart.
+Runtime changes are temporary and are not written back to the configuration file.
 
 ## The `allow_full_battery_after` Target Hour
 
@@ -116,7 +118,7 @@ Only slots within the **production window** are considered. The production windo
 
 Both the time-based and price-based components run in parallel. The **stricter (lower non-negative) limit wins**. This is the most conservative and generally recommended mode.
 
-`price_limit` is **required** for this mode. If `price_limit` is not set, peak shaving is silently disabled entirely (both components are skipped). Make sure to always configure `price_limit` when using `combined`.
+`price_limit` is **required** for the price component. If `price_limit` is not set, the price component is disabled and `combined` falls back to **time-only** behaviour — batcontrol logs a warning at startup in this case. Set a numeric `price_limit` or change the mode to `time` to silence the warning.
 
 ## Charge Limit and Minimum Charge Rate
 
@@ -143,7 +145,7 @@ Peak shaving is automatically bypassed in the following situations:
 | Discharge not allowed | Battery is being preserved for expensive hours -- limiting PV would be counterproductive |
 | evcc is actively charging the EV | The EV already consumes excess PV |
 | EV connected in PV mode (evcc) | evcc will absorb surplus PV when its threshold is reached |
-| `price_limit` not configured (modes `price`/`combined`) | Price component cannot operate |
+| `price_limit` not configured | Price component cannot operate; `combined` falls back to time-only, `price` is effectively inactive |
 
 ## evcc Interaction
 

--- a/docs/features/price-difference-calculation.md
+++ b/docs/features/price-difference-calculation.md
@@ -10,7 +10,7 @@ This feature is introduced in version 0.4.0, but defaults to `0%` (disabled).
    - Example: `€0.05`  
    - Batcontrol checks if the future price is at least `€0.05` higher than the current price.
 
-2. **Relative threshold** (`min_price_difference_relative`)  
+2. **Relative threshold** (`min_price_difference_rel`)  
    - Example: `0.10` (i.e., 10% of the current price)  
    - Batcontrol multiplies the current price by `0.10`.  
    - If `current_price = €0.50`, the difference is `€0.05`.  

--- a/docs/getting-started/how-batcontrol-works.md
+++ b/docs/getting-started/how-batcontrol-works.md
@@ -28,18 +28,18 @@ Batcontrol runs in a continuous loop, evaluating conditions **every 3 minutes**:
 Batcontrol combines three critical forecasts to make intelligent decisions:
 
 ### 1. Electricity Price Forecast
-- **Source**: Dynamic tariff providers (Tibber, aWATTar, evcc)
+- **Source**: Dynamic tariff providers (Tibber, aWATTar, evcc, energyforecast.de, static tariff zones) — see [Dynamic Tariff Provider](../configuration/dynamic-tariff-provider.md)
 - **Data**: Hourly electricity prices for the next 24-48 hours
 - **Purpose**: Identifies when electricity is cheapest for charging
 
 ### 2. Solar Production Forecast
-- **Source**: Solar forecast APIs (Forecast.Solar, Solarprognose, evcc)
+- **Source**: Solar forecast APIs (Forecast.Solar, Solarprognose, evcc, HomeAssistant Solar Forecast ML) — see [Solar Forecast](../configuration/solar-forecast.md)
 - **Data**: Expected PV generation based on weather predictions
 - **Configuration**: Your PV system specifications (kWp, orientation, location)
 - **Purpose**: Predicts available solar energy
 
 ### 3. Consumption Forecast
-- **Source**: Load profile CSV file scaled to your annual consumption
+- **Source**: Load profile CSV file scaled to your annual consumption, or your actual historical data via the HomeAssistant API — see [Consumption Forecast](../configuration/consumption-forecast.md)
 - **Data**: Expected household energy usage patterns
 - **Purpose**: Estimates energy demand throughout the day
 
@@ -114,7 +114,7 @@ Based on the forecasts and current battery state, batcontrol puts your inverter 
 - Above this SOC, battery always discharges freely
 - Prevents over-charging and ensures availability
 
-**`max_charging_from_grid_limit`** (default: 89%)
+**`max_charging_from_grid_limit`** (default: 80%)
 - Maximum SOC for grid charging
 - Must be lower than discharge limit to prevent oscillation
 

--- a/docs/integrations/evcc-connection.md
+++ b/docs/integrations/evcc-connection.md
@@ -55,16 +55,7 @@ evcc:
 
 ### TLS/SSL Support
 
-> ⚠️ **Note**: TLS/SSL support is currently **untested**. Use with caution in production environments.
-
-```yaml
-evcc:
-  tls: true
-  cafile: /etc/ssl/certs/ca-certificates.crt
-  certfile: /etc/ssl/certs/client.crt
-  keyfile: /etc/ssl/certs/client.key
-  tls_version: tlsv1.2
-```
+> ⚠️ **Note**: TLS/SSL support is currently **untested and known to be non-functional** (same limitation as in the [MQTT API](mqtt-api.md)). Keep MQTT traffic on a trusted local network.
 
 ### Battery Management Options
 
@@ -77,7 +68,7 @@ evcc:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `block_battery_while_charging` | boolean | `true` | If `true`: Block battery discharge while EV is charging. If `false`: Battery discharge follows normal batcontrol algorithm regardless of EV charging status |
-| `battery_halt_topic` | string | `evcc/site/bufferSoc` | Topic for dynamic discharge limit control |
+| `battery_halt_topic` | string | *unset (disabled)* | Topic for dynamic discharge limit control, e.g. `evcc/site/bufferSoc` |
 
 ## Battery Halt Topic (Advanced)
 
@@ -110,6 +101,14 @@ Batcontrol subscribes to the following evcc MQTT topics:
 - `evcc/loadpoints/1/charging` - Loadpoint 1 charging status (`true`/`false`)
 - `evcc/loadpoints/2/charging` - Loadpoint 2 charging status (`true`/`false`)
 - Additional loadpoints as configured
+
+### Loadpoint Mode and Connection State (derived automatically)
+For every configured `.../charging` topic, batcontrol additionally subscribes to the sibling topics:
+
+- `evcc/loadpoints/1/mode` - Loadpoint charging mode (`pv`, `now`, `minpv`, `off`)
+- `evcc/loadpoints/1/connected` - Whether an EV is connected (`true`/`false`)
+
+These are used by [peak shaving](../features/peak-shaving.md): peak shaving is automatically disabled while evcc is actively charging or while an EV is connected in PV mode, and re-enabled when the EV disconnects or the mode changes.
 
 ### Buffer SOC (Optional)
 - `evcc/site/bufferSoc` - Dynamic discharge threshold (integer 0-100)
@@ -238,6 +237,6 @@ When using both batcontrol and evcc with Home Assistant:
 ## Security Considerations
 
 - Use authentication for production MQTT brokers
-- Consider TLS encryption for remote connections (though currently untested)
+- TLS encryption is currently not functional (see above) — keep MQTT traffic on a trusted local network
 - Ensure MQTT user has appropriate topic permissions
 - Keep MQTT credentials secure and unique

--- a/docs/integrations/mqtt-api.md
+++ b/docs/integrations/mqtt-api.md
@@ -44,24 +44,7 @@ mqtt:
 
 ### TLS/SSL Configuration
 
-> ⚠️ **Note**: TLS/SSL support is currently **untested**. Use with caution in production environments.
-
-```yaml
-mqtt:
-  tls: true
-  cafile: /etc/ssl/certs/ca-certificates.crt
-  certfile: /etc/ssl/certs/client.crt
-  keyfile: /etc/ssl/certs/client.key
-  tls_version: tlsv1.2
-```
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `tls` | boolean | `false` | Enable TLS/SSL encryption |
-| `cafile` | string | `/etc/ssl/certs/ca-certificates.crt` | Path to Certificate Authority file |
-| `certfile` | string | `/etc/ssl/certs/client.crt` | Path to client certificate file |
-| `keyfile` | string | `/etc/ssl/certs/client.key` | Path to client private key file |
-| `tls_version` | string | `tlsv1.2` | TLS version to use (`tlsv1.2`, `tlsv1.3`) |
+> ⚠️ **Note**: TLS/SSL support is currently **untested and known to be non-functional**: the implementation expects the certificate options nested below `tls`, while the enable check expects a boolean — these requirements contradict each other. Track progress or report your use case in the project issues before relying on TLS.
 
 ## Home Assistant Auto-Discovery
 
@@ -96,16 +79,25 @@ Batcontrol publishes data to the following topic structure (assuming base topic 
 - `house/batcontrol/mode` - Current operational mode:
   - `-1` = Charge from Grid
   - `0` = Avoid Discharge
+  - `8` = Limit Battery Charge Rate ([peak shaving](../features/peak-shaving.md))
   - `10` = Discharge Allowed
 - `house/batcontrol/charge_rate` - Current charge rate in W
-- `house/batcontrol/discharge_blocked` - Whether discharge is blocked (`True`/`False`)
+- `house/batcontrol/limit_battery_charge_rate` - Dynamic battery charge rate limit in W
+- `house/batcontrol/discharge_blocked` - Whether discharge is blocked (`true`/`false`)
+- `house/batcontrol/api_override_active` - Whether a temporary external/API override is active (`true`/`false`)
+- `house/batcontrol/control_source` - Source that last selected the current control state (`api` or `optimizer`)
 
 ### Battery Information
-- `house/batcontrol/SOC` - State of Charge in % (formatted as 3-digit integer, e.g., `069`)
+- `house/batcontrol/SOC` - State of Charge in % (two decimal places, e.g., `69.00`)
 - `house/batcontrol/max_energy_capacity` - Maximum battery capacity in Wh
 - `house/batcontrol/stored_energy_capacity` - Energy stored in battery in Wh
 - `house/batcontrol/stored_usable_energy_capacity` - Usable energy stored in battery in Wh (considering min SOC)
 - `house/batcontrol/reserved_energy_capacity` - Energy reserved for discharge in Wh
+
+### Solar Surplus Information
+- `house/batcontrol/solar_surplus_wh` - Expected solar surplus energy in Wh (>0 means usable surplus available)
+- `house/batcontrol/solar_active` - Whether solar is currently producing (`true`/`false`)
+- `house/batcontrol/night_surplus_wh` - Expected battery surplus in Wh at start of next production window
 
 ### Configuration Limits
 - `house/batcontrol/always_allow_discharge_limit` - Always discharge limit (0.0-1.0)
@@ -113,6 +105,18 @@ Batcontrol publishes data to the following topic structure (assuming base topic 
 - `house/batcontrol/always_allow_discharge_limit_capacity` - Always discharge limit in Wh
 - `house/batcontrol/max_charging_from_grid_limit` - Max charging from grid limit (0.0-1.0)
 - `house/batcontrol/max_charging_from_grid_limit_percent` - Max charging from grid limit in %
+- `house/batcontrol/min_grid_charge_soc` - Optional minimum grid-charge target (0.0-1.0)
+- `house/batcontrol/min_grid_charge_soc_percent` - Optional minimum grid-charge target in %
+- `house/batcontrol/production_offset` - Production offset multiplier (`1.0` = 100%, `0.8` = 80%, etc.)
+
+### Peak Shaving
+See [Peak Shaving](../features/peak-shaving.md) for details:
+
+- `house/batcontrol/peak_shaving/enabled` - Whether peak shaving is enabled (`true`/`false`)
+- `house/batcontrol/peak_shaving/mode` - Active mode (`time`, `price`, or `combined`)
+- `house/batcontrol/peak_shaving/allow_full_battery_after` - Target hour (0-23)
+- `house/batcontrol/peak_shaving/charge_limit` - Current charge limit in W (`-1` = inactive / no limit)
+- `house/batcontrol/peak_shaving/price_limit` - Price threshold in EUR/kWh
 
 ### Price Information
 - `house/batcontrol/min_price_difference` - Minimum price difference in EUR (e.g., `0.050`)
@@ -144,13 +148,24 @@ Batcontrol publishes data to the following topic structure (assuming base topic 
 Batcontrol listens to the following `/set` topics for remote control:
 
 ### Main Control
-- `house/batcontrol/mode/set` - Set operational mode (send `-1`, `0`, or `10`)
+- `house/batcontrol/mode/set` - Set operational mode (send `-1`, `0`, `8`, or `10`)
 - `house/batcontrol/charge_rate/set` - Set charge rate in W (automatically sets mode to `-1`)
+- `house/batcontrol/limit_battery_charge_rate/set` - Set dynamic battery charge rate limit in W
 
 ### Configuration
 - `house/batcontrol/always_allow_discharge_limit/set` - Set always discharge limit (0.0-1.0)
 - `house/batcontrol/max_charging_from_grid_limit/set` - Set max charging from grid limit (0.0-1.0)
 - `house/batcontrol/min_price_difference/set` - Set minimum price difference in EUR
+- `house/batcontrol/min_price_difference_rel/set` - Set relative minimum price difference (e.g. `0.10` for 10%)
+- `house/batcontrol/production_offset/set` - Set production offset multiplier (0.0-2.0)
+
+### Peak Shaving
+- `house/batcontrol/peak_shaving/enabled/set` - Enable or disable peak shaving (`true`/`false`)
+- `house/batcontrol/peak_shaving/mode/set` - Set mode (`time`, `price`, or `combined`)
+- `house/batcontrol/peak_shaving/allow_full_battery_after/set` - Set target hour (0-23)
+- `house/batcontrol/peak_shaving/price_limit/set` - Set price threshold in EUR/kWh (`-1` disables the price component)
+
+All `/set` changes are temporary runtime overrides and are not written back to the configuration file.
 
 ### Inverter Control (per inverter, e.g., inverter 0)
 - `house/batcontrol/inverters/0/max_grid_charge_rate/set` - Set max grid charge rate in W
@@ -224,22 +239,6 @@ mqtt:
   auto_discover_topic: homeassistant
 ```
 
-### Secure TLS Setup (Untested)
-```yaml
-mqtt:
-  enabled: true
-  broker: secure-mqtt.example.com
-  port: 8883
-  topic: batcontrol
-  username: secure_user
-  password: secure_password
-  tls: true
-  cafile: /path/to/ca-cert.pem
-  certfile: /path/to/client-cert.pem
-  keyfile: /path/to/client-key.pem
-  tls_version: tlsv1.3
-```
-
 ## Troubleshooting
 
 ### Common Issues
@@ -274,6 +273,6 @@ This will provide detailed information about MQTT connections, published message
 ## Security Considerations
 
 - Always use authentication (`username`/`password`) in production
-- Consider using TLS encryption for remote connections (though currently untested)
+- TLS encryption is currently not functional (see above) — keep MQTT traffic on a trusted local network
 - Limit MQTT user permissions to only necessary topics
 - Use strong, unique passwords for MQTT authentication

--- a/docs/integrations/mqtt-inverter.md
+++ b/docs/integrations/mqtt-inverter.md
@@ -16,11 +16,11 @@ The MQTT inverter driver uses batcontrol's shared MQTT connection (configured in
 All topics follow the pattern: `<batcontrol_base_topic>/inverters/$num/<subtopic>`
 
 Where:
-- `<batcontrol_base_topic>` is the MQTT base topic from your main MQTT configuration
+- `<batcontrol_base_topic>` is the MQTT base topic from your main MQTT configuration (the `topic` key in the `mqtt` section)
 - `$num` is the inverter number (e.g., 0, 1, 2), **not** the literal string "$num"
 - `<subtopic>` is the specific status or command topic
 
-**Example:** If your base_topic is "batcontrol" and inverter number is 0, topics would be:
+**Example:** If your base topic is "batcontrol" and inverter number is 0, topics would be:
 - `batcontrol/inverters/0/status/soc`
 - `batcontrol/inverters/0/command/mode`
 
@@ -68,9 +68,9 @@ Configure the MQTT connection in batcontrol's main MQTT API section (not in the 
 mqtt:
   broker: 192.168.1.100
   port: 1883
-  user: batcontrol
+  username: batcontrol
   password: secret
-  base_topic: batcontrol  # Base topic for all MQTT messages
+  topic: batcontrol  # Base topic for all MQTT messages
 ```
 
 ### Inverter Configuration
@@ -83,7 +83,7 @@ inverter:
   max_soc: 100                 # Maximum SoC % (default: 100)
   max_grid_charge_rate: 5000   # Maximum charge rate in W (required)
   cache_ttl: 120               # Cache TTL for SOC values in seconds (default: 120)
-  base_topic: batcontrol/inverter/0  # Optional: override default topic structure
+  base_topic: batcontrol/inverters/0  # Optional: override default topic structure
 ```
 
 ### Configuration Parameters
@@ -96,7 +96,7 @@ inverter:
 | `min_soc` | No | 5 | Minimum State of Charge in % |
 | `max_soc` | No | 100 | Maximum State of Charge in % |
 | `cache_ttl` | No | 120 | Cache TTL for SOC values in seconds |
-| `base_topic` | No | `<mqtt.base_topic>/inverters/<num>` | Custom base topic for inverter MQTT messages |
+| `base_topic` | No | `<mqtt.topic>/inverters/<num>` | Custom base topic for inverter MQTT messages |
 
 ## External Bridge Requirements
 
@@ -254,7 +254,7 @@ Discovered entities include:
 
 ### Custom Topic Structure
 
-By default, the MQTT inverter uses the topic structure `<mqtt.base_topic>/inverters/<inverter_num>`. You can override this:
+By default, the MQTT inverter uses the topic structure `<mqtt.topic>/inverters/<inverter_num>`, where `<mqtt.topic>` is the base topic from the main MQTT configuration. You can override this:
 
 ```yaml
 inverter:

--- a/docs/integrations/mqtt-inverter.md
+++ b/docs/integrations/mqtt-inverter.md
@@ -254,7 +254,7 @@ Discovered entities include:
 
 ### Custom Topic Structure
 
-By default, the MQTT inverter uses the topic structure `<mqtt.base_topic>/inverter/<inverter_num>`. You can override this:
+By default, the MQTT inverter uses the topic structure `<mqtt.base_topic>/inverters/<inverter_num>`. You can override this:
 
 ```yaml
 inverter:


### PR DESCRIPTION
## Summary

Follow-up to #377: all 13 documentation pages were systematically verified against the source code. This PR fixes factual errors (code is the source of truth), documents missing features, and cleans up typos/broken links. `mkdocs build --strict` passes.

### Factual corrections

| Doc claim | Actual behavior (code) |
|-----------|------------------------|
| `enable_resilient_wrapper` default `true` | default is `false` (`inverter/inverter.py`) |
| README MQTT example: SoC defaults 10/95 | `DEFAULT_MIN_SOC=5`, `DEFAULT_MAX_SOC=100` (`inverter/baseclass.py`) |
| `max_charging_from_grid_limit` default 89% | default is `0.8` (`core.py`) |
| Config key `min_price_difference_relative` | key is `min_price_difference_rel` |
| `history_weights: "1,1,1"` (commas) | parser splits on semicolons only — comma example would raise `ValueError` (`forecastconsumption/consumption.py`) |
| evcc solar endpoint `/api/tariff/grid` | correct endpoint is `/api/tariff/solar` |
| `SOC` topic "3-digit integer, e.g. 069" | published as two-decimal float (`f'{soc:.2f}'`) |
| `discharge_blocked` publishes `True`/`False` | publishes lowercase `true`/`false` |
| peak_shaving `mode`/`price_limit` "read-only at runtime" | both have registered `/set` callbacks (`core.py`) |
| `combined` without `price_limit` "silently disabled entirely" | falls back to time-only with a startup warning (`logic_interface.py`) |
| `battery_halt_topic` default `evcc/site/bufferSoc` | no default — feature disabled when unset |
| MQTT inverter default topic `inverter/<num>` | `inverters/<num>` (plural) |

### Previously undocumented features (added)

- **Dynamic network fees (§14a EnWG)**: new section in the dynamic tariff page covering the `dynamic_network_fees` block (country/operator/url, applies to awattar/energyforecast, 12 h cache)
- **MQTT API**: mode `8` (limit battery charge rate / peak shaving) in both mode lists; missing published topics (`min_grid_charge_soc(_percent)`, `limit_battery_charge_rate`, `production_offset`, `api_override_active`, `control_source`, `solar_surplus_wh`, `solar_active`, `night_surplus_wh`, `peak_shaving/*`) and the matching `/set` input topics
- **evcc**: derived `mode`/`connected` loadpoint subscriptions and their peak-shaving interaction (auto-disable while charging or EV connected in PV mode)
- Architecture overview now mentions all available tariff/solar/consumption providers

### Side finding (not fixed here, doc adjusted)

The TLS handling in `mqtt_api.py` and `evcc_api.py` is self-contradictory: `if config['tls'] is True:` followed by `config['tls']['ca_certs']` — a boolean crashes the subscript, a dict never passes the check. TLS is effectively unusable, so the docs now say "non-functional" instead of "untested" and the misleading flat-key examples were removed. A separate code fix (or removal) may be worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)