### PR TITLE
Simplify resilient wrapper: fail-fast → communication error → outage error

### DIFF
--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -104,9 +104,8 @@ inverter:
                         # Only affects mode 8; ignored in other modes.
   # fronius_inverter_id: '1' # Optional: ID of the inverter in Fronius API (default: '1')
   # fronius_controller_id: '0' # Optional: ID of the controller in Fronius API (default: '0')
-  enable_resilient_wrapper: false # Enable resilient wrapper for graceful outage handling (default: false)
+  enable_resilient_wrapper: false # Skip a control cycle on transient inverter outages instead of terminating (default: false)
   outage_tolerance_minutes: 24 # Minutes to tolerate inverter outages before terminating (default: 24)
-  retry_backoff_seconds: 60 # Seconds to wait before retrying after a failure (default: 60)
 
 #--------------------------
 #  Dynamic Tariff Provider

--- a/docs/configuration/inverter-configuration.md
+++ b/docs/configuration/inverter-configuration.md
@@ -26,6 +26,8 @@ Enable or disable the resilient wrapper for graceful outage handling. When enabl
 
 Errors before the first successful control command still fail fast, so configuration mistakes are caught at startup.
 
+Why not just let batcontrol crash and rely on the container restart policy? Without the wrapper, every inverter outage terminates the process, and `restart: unless-stopped` brings it straight back up. During a multi-minute outage this turns into a tight restart loop, and **each restart re-fetches the price and solar forecasts from their providers**. Repeated cold starts can therefore run into provider rate limits (e.g. Awattar/Tibber for prices, Forecast.Solar/SolarPrognose for solar), which can leave batcontrol without fresh data even after the inverter recovers. Keeping the process alive and skipping cycles avoids hammering both the inverter and the data providers.
+
 Default:
 ```
 enable_resilient_wrapper: false

--- a/docs/configuration/inverter-configuration.md
+++ b/docs/configuration/inverter-configuration.md
@@ -22,7 +22,9 @@ Default:
 These options enable graceful handling of temporary inverter outages (e.g., during firmware upgrades or network interruptions).
 
 ### enable_resilient_wrapper
-Enable or disable the resilient wrapper for graceful outage handling. When enabled, temporary inverter failures are handled gracefully by caching values and applying retry backoff. This helps batcontrol survive brief connection losses without terminating.
+Enable or disable the resilient wrapper for graceful outage handling. When enabled, a temporary inverter failure makes batcontrol skip the current control cycle and retry on the next scheduled run, instead of terminating. No decisions are made on stale data - the inverter is simply read again next cycle. This helps batcontrol survive brief connection losses (e.g. firmware upgrades) without exiting.
+
+Errors before the first successful control command still fail fast, so configuration mistakes are caught at startup.
 
 Default:
 ```
@@ -30,19 +32,11 @@ enable_resilient_wrapper: false
 ```
 
 ### outage_tolerance_minutes
-The maximum duration (in minutes) to tolerate inverter outages before terminating. This allows batcontrol to survive firmware upgrades or network issues up to the specified time window. After this timeout, batcontrol will give up and exit with an error.
+The maximum duration (in minutes) to tolerate inverter outages before terminating. While the inverter is unreachable, each control cycle is skipped. If communication is not restored within this window, batcontrol gives up and exits with an error.
 
 Default:
 ```
 outage_tolerance_minutes: 24  # 24 minutes
-```
-
-### retry_backoff_seconds
-The time to wait (in seconds) before retrying after an inverter failure. This prevents hammering an unavailable inverter during the outage period and allows time for recovery.
-
-Default:
-```
-retry_backoff_seconds: 60  # 60 seconds
 ```
 
 ## mqtt

--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -65,8 +65,9 @@ def _tolerate_inverter_outage(func):
 
     These run on background threads in response to MQTT/evcc events. If the
     inverter is briefly unavailable the request is dropped and logged; the
-    next scheduled run() reconciles the inverter state. Termination on a
-    permanent outage is driven by the main run() loop, not background threads.
+    next scheduled run() reconciles the inverter state. Background calls
+    advance the shared outage clock in the resilient wrapper; termination on
+    a permanent outage is only triggered from the main run() loop.
     """
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
@@ -498,7 +499,7 @@ class Batcontrol:
             self.allow_discharging()
 
     def run(self):
-        """ One control cycle. Aborts cleanly on a transient inverter outage.
+        """One control cycle. Aborts cleanly on a transient inverter outage.
 
         Communication failures are turned into InverterCommunicationError by
         the resilient wrapper. We skip the cycle and let the scheduler retry on

--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -15,6 +15,7 @@ import time
 import os
 import logging
 import platform
+import functools
 
 import dataclasses
 from typing import Optional
@@ -33,6 +34,7 @@ from .logic import PeakShavingConfig
 
 from .dynamictariff import DynamicTariff as tariff_factory
 from .inverter import Inverter as inverter_factory
+from .inverter import InverterError, InverterCommunicationError
 from .forecastsolar import ForecastSolar as solar_factory
 
 from .forecastconsumption import Consumption as consumption_factory
@@ -56,6 +58,27 @@ CONTROL_SOURCE_API = 'api'
 CONTROL_SOURCE_OPTIMIZER = 'optimizer'
 
 logger = logging.getLogger(__name__)
+
+
+def _tolerate_inverter_outage(func):
+    """Swallow inverter outages for externally triggered (API/evcc) actions.
+
+    These run on background threads in response to MQTT/evcc events. If the
+    inverter is briefly unavailable the request is dropped and logged; the
+    next scheduled run() reconciles the inverter state. Termination on a
+    permanent outage is driven by the main run() loop, not background threads.
+    """
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return func(self, *args, **kwargs)
+        except InverterError as e:
+            logger.warning(
+                "Inverter unavailable during '%s', ignoring external request: %s",
+                func.__name__, e,
+            )
+            return None
+    return wrapper
 
 
 def _parse_optional_ratio(value, config_key: str) -> Optional[float]:
@@ -475,6 +498,22 @@ class Batcontrol:
             self.allow_discharging()
 
     def run(self):
+        """ One control cycle. Aborts cleanly on a transient inverter outage.
+
+        Communication failures are turned into InverterCommunicationError by
+        the resilient wrapper. We skip the cycle and let the scheduler retry on
+        the next run - no decision is made on stale data. A permanent outage
+        surfaces as InverterOutageError, which propagates to terminate.
+        """
+        try:
+            self._run_once()
+        except InverterCommunicationError as e:
+            logger.warning(
+                "Inverter unreachable this cycle (%s). "
+                "Skipping control cycle, will retry on next run.", e
+            )
+
+    def _run_once(self):
         """ Main calculation & control loop """
         logger.debug('Timeslots are in %d-minute intervals', self.time_resolution)
 
@@ -940,6 +979,7 @@ class Batcontrol:
         """ Get the max charging from grid limit for battery control """
         return self.max_charging_from_grid_limit
 
+    @_tolerate_inverter_outage
     def set_discharge_blocked(self, discharge_blocked) -> None:
         """ Avoid discharging if an external block is received,
             but take care of the always_allow_discharge_limit.
@@ -1007,6 +1047,7 @@ class Batcontrol:
             # Trigger Inverter
             self.inverter.refresh_api_values()
 
+    @_tolerate_inverter_outage
     def api_set_mode(self, mode: int):
         """ Log and change config run mode of inverter(s) from external call """
         # Check if mode is valid
@@ -1043,6 +1084,7 @@ class Batcontrol:
         else:
             self.__set_control_source(CONTROL_SOURCE_API)
 
+    @_tolerate_inverter_outage
     def api_set_charge_rate(self, charge_rate: int):
         """ Log and change config charge_rate and activate charging."""
         if charge_rate < 0:
@@ -1060,6 +1102,7 @@ class Batcontrol:
         else:
             self.__set_control_source(CONTROL_SOURCE_API)
 
+    @_tolerate_inverter_outage
     def api_set_limit_battery_charge_rate(self, limit: int):
         """ Set dynamic battery charge rate limit from external call
 

--- a/src/batcontrol/inverter/__init__.py
+++ b/src/batcontrol/inverter/__init__.py
@@ -1,3 +1,7 @@
 from .inverter import Inverter
-from .exceptions import InverterOutageError
+from .exceptions import (
+    InverterError,
+    InverterCommunicationError,
+    InverterOutageError,
+)
 from .resilient_wrapper import ResilientInverterWrapper

--- a/src/batcontrol/inverter/exceptions.py
+++ b/src/batcontrol/inverter/exceptions.py
@@ -1,22 +1,34 @@
 """
-Custom exceptions for inverter module.
+Custom exceptions for the inverter module.
 
-These exceptions provide specific error handling for inverter-related failures,
-particularly for handling temporary outages gracefully.
+These let batcontrol distinguish three situations:
+
+1. Configuration errors         -> fail immediately on the first run.
+2. Transient communication loss -> skip the current control cycle and retry
+   on the next scheduled run (InverterCommunicationError).
+3. Permanent outage             -> terminate after the tolerance window
+   (InverterOutageError).
 """
 
 
-class InverterOutageError(Exception):
+class InverterError(Exception):
+    """Base class for inverter communication problems."""
+
+
+class InverterCommunicationError(InverterError):
     """
-    Exception raised when an inverter has been unreachable for too long.
+    Raised when an inverter call fails after initialization.
 
-    This exception is raised after the configured outage tolerance period
-    (default: 24 minutes) has elapsed without successful communication
-    with the inverter. This allows batcontrol to distinguish between:
+    Signals the caller to abort the current control cycle. batcontrol retries
+    on the next scheduled run, so no decision is ever made on stale data.
+    """
 
-    1. Configuration errors (fail immediately on first run)
-    2. Transient outages (tolerate for up to 24 minutes using cached values)
-    3. Permanent outages (terminate after 24 minutes)
+
+class InverterOutageError(InverterError):
+    """
+    Raised when the inverter stays unreachable beyond the tolerance window.
+
+    Terminates batcontrol - the inverter is considered permanently down.
 
     Attributes:
         message: Explanation of the error

--- a/src/batcontrol/inverter/inverter.py
+++ b/src/batcontrol/inverter/inverter.py
@@ -129,7 +129,5 @@ class Inverter:
             inverter,
             outage_tolerance_seconds=outage_tolerance,
         )
-        # Preserve inverter_num on wrapper
-        resilient_inverter.inverter_num = inverter.inverter_num
 
         return resilient_inverter

--- a/src/batcontrol/inverter/inverter.py
+++ b/src/batcontrol/inverter/inverter.py
@@ -10,7 +10,6 @@ from .inverter_interface import InverterInterface
 from .resilient_wrapper import (
     ResilientInverterWrapper,
     DEFAULT_OUTAGE_TOLERANCE_SECONDS,
-    DEFAULT_RETRY_BACKOFF_SECONDS
 )
 
 logger = logging.getLogger(__name__)
@@ -121,22 +120,14 @@ class Inverter:
             DEFAULT_OUTAGE_TOLERANCE_SECONDS / 60
         ) * 60  # Convert to seconds
 
-        # Get retry backoff from config (default: 60 seconds)
-        retry_backoff = config.get(
-            'retry_backoff_seconds',
-            DEFAULT_RETRY_BACKOFF_SECONDS
-        )
-
         logger.info(
             'Wrapping inverter with resilient wrapper '
-            '(outage tolerance: %.1f min, retry backoff: %.0fs)',
+            '(outage tolerance: %.1f min)',
             outage_tolerance / 60,
-            retry_backoff
         )
         resilient_inverter = ResilientInverterWrapper(
             inverter,
             outage_tolerance_seconds=outage_tolerance,
-            retry_backoff_seconds=retry_backoff
         )
         # Preserve inverter_num on wrapper
         resilient_inverter.inverter_num = inverter.inverter_num

--- a/src/batcontrol/inverter/resilient_wrapper.py
+++ b/src/batcontrol/inverter/resilient_wrapper.py
@@ -1,45 +1,47 @@
-"""Resilient Inverter Wrapper - adds fault tolerance to any inverter backend.
+"""Resilient Inverter Wrapper - thin fault-tolerance layer.
 
-During temporary outages (firmware upgrades, network blips):
-- Read operations return cached values for up to 24 minutes (configurable).
-- Write operations (set_mode_*) are discarded and retried next cycle.
-- After the tolerance window expires, InverterOutageError is raised.
+Concept (deliberately simple - no caching, no backoff timers):
 
-Before the first successful set_mode_* call, all errors propagate
-immediately so configuration mistakes are caught at startup.
+- Before the first successful set_mode_* call every error propagates
+  unchanged, so configuration mistakes fail fast at startup.
+- After initialization an inverter failure raises InverterCommunicationError.
+  The caller (core.run) aborts the current control cycle and retries on the
+  next scheduled run - the loop interval is the natural backoff, and no
+  decision is ever made on stale data.
+- If the inverter stays unreachable past the tolerance window, the failure is
+  escalated to InverterOutageError, which terminates batcontrol.
 """
 
 import time
 import logging
-from typing import Optional
 
 from .inverter_interface import InverterInterface
-from .exceptions import InverterOutageError
+from .exceptions import InverterCommunicationError, InverterOutageError
 
 logger = logging.getLogger(__name__)
 
+# Default outage tolerance: 24 minutes (to handle firmware upgrades)
 DEFAULT_OUTAGE_TOLERANCE_SECONDS = 24 * 60
-DEFAULT_RETRY_BACKOFF_SECONDS = 60
+
+# Attributes forwarded from the wrapped inverter
+_FORWARDED_ATTRS = (
+    'min_soc', 'max_soc', 'mqtt_api', 'capacity',
+    'inverter_num', 'max_grid_charge_rate', 'max_pv_charge_rate',
+)
 
 
 class ResilientInverterWrapper(InverterInterface):
-    """Wraps any inverter and provides graceful degradation during outages."""
+    """Wraps any inverter and turns communication failures into clear signals."""
 
     def __init__(
         self,
         inverter: InverterInterface,
         outage_tolerance_seconds: float = DEFAULT_OUTAGE_TOLERANCE_SECONDS,
-        retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS,
     ):
         self._inverter = inverter
         self._outage_tolerance = outage_tolerance_seconds
-        self._retry_backoff = retry_backoff_seconds
-
-        self._initialized = False        # True after first successful set_mode_*
-        self._outage_start: Optional[float] = None  # timestamp of first failure
-        self._backoff_until: float = 0   # don't call inverter until this time
-        self._cache: dict = {}
-        self._cache_time: float = time.time()
+        self._initialized = False           # True after first successful set_mode_*
+        self._outage_start = None           # timestamp of the first failure
 
         # Forward common attributes from the wrapped inverter
         self.min_soc = None
@@ -49,166 +51,117 @@ class ResilientInverterWrapper(InverterInterface):
         self.inverter_num = 0
         self.max_grid_charge_rate = 0
         self.max_pv_charge_rate = 0
-        for attr in ('min_soc', 'max_soc', 'mqtt_api', 'capacity',
-                     'inverter_num', 'max_grid_charge_rate', 'max_pv_charge_rate'):
+        for attr in _FORWARDED_ATTRS:
             if hasattr(self._inverter, attr):
                 setattr(self, attr, getattr(self._inverter, attr))
 
     # -------------------------------------------------------------------------
-    # Internal helpers
+    # Core guard
     # -------------------------------------------------------------------------
 
-    def _in_backoff(self) -> bool:
-        return time.time() < self._backoff_until
+    def _guard(self, name, method, *args, is_command=False):
+        """Call an inverter method, classifying any failure."""
+        try:
+            result = method(*args)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            self._on_failure(name, e)  # always raises
+        else:
+            if self._outage_start is not None:
+                logger.info(
+                    "Inverter connection restored after %.1f min outage",
+                    (time.time() - self._outage_start) / 60,
+                )
+                self._outage_start = None
+            if is_command and not self._initialized:
+                logger.info("Inverter initialization complete (first set_mode succeeded)")
+                self._initialized = True
+            return result
 
-    def _on_success(self, mark_initialized: bool = False) -> None:
-        if self._outage_start is not None:
-            logger.info(
-                "Inverter connection restored after %.1f min outage",
-                (time.time() - self._outage_start) / 60,
-            )
-        self._outage_start = None
-        self._backoff_until = 0
-        if mark_initialized and not self._initialized:
-            logger.info("Inverter initialization complete (first set_mode succeeded)")
-            self._initialized = True
-
-    def _on_failure(self, op: str, error: Exception) -> bool:
-        """Record failure state. Returns True if the caller should re-raise.
-
-        Raises InverterOutageError directly when the tolerance window expires.
-        """
-        self._backoff_until = time.time() + self._retry_backoff
+    def _on_failure(self, name, error):
+        """Decide how to escalate a failure. Never returns - always raises."""
+        # Before initialization a failure is most likely a configuration error.
         if not self._initialized:
             logger.error(
                 "Inverter failure before initialization (config error?): %s", error
             )
-            return True  # fail-fast
+            raise error
 
+        now = time.time()
         if self._outage_start is None:
-            self._outage_start = time.time()
+            self._outage_start = now
+        outage = now - self._outage_start
 
-        outage = time.time() - self._outage_start
         if outage > self._outage_tolerance:
             raise InverterOutageError(
-                f"Inverter unreachable for {outage/60:.1f} min during '{op}'",
+                f"Inverter unreachable for {outage / 60:.1f} min during '{name}'",
                 outage_duration_seconds=outage,
-            )
+            ) from error
 
         logger.warning(
-            "Inverter communication failed for '%s' (outage: %.1f min, tolerance: %.1f min)",
-            op, outage / 60, self._outage_tolerance / 60,
+            "Inverter communication failed for '%s' (outage: %.1f min, "
+            "tolerance: %.1f min). Skipping this control cycle.",
+            name, outage / 60, self._outage_tolerance / 60,
         )
-        return False
-
-    def _read(self, key: str, method, default=None):
-        """Call a read method, returning cached value during outages."""
-        if self._in_backoff():
-            cached = self._cache.get(key)
-            if cached is not None:
-                age = (time.time() - self._cache_time) / 60
-                retry_in = self._backoff_until - time.time()
-                logger.debug(
-                    "Using cached %s value: %s (in backoff period, age: %.1f min, retry in: %.0fs)",
-                    key, cached, age, retry_in,
-                )
-                return cached
-            if default is not None:
-                return default
-            raise RuntimeError(f"No cached value for '{key}' during backoff")
-
-        try:
-            result = method()
-            self._on_success()
-            self._cache[key] = result
-            self._cache_time = time.time()
-            return result
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            if self._on_failure(key, e):
-                raise
-            cached = self._cache.get(key)
-            if cached is not None:
-                logger.debug("Using cached %s value: %s (after failure)", key, cached)
-                return cached
-            if default is not None:
-                return default
-            raise RuntimeError(f"No cached value for '{key}' after failure") from e
-
-    def _command(self, name: str, method, *args, mark_initialized: bool = False):
-        """Call a write method. Discards during backoff; degrades to None on failure."""
-        if self._in_backoff():
-            logger.debug("Skipping command '%s' (in backoff, inverter unavailable)", name)
-            return None
-        try:
-            result = method(*args)
-            self._on_success(mark_initialized=mark_initialized)
-            return result
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            if self._on_failure(name, e):
-                raise
-            logger.warning(
-                "Inverter command '%s' could not be applied, retrying next cycle", name
-            )
-            return None
+        raise InverterCommunicationError(name) from error
 
     # -------------------------------------------------------------------------
-    # Read operations (InverterInterface)
+    # Read operations
     # -------------------------------------------------------------------------
 
     def get_SOC(self) -> float:
-        return self._read("soc", self._inverter.get_SOC, default=50.0)
+        return self._guard("get_SOC", self._inverter.get_SOC)
 
     def get_stored_energy(self) -> float:
-        return self._read("stored_energy", self._inverter.get_stored_energy)
+        return self._guard("get_stored_energy", self._inverter.get_stored_energy)
 
     def get_stored_usable_energy(self) -> float:
-        return self._read("stored_usable_energy", self._inverter.get_stored_usable_energy)
+        return self._guard("get_stored_usable_energy", self._inverter.get_stored_usable_energy)
 
     def get_capacity(self) -> float:
-        return self._read("capacity", self._inverter.get_capacity)
+        return self._guard("get_capacity", self._inverter.get_capacity)
 
     def get_free_capacity(self) -> float:
-        return self._read("free_capacity", self._inverter.get_free_capacity)
+        return self._guard("get_free_capacity", self._inverter.get_free_capacity)
 
     def get_max_capacity(self) -> float:
-        return self._read("max_capacity", self._inverter.get_max_capacity)
+        return self._guard("get_max_capacity", self._inverter.get_max_capacity)
 
     def get_designed_capacity(self) -> float:
         if hasattr(self._inverter, 'get_designed_capacity'):
-            return self._read("designed_capacity", self._inverter.get_designed_capacity)
+            return self._guard("get_designed_capacity", self._inverter.get_designed_capacity)
         return self.get_capacity()
 
     def get_usable_capacity(self) -> float:
         if hasattr(self._inverter, 'get_usable_capacity'):
-            return self._read("usable_capacity", self._inverter.get_usable_capacity)
+            return self._guard("get_usable_capacity", self._inverter.get_usable_capacity)
         return self.get_max_capacity()
 
     # -------------------------------------------------------------------------
-    # Write operations (InverterInterface)
+    # Write operations
     # -------------------------------------------------------------------------
 
     def set_mode_force_charge(self, chargerate: float):
-        return self._command(
+        return self._guard(
             "set_mode_force_charge", self._inverter.set_mode_force_charge,
-            chargerate, mark_initialized=True,
+            chargerate, is_command=True,
         )
 
     def set_mode_avoid_discharge(self):
-        return self._command(
+        return self._guard(
             "set_mode_avoid_discharge", self._inverter.set_mode_avoid_discharge,
-            mark_initialized=True,
+            is_command=True,
         )
 
     def set_mode_allow_discharge(self):
-        return self._command(
+        return self._guard(
             "set_mode_allow_discharge", self._inverter.set_mode_allow_discharge,
-            mark_initialized=True,
+            is_command=True,
         )
 
     def set_mode_limit_battery_charge(self, limit_charge_rate: int):
-        return self._command(
+        return self._guard(
             "set_mode_limit_battery_charge", self._inverter.set_mode_limit_battery_charge,
-            limit_charge_rate, mark_initialized=True,
+            limit_charge_rate, is_command=True,
         )
 
     # -------------------------------------------------------------------------
@@ -221,17 +174,11 @@ class ResilientInverterWrapper(InverterInterface):
             self.mqtt_api = self._inverter.mqtt_api
 
     def refresh_api_values(self):
-        if self._in_backoff():
-            logger.debug("Skipping API value refresh (in backoff)")
-            return
+        """Best-effort refresh - never aborts a cycle on its own."""
         try:
             self._inverter.refresh_api_values()
-            self._on_success()
         except Exception as e:  # pylint: disable=broad-exception-caught
-            if not self._initialized:
-                return  # non-fatal before init
-            self._on_failure("refresh_api_values", e)  # may raise InverterOutageError
-            logger.debug("Skipping API value refresh during outage")
+            logger.debug("Skipping API value refresh (inverter unavailable): %s", e)
 
     def shutdown(self):
         try:
@@ -251,28 +198,11 @@ class ResilientInverterWrapper(InverterInterface):
             except Exception as e:  # pylint: disable=broad-exception-caught
                 logger.warning("Failed to publish discovery messages: %s", e)
 
-    # -------------------------------------------------------------------------
-    # Diagnostics
-    # -------------------------------------------------------------------------
-
-    def get_outage_status(self) -> dict:
-        now = time.time()
-        outage_duration = (now - self._outage_start) if self._outage_start else 0
-        return {
-            "is_connected": self._outage_start is None,
-            "initialization_complete": self._initialized,
-            "outage_duration_seconds": outage_duration,
-            "outage_duration_minutes": outage_duration / 60,
-            "outage_tolerance_seconds": self._outage_tolerance,
-            "cache_age_seconds": now - self._cache_time,
-            "in_backoff_period": self._in_backoff(),
-            "retry_backoff_seconds": self._retry_backoff,
-            "time_until_retry_seconds": max(0, self._backoff_until - now),
-        }
-
     @property
     def wrapped_inverter(self) -> InverterInterface:
+        """Access to the wrapped inverter for advanced use cases."""
         return self._inverter
 
     def __getattr__(self, name):
+        """Forward unknown attributes to the wrapped inverter."""
         return getattr(self._inverter, name)

--- a/src/batcontrol/inverter/resilient_wrapper.py
+++ b/src/batcontrol/inverter/resilient_wrapper.py
@@ -1,94 +1,47 @@
-"""Resilient Inverter Wrapper
+"""Resilient Inverter Wrapper - adds fault tolerance to any inverter backend.
 
-This module provides a wrapper class that adds resilience to any inverter
-implementation. It handles temporary connection outages by caching values
-and providing graceful degradation during firmware upgrades or network issues.
+During temporary outages (firmware upgrades, network blips):
+- Read operations return cached values for up to 24 minutes (configurable).
+- Write operations (set_mode_*) are discarded and retried next cycle.
+- After the tolerance window expires, InverterOutageError is raised.
 
-Key features:
-- Failures before first successful set_mode call propagate immediately
-  (config errors should fail fast - all API calls are validated during init)
-- After initialization, failures use cached values for up to 24 minutes (configurable)
-- After timeout, raises InverterOutageError to signal permanent failure
-- Automatic recovery when connection is restored
+Before the first successful set_mode_* call, all errors propagate
+immediately so configuration mistakes are caught at startup.
 """
 
 import time
 import logging
-from typing import Optional, Any, Callable
-from dataclasses import dataclass, field
+from typing import Optional
 
 from .inverter_interface import InverterInterface
 from .exceptions import InverterOutageError
 
 logger = logging.getLogger(__name__)
 
-# Default outage tolerance: 24 minutes (to handle firmware upgrades)
 DEFAULT_OUTAGE_TOLERANCE_SECONDS = 24 * 60
-
-# Default retry backoff: 60 seconds (don't hammer inverter after failure)
 DEFAULT_RETRY_BACKOFF_SECONDS = 60
 
 
-@dataclass
-class CachedValues:
-    """Container for cached inverter values during outages."""
-    soc: Optional[float] = None
-    stored_energy: Optional[float] = None
-    stored_usable_energy: Optional[float] = None
-    capacity: Optional[float] = None
-    free_capacity: Optional[float] = None
-    max_capacity: Optional[float] = None
-    designed_capacity: Optional[float] = None
-    usable_capacity: Optional[float] = None
-    last_update_time: float = field(default_factory=time.time)
-
-    def is_valid(self) -> bool:
-        """Check if we have at least the essential cached values."""
-        return self.soc is not None and self.capacity is not None
-
-
 class ResilientInverterWrapper(InverterInterface):
-    """
-    Wrapper that adds resilience to any inverter implementation.
-
-    This wrapper intercepts all inverter calls and provides:
-    1. Immediate failure on first run (config errors)
-    2. Cached value fallback during temporary outages
-    3. Timeout after configurable period (default 24 minutes)
-    4. Automatic recovery when connection is restored
-
-    Usage:
-        real_inverter = FroniusWR(config)
-        resilient = ResilientInverterWrapper(real_inverter)
-        # Use resilient instead of real_inverter
-    """
+    """Wraps any inverter and provides graceful degradation during outages."""
 
     def __init__(
         self,
         inverter: InverterInterface,
         outage_tolerance_seconds: float = DEFAULT_OUTAGE_TOLERANCE_SECONDS,
-        retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS
+        retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS,
     ):
-        """
-        Initialize the resilient wrapper.
-
-        Args:
-            inverter: The actual inverter implementation to wrap
-            outage_tolerance_seconds: Max time to tolerate outage (default: 24 min)
-            retry_backoff_seconds: Time to wait before retrying after failure (default: 60s)
-        """
         self._inverter = inverter
-        self._outage_tolerance_seconds = outage_tolerance_seconds
-        self._retry_backoff_seconds = retry_backoff_seconds
-        # Initialization is complete after first successful set_mode_* call
-        # Until then, all errors propagate immediately (fail-fast for config errors)
-        self._initialization_complete = False
-        self._first_failure_time: Optional[float] = None
-        self._last_failure_time: Optional[float] = None
-        self._cache = CachedValues()
-        self._consecutive_failures = 0
+        self._outage_tolerance = outage_tolerance_seconds
+        self._retry_backoff = retry_backoff_seconds
 
-        # Initialize attributes that will be forwarded from wrapped inverter
+        self._initialized = False        # True after first successful set_mode_*
+        self._outage_start: Optional[float] = None  # timestamp of first failure
+        self._backoff_until: float = 0   # don't call inverter until this time
+        self._cache: dict = {}
+        self._cache_time: float = time.time()
+
+        # Forward common attributes from the wrapped inverter
         self.min_soc = None
         self.max_soc = None
         self.mqtt_api = None
@@ -96,471 +49,230 @@ class ResilientInverterWrapper(InverterInterface):
         self.inverter_num = 0
         self.max_grid_charge_rate = 0
         self.max_pv_charge_rate = 0
-
-        # Forward common attributes from wrapped inverter
-        self._forward_attributes()
-
-    def _forward_attributes(self):
-        """Forward common attributes from the wrapped inverter."""
-        # These are typically set during inverter initialization
-        attrs_to_forward = [
-            'min_soc', 'max_soc', 'mqtt_api', 'capacity',
-            'inverter_num', 'max_grid_charge_rate', 'max_pv_charge_rate'
-        ]
-        for attr in attrs_to_forward:
+        for attr in ('min_soc', 'max_soc', 'mqtt_api', 'capacity',
+                     'inverter_num', 'max_grid_charge_rate', 'max_pv_charge_rate'):
             if hasattr(self._inverter, attr):
                 setattr(self, attr, getattr(self._inverter, attr))
 
-    def _is_in_backoff_period(self) -> bool:
+    # -------------------------------------------------------------------------
+    # Internal helpers
+    # -------------------------------------------------------------------------
+
+    def _in_backoff(self) -> bool:
+        return time.time() < self._backoff_until
+
+    def _on_success(self, mark_initialized: bool = False) -> None:
+        if self._outage_start is not None:
+            logger.info(
+                "Inverter connection restored after %.1f min outage",
+                (time.time() - self._outage_start) / 60,
+            )
+        self._outage_start = None
+        self._backoff_until = 0
+        if mark_initialized and not self._initialized:
+            logger.info("Inverter initialization complete (first set_mode succeeded)")
+            self._initialized = True
+
+    def _on_failure(self, op: str, error: Exception) -> bool:
+        """Record failure state. Returns True if the caller should re-raise.
+
+        Raises InverterOutageError directly when the tolerance window expires.
         """
-        Check if we're still in the backoff period after a failure.
-
-        After a failure, we wait for retry_backoff_seconds before attempting
-        another call to the inverter. This prevents hammering an unavailable
-        inverter and allows time for it to recover.
-
-        Returns:
-            True if we should skip the actual call and use cached values
-        """
-        if self._last_failure_time is None:
-            return False
-
-        time_since_failure = time.time() - self._last_failure_time
-        return time_since_failure < self._retry_backoff_seconds
-
-    def _handle_failure(self, operation: str, error: Exception) -> bool:
-        """
-        Handle an inverter communication failure.
-
-        Args:
-            operation: Name of the failed operation (for logging)
-            error: The exception that was raised
-
-        Returns:
-            True if the failure should be re-raised (first run or timeout)
-
-        Raises:
-            InverterOutageError if outage tolerance exceeded
-        """
-        self._consecutive_failures += 1
-        self._last_failure_time = time.time()
-
-        # Before initialization complete (first successful set_mode call),
-        # fail fast - this is likely a configuration error
-        if not self._initialization_complete:
+        self._backoff_until = time.time() + self._retry_backoff
+        if not self._initialized:
             logger.error(
-                "Inverter communication failed before initialization complete. "
-                "This may be a configuration error: %s", error
+                "Inverter failure before initialization (config error?): %s", error
             )
-            return True  # Signal to caller to re-raise
+            return True  # fail-fast
 
-        # Start tracking outage time
-        if self._first_failure_time is None:
-            self._first_failure_time = time.time()
-            logger.warning(
-                "Inverter communication failed for '%s': %s. "
-                "Starting outage tolerance window.",
-                operation, error
-            )
+        if self._outage_start is None:
+            self._outage_start = time.time()
 
-        # Calculate outage duration
-        outage_duration = time.time() - self._first_failure_time
-        outage_minutes = outage_duration / 60
-
-        # Check if we've exceeded tolerance
-        if outage_duration > self._outage_tolerance_seconds:
-            logger.error(
-                "Inverter has been unreachable for %.1f minutes "
-                "(tolerance: %.1f minutes). Giving up.",
-                outage_minutes,
-                self._outage_tolerance_seconds / 60
-            )
+        outage = time.time() - self._outage_start
+        if outage > self._outage_tolerance:
             raise InverterOutageError(
-                f"Inverter unreachable for {outage_minutes:.1f} minutes "
-                f"during '{operation}'",
-                outage_duration_seconds=outage_duration
+                f"Inverter unreachable for {outage/60:.1f} min during '{op}'",
+                outage_duration_seconds=outage,
             )
 
         logger.warning(
-            "Inverter communication failed for '%s' (outage: %.1f min, "
-            "tolerance: %.1f min, failures: %d)",
-            operation, outage_minutes,
-            self._outage_tolerance_seconds / 60,
-            self._consecutive_failures
+            "Inverter communication failed for '%s' (outage: %.1f min, tolerance: %.1f min)",
+            op, outage / 60, self._outage_tolerance / 60,
         )
+        return False
 
-        return False  # Don't re-raise, try cache/default
-
-    def _handle_success(self, mark_initialized: bool = False) -> None:
-        """
-        Handle a successful inverter communication.
-
-        Args:
-            mark_initialized: If True, mark initialization as complete.
-                              This should only be True for set_mode_* calls.
-        """
-        if self._first_failure_time is not None:
-            outage_duration = time.time() - self._first_failure_time
-            logger.info(
-                "Inverter connection restored after %.1f minutes outage",
-                outage_duration / 60
-            )
-
-        if mark_initialized and not self._initialization_complete:
-            logger.info("Inverter initialization complete (first set_mode succeeded)")
-            self._initialization_complete = True
-
-        self._first_failure_time = None
-        self._last_failure_time = None
-        self._consecutive_failures = 0
-
-    def _call_with_resilience(
-        self,
-        method: Callable,
-        operation_name: str,
-        cache_attr: Optional[str] = None,
-        default_value: Any = None,
-        method_args: tuple = (),
-        mark_initialized: bool = False,
-        is_command: bool = False
-    ) -> Any:
-        """
-        Call an inverter method with resilience handling.
-
-        Args:
-            method: The inverter method to call
-            operation_name: Name for logging
-            cache_attr: Attribute name in CachedValues to use for fallback
-            default_value: Value to return if no cache available
-            method_args: Arguments to pass to the method
-            mark_initialized: If True, mark initialization complete on success
-                              (should only be True for set_mode_* calls)
-            is_command: If True, this is a write/command operation (set_mode_*)
-                        with no cached fallback. During the backoff period the
-                        inverter is presumed unavailable, so the command is
-                        discarded (returns None) rather than attempted - it will
-                        be re-issued on the next cycle. A command that is
-                        attempted outside backoff and fails also degrades to
-                        None instead of raising. Either way the process keeps
-                        running; the outage tolerance window still applies.
-
-        Returns:
-            The method result, cached value, default value, or None for a
-            command that could not be applied during an outage.
-        """
-        # Check if we're in backoff period - skip the actual call to avoid
-        # hammering an unavailable inverter.
-        if self._is_in_backoff_period():
-            if is_command:
-                # Commands have no cached fallback. The inverter is presumed
-                # unavailable during backoff, so the command cannot be
-                # delivered - discard it. batcontrol recalculates and re-issues
-                # the mode on the next cycle.
+    def _read(self, key: str, method, default=None):
+        """Call a read method, returning cached value during outages."""
+        if self._in_backoff():
+            cached = self._cache.get(key)
+            if cached is not None:
+                age = (time.time() - self._cache_time) / 60
+                retry_in = self._backoff_until - time.time()
                 logger.debug(
-                    "Skipping inverter command '%s' during backoff "
-                    "(inverter unavailable, retry next cycle)",
-                    operation_name
+                    "Using cached %s value: %s (in backoff period, age: %.1f min, retry in: %.0fs)",
+                    key, cached, age, retry_in,
                 )
-                return None
-            return self._get_cached_or_default(
-                operation_name, cache_attr, default_value, is_backoff=True
-            )
+                return cached
+            if default is not None:
+                return default
+            raise RuntimeError(f"No cached value for '{key}' during backoff")
 
         try:
-            result = method(*method_args)
-            self._handle_success(mark_initialized=mark_initialized)
-
-            # Update cache if applicable
-            if cache_attr is not None:
-                setattr(self._cache, cache_attr, result)
-                self._cache.last_update_time = time.time()
-
+            result = method()
+            self._on_success()
+            self._cache[key] = result
+            self._cache_time = time.time()
             return result
-
         except Exception as e:  # pylint: disable=broad-exception-caught
-            should_reraise = self._handle_failure(operation_name, e)
-
-            if should_reraise:
+            if self._on_failure(key, e):
                 raise
+            cached = self._cache.get(key)
+            if cached is not None:
+                logger.debug("Using cached %s value: %s (after failure)", key, cached)
+                return cached
+            if default is not None:
+                return default
+            raise RuntimeError(f"No cached value for '{key}' after failure") from e
 
-            if is_command:
-                # A command (set_mode_*) has no cached value or default to
-                # fall back on. Within the outage tolerance window we degrade
-                # gracefully: the action could not be applied this cycle, but
-                # batcontrol will recalculate and retry on the next cycle. Once
-                # the tolerance window is exceeded, _handle_failure above raises
-                # InverterOutageError instead of returning.
-                logger.warning(
-                    "Inverter command '%s' could not be applied "
-                    "(communication failure). Will retry next cycle.",
-                    operation_name
-                )
-                return None
-
-            return self._get_cached_or_default(
-                operation_name, cache_attr, default_value, is_backoff=False
-            )
-
-    def _get_cached_or_default(
-        self,
-        operation_name: str,
-        cache_attr: Optional[str],
-        default_value: Any,
-        is_backoff: bool
-    ) -> Any:
-        """
-        Get cached value or default when inverter is unavailable.
-
-        Args:
-            operation_name: Name for logging
-            cache_attr: Attribute name in CachedValues
-            default_value: Fallback value if no cache
-            is_backoff: True if skipping due to backoff period
-
-        Returns:
-            Cached value, default value, or raises if neither available
-        """
-        reason = "in backoff period" if is_backoff else "after failure"
-
-        # Try to use cached value
-        if cache_attr is not None:
-            cached_value = getattr(self._cache, cache_attr, None)
-            if cached_value is not None:
-                cache_age = time.time() - self._cache.last_update_time
-                time_until_retry = 0
-                if self._last_failure_time:
-                    time_until_retry = max(
-                        0,
-                        self._retry_backoff_seconds - (time.time() - self._last_failure_time)
-                    )
-                logger.debug(
-                    "Using cached %s value: %s (%s, age: %.1f min, retry in: %.0fs)",
-                    cache_attr, cached_value, reason, cache_age / 60, time_until_retry
-                )
-                return cached_value
-
-        # No cache available
-        if default_value is not None:
+    def _command(self, name: str, method, *args, mark_initialized: bool = False):
+        """Call a write method. Discards during backoff; degrades to None on failure."""
+        if self._in_backoff():
+            logger.debug("Skipping command '%s' (in backoff, inverter unavailable)", name)
+            return None
+        try:
+            result = method(*args)
+            self._on_success(mark_initialized=mark_initialized)
+            return result
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            if self._on_failure(name, e):
+                raise
             logger.warning(
-                "No cached value for %s (%s), using default: %s",
-                operation_name, reason, default_value
+                "Inverter command '%s' could not be applied, retrying next cycle", name
             )
-            return default_value
+            return None
 
-        # Re-raise if no fallback available
-        raise RuntimeError(
-            f"No cached value or default available for {operation_name} ({reason})"
-        )
-
-    # =========================================================================
-    # InverterInterface Implementation - Read Operations (with caching)
-    # =========================================================================
+    # -------------------------------------------------------------------------
+    # Read operations (InverterInterface)
+    # -------------------------------------------------------------------------
 
     def get_SOC(self) -> float:
-        """Get state of charge with resilience handling."""
-        return self._call_with_resilience(
-            self._inverter.get_SOC,
-            "get_SOC",
-            cache_attr="soc",
-            default_value=50.0  # Safe middle value if no cache
-        )
+        return self._read("soc", self._inverter.get_SOC, default=50.0)
 
     def get_stored_energy(self) -> float:
-        """Get stored energy with resilience handling."""
-        return self._call_with_resilience(
-            self._inverter.get_stored_energy,
-            "get_stored_energy",
-            cache_attr="stored_energy"
-        )
+        return self._read("stored_energy", self._inverter.get_stored_energy)
 
     def get_stored_usable_energy(self) -> float:
-        """Get stored usable energy with resilience handling."""
-        return self._call_with_resilience(
-            self._inverter.get_stored_usable_energy,
-            "get_stored_usable_energy",
-            cache_attr="stored_usable_energy"
-        )
+        return self._read("stored_usable_energy", self._inverter.get_stored_usable_energy)
 
     def get_capacity(self) -> float:
-        """Get capacity with resilience handling."""
-        return self._call_with_resilience(
-            self._inverter.get_capacity,
-            "get_capacity",
-            cache_attr="capacity"
-        )
+        return self._read("capacity", self._inverter.get_capacity)
 
     def get_free_capacity(self) -> float:
-        """Get free capacity with resilience handling."""
-        return self._call_with_resilience(
-            self._inverter.get_free_capacity,
-            "get_free_capacity",
-            cache_attr="free_capacity"
-        )
+        return self._read("free_capacity", self._inverter.get_free_capacity)
 
     def get_max_capacity(self) -> float:
-        """Get max capacity with resilience handling."""
-        return self._call_with_resilience(
-            self._inverter.get_max_capacity,
-            "get_max_capacity",
-            cache_attr="max_capacity"
-        )
+        return self._read("max_capacity", self._inverter.get_max_capacity)
 
-    # =========================================================================
-    # InverterInterface Implementation - Write Operations (no caching)
-    # =========================================================================
+    def get_designed_capacity(self) -> float:
+        if hasattr(self._inverter, 'get_designed_capacity'):
+            return self._read("designed_capacity", self._inverter.get_designed_capacity)
+        return self.get_capacity()
+
+    def get_usable_capacity(self) -> float:
+        if hasattr(self._inverter, 'get_usable_capacity'):
+            return self._read("usable_capacity", self._inverter.get_usable_capacity)
+        return self.get_max_capacity()
+
+    # -------------------------------------------------------------------------
+    # Write operations (InverterInterface)
+    # -------------------------------------------------------------------------
 
     def set_mode_force_charge(self, chargerate: float):
-        """Set force charge mode with resilience handling."""
-        return self._call_with_resilience(
-            self._inverter.set_mode_force_charge,
-            "set_mode_force_charge",
-            None, None,
-            method_args=(chargerate,),
-            mark_initialized=True,
-            is_command=True
+        return self._command(
+            "set_mode_force_charge", self._inverter.set_mode_force_charge,
+            chargerate, mark_initialized=True,
         )
 
     def set_mode_avoid_discharge(self):
-        """Set avoid discharge mode with resilience handling."""
-        return self._call_with_resilience(
-            self._inverter.set_mode_avoid_discharge,
-            "set_mode_avoid_discharge",
+        return self._command(
+            "set_mode_avoid_discharge", self._inverter.set_mode_avoid_discharge,
             mark_initialized=True,
-            is_command=True
         )
 
     def set_mode_allow_discharge(self):
-        """Set allow discharge mode with resilience handling."""
-        return self._call_with_resilience(
-            self._inverter.set_mode_allow_discharge,
-            "set_mode_allow_discharge",
+        return self._command(
+            "set_mode_allow_discharge", self._inverter.set_mode_allow_discharge,
             mark_initialized=True,
-            is_command=True
         )
 
     def set_mode_limit_battery_charge(self, limit_charge_rate: int):
-        """Set limit battery charge mode with resilience handling."""
-        return self._call_with_resilience(
-            self._inverter.set_mode_limit_battery_charge,
-            "set_mode_limit_battery_charge",
-            None, None,
-            method_args=(limit_charge_rate,),
-            mark_initialized=True,
-            is_command=True
+        return self._command(
+            "set_mode_limit_battery_charge", self._inverter.set_mode_limit_battery_charge,
+            limit_charge_rate, mark_initialized=True,
         )
 
-    # =========================================================================
-    # InverterInterface Implementation - Other Methods
-    # =========================================================================
+    # -------------------------------------------------------------------------
+    # Other methods
+    # -------------------------------------------------------------------------
 
     def activate_mqtt(self, api_mqtt_api: object):
-        """Activate MQTT - delegate to wrapped inverter."""
         self._inverter.activate_mqtt(api_mqtt_api)
-        # Update forwarded mqtt_api attribute
         if hasattr(self._inverter, 'mqtt_api'):
             self.mqtt_api = self._inverter.mqtt_api
 
     def refresh_api_values(self):
-        """Refresh API values with resilience handling."""
+        if self._in_backoff():
+            logger.debug("Skipping API value refresh (in backoff)")
+            return
         try:
             self._inverter.refresh_api_values()
-            self._handle_success(mark_initialized=False)
+            self._on_success()
         except Exception as e:  # pylint: disable=broad-exception-caught
-            self._handle_failure("refresh_api_values", e)
-            # This is non-critical, just log and continue
+            if not self._initialized:
+                return  # non-fatal before init
+            self._on_failure("refresh_api_values", e)  # may raise InverterOutageError
             logger.debug("Skipping API value refresh during outage")
 
     def shutdown(self):
-        """Shutdown - delegate to wrapped inverter."""
         try:
             self._inverter.shutdown()
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger.warning("Error during inverter shutdown: %s", e)
 
-    # =========================================================================
-    # Additional Methods (forward to wrapped inverter)
-    # =========================================================================
-
-    def get_designed_capacity(self) -> float:
-        """Get designed capacity with resilience handling."""
-        if hasattr(self._inverter, 'get_designed_capacity'):
-            return self._call_with_resilience(
-                self._inverter.get_designed_capacity,
-                "get_designed_capacity",
-                cache_attr="designed_capacity"
-            )
-        return self.get_capacity()
-
-    def get_usable_capacity(self) -> float:
-        """Get usable capacity with resilience handling."""
-        if hasattr(self._inverter, 'get_usable_capacity'):
-            return self._call_with_resilience(
-                self._inverter.get_usable_capacity,
-                "get_usable_capacity",
-                cache_attr="usable_capacity"
-            )
-        # Fallback calculation
-        return self.get_max_capacity()
-
     def get_mqtt_inverter_topic(self) -> str:
-        """Get MQTT topic - delegate to wrapped inverter."""
         if hasattr(self._inverter, 'get_mqtt_inverter_topic'):
             return self._inverter.get_mqtt_inverter_topic()
         return f'inverters/{getattr(self, "inverter_num", 0)}/'
 
     def publish_inverter_discovery_messages(self):
-        """Publish discovery messages - delegate to wrapped inverter."""
         if hasattr(self._inverter, 'publish_inverter_discovery_messages'):
             try:
                 self._inverter.publish_inverter_discovery_messages()
             except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.warning(
-                    "Failed to publish discovery messages: %s", e
-                )
+                logger.warning("Failed to publish discovery messages: %s", e)
 
-    # =========================================================================
-    # Status and Diagnostics
-    # =========================================================================
+    # -------------------------------------------------------------------------
+    # Diagnostics
+    # -------------------------------------------------------------------------
 
     def get_outage_status(self) -> dict:
-        """
-        Get current outage status for diagnostics.
-
-        Returns:
-            dict with outage information
-        """
-        outage_duration = 0
-        if self._first_failure_time is not None:
-            outage_duration = time.time() - self._first_failure_time
-
-        time_until_retry = 0
-        if self._last_failure_time is not None:
-            time_until_retry = max(
-                0,
-                self._retry_backoff_seconds - (time.time() - self._last_failure_time)
-            )
-
+        now = time.time()
+        outage_duration = (now - self._outage_start) if self._outage_start else 0
         return {
-            "is_connected": self._first_failure_time is None,
-            "initialization_complete": self._initialization_complete,
+            "is_connected": self._outage_start is None,
+            "initialization_complete": self._initialized,
             "outage_duration_seconds": outage_duration,
             "outage_duration_minutes": outage_duration / 60,
-            "outage_tolerance_seconds": self._outage_tolerance_seconds,
-            "consecutive_failures": self._consecutive_failures,
-            "cache_valid": self._cache.is_valid(),
-            "cache_age_seconds": time.time() - self._cache.last_update_time,
-            "in_backoff_period": self._is_in_backoff_period(),
-            "retry_backoff_seconds": self._retry_backoff_seconds,
-            "time_until_retry_seconds": time_until_retry
+            "outage_tolerance_seconds": self._outage_tolerance,
+            "cache_age_seconds": now - self._cache_time,
+            "in_backoff_period": self._in_backoff(),
+            "retry_backoff_seconds": self._retry_backoff,
+            "time_until_retry_seconds": max(0, self._backoff_until - now),
         }
 
     @property
     def wrapped_inverter(self) -> InverterInterface:
-        """Access to the wrapped inverter for advanced use cases."""
         return self._inverter
 
     def __getattr__(self, name):
-        """Forward unknown attributes to the wrapped inverter."""
-        # This is called when an attribute is not found on the wrapper
-        # Forward to the wrapped inverter
         return getattr(self._inverter, name)

--- a/src/batcontrol/inverter/resilient_wrapper.py
+++ b/src/batcontrol/inverter/resilient_wrapper.py
@@ -94,7 +94,7 @@ class ResilientInverterWrapper:
         if not self._initialized:
             logger.error(
                 "Inverter failure before initialization (config error?): %s", error)
-            raise error
+            raise
 
         now = time.time()
         if self._outage_start is None:
@@ -108,7 +108,7 @@ class ResilientInverterWrapper:
             ) from error
 
         logger.warning(
-            "Inverter communication failed for '%s' (outage: %.1f min, "
+            "Inverter communication failed for '%s': %s (outage: %.1f min, "
             "tolerance: %.1f min). Skipping this control cycle.",
-            name, outage / 60, self._outage_tolerance / 60)
+            name, error, outage / 60, self._outage_tolerance / 60)
         raise InverterCommunicationError(name) from error

--- a/src/batcontrol/inverter/resilient_wrapper.py
+++ b/src/batcontrol/inverter/resilient_wrapper.py
@@ -221,7 +221,8 @@ class ResilientInverterWrapper(InverterInterface):
         cache_attr: Optional[str] = None,
         default_value: Any = None,
         method_args: tuple = (),
-        mark_initialized: bool = False
+        mark_initialized: bool = False,
+        is_command: bool = False
     ) -> Any:
         """
         Call an inverter method with resilience handling.
@@ -234,13 +235,33 @@ class ResilientInverterWrapper(InverterInterface):
             method_args: Arguments to pass to the method
             mark_initialized: If True, mark initialization complete on success
                               (should only be True for set_mode_* calls)
+            is_command: If True, this is a write/command operation (set_mode_*)
+                        with no cached fallback. During the backoff period the
+                        inverter is presumed unavailable, so the command is
+                        discarded (returns None) rather than attempted - it will
+                        be re-issued on the next cycle. A command that is
+                        attempted outside backoff and fails also degrades to
+                        None instead of raising. Either way the process keeps
+                        running; the outage tolerance window still applies.
 
         Returns:
-            The method result, cached value, or default value
+            The method result, cached value, default value, or None for a
+            command that could not be applied during an outage.
         """
-        # Check if we're in backoff period - skip actual call to avoid
-        # hammering an unavailable inverter
+        # Check if we're in backoff period - skip the actual call to avoid
+        # hammering an unavailable inverter.
         if self._is_in_backoff_period():
+            if is_command:
+                # Commands have no cached fallback. The inverter is presumed
+                # unavailable during backoff, so the command cannot be
+                # delivered - discard it. batcontrol recalculates and re-issues
+                # the mode on the next cycle.
+                logger.debug(
+                    "Skipping inverter command '%s' during backoff "
+                    "(inverter unavailable, retry next cycle)",
+                    operation_name
+                )
+                return None
             return self._get_cached_or_default(
                 operation_name, cache_attr, default_value, is_backoff=True
             )
@@ -261,6 +282,20 @@ class ResilientInverterWrapper(InverterInterface):
 
             if should_reraise:
                 raise
+
+            if is_command:
+                # A command (set_mode_*) has no cached value or default to
+                # fall back on. Within the outage tolerance window we degrade
+                # gracefully: the action could not be applied this cycle, but
+                # batcontrol will recalculate and retry on the next cycle. Once
+                # the tolerance window is exceeded, _handle_failure above raises
+                # InverterOutageError instead of returning.
+                logger.warning(
+                    "Inverter command '%s' could not be applied "
+                    "(communication failure). Will retry next cycle.",
+                    operation_name
+                )
+                return None
 
             return self._get_cached_or_default(
                 operation_name, cache_attr, default_value, is_backoff=False
@@ -381,7 +416,8 @@ class ResilientInverterWrapper(InverterInterface):
             "set_mode_force_charge",
             None, None,
             method_args=(chargerate,),
-            mark_initialized=True
+            mark_initialized=True,
+            is_command=True
         )
 
     def set_mode_avoid_discharge(self):
@@ -389,7 +425,8 @@ class ResilientInverterWrapper(InverterInterface):
         return self._call_with_resilience(
             self._inverter.set_mode_avoid_discharge,
             "set_mode_avoid_discharge",
-            mark_initialized=True
+            mark_initialized=True,
+            is_command=True
         )
 
     def set_mode_allow_discharge(self):
@@ -397,7 +434,8 @@ class ResilientInverterWrapper(InverterInterface):
         return self._call_with_resilience(
             self._inverter.set_mode_allow_discharge,
             "set_mode_allow_discharge",
-            mark_initialized=True
+            mark_initialized=True,
+            is_command=True
         )
 
     def set_mode_limit_battery_charge(self, limit_charge_rate: int):
@@ -407,7 +445,8 @@ class ResilientInverterWrapper(InverterInterface):
             "set_mode_limit_battery_charge",
             None, None,
             method_args=(limit_charge_rate,),
-            mark_initialized=True
+            mark_initialized=True,
+            is_command=True
         )
 
     # =========================================================================

--- a/src/batcontrol/inverter/resilient_wrapper.py
+++ b/src/batcontrol/inverter/resilient_wrapper.py
@@ -1,21 +1,25 @@
-"""Resilient Inverter Wrapper - thin fault-tolerance layer.
+"""Resilient inverter proxy - normalizes backend communication failures.
 
-Concept (deliberately simple - no caching, no backoff timers):
+This is a thin __getattr__ proxy around any inverter backend. It does not
+re-declare the inverter interface; it simply delegates every attribute and
+method to the wrapped inverter and only intercepts method calls that raise.
 
-- Before the first successful set_mode_* call every error propagates
-  unchanged, so configuration mistakes fail fast at startup.
-- After initialization an inverter failure raises InverterCommunicationError.
-  The caller (core.run) aborts the current control cycle and retries on the
-  next scheduled run - the loop interval is the natural backoff, and no
-  decision is ever made on stale data.
+Behaviour:
+- Before the first successful set_mode_* call, errors propagate unchanged, so
+  configuration mistakes fail fast at startup.
+- After that an inverter failure becomes InverterCommunicationError; the caller
+  (core.run) skips the control cycle and retries on the next scheduled run, so
+  the loop interval is the natural backoff and no decision is made on stale
+  data.
 - If the inverter stays unreachable past the tolerance window, the failure is
   escalated to InverterOutageError, which terminates batcontrol.
+- shutdown() and refresh_api_values() are best-effort: they never abort a cycle.
 """
 
 import time
 import logging
+import functools
 
-from .inverter_interface import InverterInterface
 from .exceptions import InverterCommunicationError, InverterOutageError
 
 logger = logging.getLogger(__name__)
@@ -23,67 +27,73 @@ logger = logging.getLogger(__name__)
 # Default outage tolerance: 24 minutes (to handle firmware upgrades)
 DEFAULT_OUTAGE_TOLERANCE_SECONDS = 24 * 60
 
-# Attributes forwarded from the wrapped inverter
-_FORWARDED_ATTRS = (
-    'min_soc', 'max_soc', 'mqtt_api', 'capacity',
-    'inverter_num', 'max_grid_charge_rate', 'max_pv_charge_rate',
-)
+# Commands whose first success means the inverter is initialized. From then on
+# failures are tolerated instead of treated as fail-fast configuration errors.
+_COMMAND_METHODS = frozenset({
+    'set_mode_force_charge', 'set_mode_avoid_discharge',
+    'set_mode_allow_discharge', 'set_mode_limit_battery_charge',
+})
+
+# Best-effort methods never abort a control cycle - just log and move on.
+_BEST_EFFORT_METHODS = frozenset({'refresh_api_values', 'shutdown'})
 
 
-class ResilientInverterWrapper(InverterInterface):
-    """Wraps any inverter and turns communication failures into clear signals."""
+class ResilientInverterWrapper:
+    """Delegates to an inverter, turning communication failures into signals."""
 
-    def __init__(
-        self,
-        inverter: InverterInterface,
-        outage_tolerance_seconds: float = DEFAULT_OUTAGE_TOLERANCE_SECONDS,
-    ):
+    def __init__(self, inverter, outage_tolerance_seconds=DEFAULT_OUTAGE_TOLERANCE_SECONDS):
         self._inverter = inverter
         self._outage_tolerance = outage_tolerance_seconds
         self._initialized = False           # True after first successful set_mode_*
-        self._outage_start = None           # timestamp of the first failure
+        self._outage_start = None            # timestamp of the first failure
 
-        # Forward common attributes from the wrapped inverter
-        self.min_soc = None
-        self.max_soc = None
-        self.mqtt_api = None
-        self.capacity = None
-        self.inverter_num = 0
-        self.max_grid_charge_rate = 0
-        self.max_pv_charge_rate = 0
-        for attr in _FORWARDED_ATTRS:
-            if hasattr(self._inverter, attr):
-                setattr(self, attr, getattr(self._inverter, attr))
+    @property
+    def wrapped_inverter(self):
+        """Access to the wrapped inverter for advanced use cases."""
+        return self._inverter
 
-    # -------------------------------------------------------------------------
-    # Core guard
-    # -------------------------------------------------------------------------
+    def __getattr__(self, name):
+        """Delegate to the wrapped inverter; guard method calls."""
+        inverter = self.__dict__.get('_inverter')
+        if inverter is None:
+            raise AttributeError(name)
+        attr = getattr(inverter, name)
+        if not callable(attr) or name.startswith('__'):
+            return attr
+        return self._guard(name, attr)
 
-    def _guard(self, name, method, *args, is_command=False):
-        """Call an inverter method, classifying any failure."""
-        try:
-            result = method(*args)
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            self._on_failure(name, e)  # always raises
-        else:
+    def _guard(self, name, method):
+        best_effort = name in _BEST_EFFORT_METHODS
+        is_command = name in _COMMAND_METHODS
+
+        @functools.wraps(method)
+        def guarded(*args, **kwargs):
+            try:
+                result = method(*args, **kwargs)
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                if best_effort:
+                    logger.debug(
+                        "Inverter '%s' failed (best-effort, ignored): %s", name, e)
+                    return None
+                self._on_failure(name, e)  # always raises
+                return None  # unreachable, keeps linters happy
             if self._outage_start is not None:
                 logger.info(
                     "Inverter connection restored after %.1f min outage",
-                    (time.time() - self._outage_start) / 60,
-                )
+                    (time.time() - self._outage_start) / 60)
                 self._outage_start = None
             if is_command and not self._initialized:
                 logger.info("Inverter initialization complete (first set_mode succeeded)")
                 self._initialized = True
             return result
+        return guarded
 
     def _on_failure(self, name, error):
-        """Decide how to escalate a failure. Never returns - always raises."""
+        """Classify a failure. Never returns - always raises."""
         # Before initialization a failure is most likely a configuration error.
         if not self._initialized:
             logger.error(
-                "Inverter failure before initialization (config error?): %s", error
-            )
+                "Inverter failure before initialization (config error?): %s", error)
             raise error
 
         now = time.time()
@@ -100,109 +110,5 @@ class ResilientInverterWrapper(InverterInterface):
         logger.warning(
             "Inverter communication failed for '%s' (outage: %.1f min, "
             "tolerance: %.1f min). Skipping this control cycle.",
-            name, outage / 60, self._outage_tolerance / 60,
-        )
+            name, outage / 60, self._outage_tolerance / 60)
         raise InverterCommunicationError(name) from error
-
-    # -------------------------------------------------------------------------
-    # Read operations
-    # -------------------------------------------------------------------------
-
-    def get_SOC(self) -> float:
-        return self._guard("get_SOC", self._inverter.get_SOC)
-
-    def get_stored_energy(self) -> float:
-        return self._guard("get_stored_energy", self._inverter.get_stored_energy)
-
-    def get_stored_usable_energy(self) -> float:
-        return self._guard("get_stored_usable_energy", self._inverter.get_stored_usable_energy)
-
-    def get_capacity(self) -> float:
-        return self._guard("get_capacity", self._inverter.get_capacity)
-
-    def get_free_capacity(self) -> float:
-        return self._guard("get_free_capacity", self._inverter.get_free_capacity)
-
-    def get_max_capacity(self) -> float:
-        return self._guard("get_max_capacity", self._inverter.get_max_capacity)
-
-    def get_designed_capacity(self) -> float:
-        if hasattr(self._inverter, 'get_designed_capacity'):
-            return self._guard("get_designed_capacity", self._inverter.get_designed_capacity)
-        return self.get_capacity()
-
-    def get_usable_capacity(self) -> float:
-        if hasattr(self._inverter, 'get_usable_capacity'):
-            return self._guard("get_usable_capacity", self._inverter.get_usable_capacity)
-        return self.get_max_capacity()
-
-    # -------------------------------------------------------------------------
-    # Write operations
-    # -------------------------------------------------------------------------
-
-    def set_mode_force_charge(self, chargerate: float):
-        return self._guard(
-            "set_mode_force_charge", self._inverter.set_mode_force_charge,
-            chargerate, is_command=True,
-        )
-
-    def set_mode_avoid_discharge(self):
-        return self._guard(
-            "set_mode_avoid_discharge", self._inverter.set_mode_avoid_discharge,
-            is_command=True,
-        )
-
-    def set_mode_allow_discharge(self):
-        return self._guard(
-            "set_mode_allow_discharge", self._inverter.set_mode_allow_discharge,
-            is_command=True,
-        )
-
-    def set_mode_limit_battery_charge(self, limit_charge_rate: int):
-        return self._guard(
-            "set_mode_limit_battery_charge", self._inverter.set_mode_limit_battery_charge,
-            limit_charge_rate, is_command=True,
-        )
-
-    # -------------------------------------------------------------------------
-    # Other methods
-    # -------------------------------------------------------------------------
-
-    def activate_mqtt(self, api_mqtt_api: object):
-        self._inverter.activate_mqtt(api_mqtt_api)
-        if hasattr(self._inverter, 'mqtt_api'):
-            self.mqtt_api = self._inverter.mqtt_api
-
-    def refresh_api_values(self):
-        """Best-effort refresh - never aborts a cycle on its own."""
-        try:
-            self._inverter.refresh_api_values()
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.debug("Skipping API value refresh (inverter unavailable): %s", e)
-
-    def shutdown(self):
-        try:
-            self._inverter.shutdown()
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.warning("Error during inverter shutdown: %s", e)
-
-    def get_mqtt_inverter_topic(self) -> str:
-        if hasattr(self._inverter, 'get_mqtt_inverter_topic'):
-            return self._inverter.get_mqtt_inverter_topic()
-        return f'inverters/{getattr(self, "inverter_num", 0)}/'
-
-    def publish_inverter_discovery_messages(self):
-        if hasattr(self._inverter, 'publish_inverter_discovery_messages'):
-            try:
-                self._inverter.publish_inverter_discovery_messages()
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.warning("Failed to publish discovery messages: %s", e)
-
-    @property
-    def wrapped_inverter(self) -> InverterInterface:
-        """Access to the wrapped inverter for advanced use cases."""
-        return self._inverter
-
-    def __getattr__(self, name):
-        """Forward unknown attributes to the wrapped inverter."""
-        return getattr(self._inverter, name)

--- a/tests/batcontrol/inverter/test_resilient_wrapper.py
+++ b/tests/batcontrol/inverter/test_resilient_wrapper.py
@@ -1,30 +1,23 @@
-"""
-Tests for the ResilientInverterWrapper class.
+"""Tests for ResilientInverterWrapper.
 
-These tests verify that the resilient wrapper:
-1. Fails fast on first connection attempt (config errors)
-2. Uses cached values during temporary outages
-3. Raises InverterOutageError after 24-minute timeout
-4. Recovers properly when connection is restored
+Behaviour under test:
+1. Before first successful set_mode_*: errors propagate immediately (fail-fast).
+2. After initialization: read failures return cached values; commands are discarded.
+3. After the outage tolerance expires: InverterOutageError is raised.
+4. Automatic recovery when the connection is restored.
 """
 
 import pytest
 import time
 from unittest.mock import Mock
 
-from batcontrol.inverter.resilient_wrapper import (
-    ResilientInverterWrapper,
-    CachedValues,
-)
+from batcontrol.inverter.resilient_wrapper import ResilientInverterWrapper
 from batcontrol.inverter.exceptions import InverterOutageError
 
 
 class MockInverter:
-    """Mock inverter for testing."""
-
     def __init__(self, should_fail=False):
         self.should_fail = should_fail
-        self.failure_count = 0
         self.min_soc = 10
         self.max_soc = 95
         self.mqtt_api = None
@@ -32,620 +25,356 @@ class MockInverter:
         self.inverter_num = 0
         self.max_grid_charge_rate = 5000
         self.max_pv_charge_rate = 0
-
-        # Track calls
-        self.get_soc_calls = 0
+        self.soc_calls = 0
         self.set_mode_calls = []
 
-    def get_SOC(self):
-        self.get_soc_calls += 1
+    def _maybe_fail(self):
         if self.should_fail:
-            self.failure_count += 1
             raise ConnectionError("Inverter unreachable")
+
+    def get_SOC(self):
+        self.soc_calls += 1
+        self._maybe_fail()
         return 75.0
 
     def get_stored_energy(self):
-        if self.should_fail:
-            raise ConnectionError("Inverter unreachable")
+        self._maybe_fail()
         return 7500.0
 
     def get_stored_usable_energy(self):
-        if self.should_fail:
-            raise ConnectionError("Inverter unreachable")
+        self._maybe_fail()
         return 6500.0
 
     def get_capacity(self):
-        if self.should_fail:
-            raise ConnectionError("Inverter unreachable")
+        self._maybe_fail()
         return 10000.0
 
     def get_free_capacity(self):
-        if self.should_fail:
-            raise ConnectionError("Inverter unreachable")
+        self._maybe_fail()
         return 2500.0
 
     def get_max_capacity(self):
-        if self.should_fail:
-            raise ConnectionError("Inverter unreachable")
+        self._maybe_fail()
         return 9500.0
 
     def set_mode_force_charge(self, chargerate):
         self.set_mode_calls.append(('force_charge', chargerate))
-        if self.should_fail:
-            raise ConnectionError("Inverter unreachable")
+        self._maybe_fail()
 
     def set_mode_avoid_discharge(self):
         self.set_mode_calls.append(('avoid_discharge',))
-        if self.should_fail:
-            raise ConnectionError("Inverter unreachable")
+        self._maybe_fail()
 
     def set_mode_allow_discharge(self):
         self.set_mode_calls.append(('allow_discharge',))
-        if self.should_fail:
-            raise ConnectionError("Inverter unreachable")
+        self._maybe_fail()
 
-    def set_mode_limit_battery_charge(self, limit_charge_rate):
-        self.set_mode_calls.append(('limit_battery_charge', limit_charge_rate))
-        if self.should_fail:
-            raise ConnectionError("Inverter unreachable")
+    def set_mode_limit_battery_charge(self, rate):
+        self.set_mode_calls.append(('limit_battery_charge', rate))
+        self._maybe_fail()
 
     def activate_mqtt(self, api):
         self.mqtt_api = api
 
     def refresh_api_values(self):
-        if self.should_fail:
-            raise ConnectionError("Inverter unreachable")
+        self._maybe_fail()
 
     def shutdown(self):
         pass
 
 
-class TestCachedValues:
-    """Tests for the CachedValues dataclass."""
+# ---------------------------------------------------------------------------
+# Fail-fast before initialization
+# ---------------------------------------------------------------------------
 
-    def test_default_values(self):
-        cache = CachedValues()
-        assert cache.soc is None
-        assert cache.stored_energy is None
-        assert cache.capacity is None
-
-    def test_is_valid_when_empty(self):
-        cache = CachedValues()
-        assert cache.is_valid() is False
-
-    def test_is_valid_with_required_values(self):
-        cache = CachedValues(soc=75.0, capacity=10000.0)
-        assert cache.is_valid() is True
-
-    def test_is_valid_partial(self):
-        cache = CachedValues(soc=75.0)
-        assert cache.is_valid() is False
-
-
-class TestResilientWrapperFirstRun:
-    """Tests for first-run behavior (config error detection)."""
-
-    def test_first_run_failure_propagates(self):
-        """First connection failure should propagate immediately."""
-        mock_inverter = MockInverter(should_fail=True)
-        wrapper = ResilientInverterWrapper(mock_inverter)
-
+class TestPreInitFailFast:
+    def test_read_failure_before_init_propagates(self):
+        inv = MockInverter(should_fail=True)
+        w = ResilientInverterWrapper(inv)
         with pytest.raises(ConnectionError):
-            wrapper.get_SOC()
+            w.get_SOC()
 
-    def test_first_run_success_sets_flag(self):
-        """Successful set_mode should set the initialization flag."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(mock_inverter)
+    def test_command_failure_before_init_propagates(self):
+        inv = MockInverter(should_fail=True)
+        w = ResilientInverterWrapper(inv)
+        with pytest.raises(ConnectionError):
+            w.set_mode_allow_discharge()
 
-        # get_SOC doesn't mark initialization complete
-        wrapper.get_SOC()
-        assert wrapper._initialization_complete is False
+    def test_successful_set_mode_marks_initialized(self):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv)
+        assert w._initialized is False
+        w.set_mode_allow_discharge()
+        assert w._initialized is True
 
-        # set_mode marks initialization complete
-        wrapper.set_mode_allow_discharge()
-        assert wrapper._initialization_complete is True
-
-    def test_first_run_caches_values(self):
-        """Successful first run should cache values."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(mock_inverter)
-
-        wrapper.get_SOC()
-
-        assert wrapper._cache.soc == 75.0
+    def test_read_success_does_not_mark_initialized(self):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv)
+        w.get_SOC()
+        assert w._initialized is False
 
 
-class TestResilientWrapperOutage:
-    """Tests for outage handling behavior."""
+# ---------------------------------------------------------------------------
+# Cache behaviour during outages
+# ---------------------------------------------------------------------------
 
-    def test_subsequent_failure_uses_cache(self):
-        """After initialization, failures should use cached values."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(mock_inverter, outage_tolerance_seconds=60)
+class TestCacheDuringOutage:
+    def _init(self, **kw):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv, **kw)
+        w.set_mode_allow_discharge()
+        w.get_SOC()  # prime cache
+        return inv, w
 
-        # Initialize with set_mode and cache SOC
-        wrapper.set_mode_allow_discharge()
-        soc1 = wrapper.get_SOC()
-        assert soc1 == 75.0
+    def test_read_returns_cached_value_after_failure(self):
+        inv, w = self._init(outage_tolerance_seconds=60)
+        inv.should_fail = True
+        assert w.get_SOC() == 75.0
 
-        # Now fail
-        mock_inverter.should_fail = True
-        soc2 = wrapper.get_SOC()
+    def test_read_returns_cached_value_during_backoff(self):
+        inv, w = self._init(outage_tolerance_seconds=60, retry_backoff_seconds=60)
+        inv.should_fail = True
+        w.get_SOC()  # triggers failure, starts backoff
+        inv.should_fail = False
+        # still in backoff - must use cache, not call inverter
+        calls_before = inv.soc_calls
+        assert w.get_SOC() == 75.0
+        assert inv.soc_calls == calls_before  # no new call
 
-        # Should return cached value
-        assert soc2 == 75.0
-        assert wrapper._consecutive_failures == 1
+    def test_soc_default_used_when_cache_empty(self):
+        inv, w = self._init(outage_tolerance_seconds=60)
+        del w._cache['soc']  # clear soc from cache
+        inv.should_fail = True
+        assert w.get_SOC() == 50.0  # default
 
-    def test_failure_tracking_starts_on_first_failure(self):
-        """Failure timer should start on first failure after initialization."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(mock_inverter, outage_tolerance_seconds=60)
+    def test_outage_start_set_on_first_failure(self):
+        inv, w = self._init(outage_tolerance_seconds=60)
+        assert w._outage_start is None
+        inv.should_fail = True
+        w.get_SOC()
+        assert w._outage_start is not None
 
-        # Initialize with set_mode and cache values
-        wrapper.set_mode_allow_discharge()
-        wrapper.get_SOC()
-        assert wrapper._first_failure_time is None
+    def test_recovery_resets_outage_state(self):
+        inv, w = self._init(outage_tolerance_seconds=60, retry_backoff_seconds=0.05)
+        inv.should_fail = True
+        w.get_SOC()
+        assert w._outage_start is not None
 
-        # Now fail
-        mock_inverter.should_fail = True
-        wrapper.get_SOC()
-
-        assert wrapper._first_failure_time is not None
-
-    def test_outage_timeout_raises_error(self):
-        """After timeout, should raise InverterOutageError."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(
-            mock_inverter,
-            outage_tolerance_seconds=0.1,
-            retry_backoff_seconds=0.05  # Short backoff for testing
-        )
-
-        # Initialize with set_mode and cache values
-        wrapper.set_mode_allow_discharge()
-        wrapper.get_SOC()
-
-        # Now fail
-        mock_inverter.should_fail = True
-
-        # First failure uses cache
-        wrapper.get_SOC()
-
-        # Wait for timeout (and backoff to expire)
-        time.sleep(0.2)
-
-        # Next failure should raise InverterOutageError
-        with pytest.raises(InverterOutageError) as exc_info:
-            wrapper.get_SOC()
-
-        assert exc_info.value.outage_duration_seconds >= 0.1
-
-    def test_recovery_resets_failure_tracking(self):
-        """Successful call after failures should reset tracking."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(
-            mock_inverter,
-            outage_tolerance_seconds=60,
-            retry_backoff_seconds=0.05  # Short backoff for testing
-        )
-
-        # Initialize with set_mode
-        wrapper.set_mode_allow_discharge()
-        wrapper.get_SOC()
-
-        # Fail
-        mock_inverter.should_fail = True
-        wrapper.get_SOC()
-        assert wrapper._first_failure_time is not None
-        assert wrapper._consecutive_failures == 1
-
-        # Wait for backoff to expire
         time.sleep(0.1)
+        inv.should_fail = False
+        w.get_SOC()
 
-        # Recover
-        mock_inverter.should_fail = False
-        wrapper.get_SOC()
+        assert w._outage_start is None
+        assert not w._in_backoff()
 
-        assert wrapper._first_failure_time is None
-        assert wrapper._consecutive_failures == 0
+    def test_outage_error_after_tolerance_exceeded(self):
+        inv, w = self._init(outage_tolerance_seconds=0.1, retry_backoff_seconds=0.05)
+        inv.should_fail = True
+        w.get_SOC()          # first failure, starts backoff
+        time.sleep(0.2)      # exceed both backoff and tolerance
+        with pytest.raises(InverterOutageError):
+            w.get_SOC()
 
 
-class TestResilientWrapperBackoff:
-    """Tests for retry backoff behavior."""
+# ---------------------------------------------------------------------------
+# Command behaviour during outages
+# ---------------------------------------------------------------------------
 
-    def test_backoff_skips_inverter_call(self):
-        """During backoff period, actual inverter calls should be skipped."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(
-            mock_inverter,
-            outage_tolerance_seconds=60,
-            retry_backoff_seconds=0.5  # 500ms backoff for testing
-        )
+class TestCommandsDuringOutage:
+    def _init(self, **kw):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv, **kw)
+        w.set_mode_allow_discharge()
+        return inv, w
 
-        # Initialize with set_mode and cache values
-        wrapper.set_mode_allow_discharge()
-        wrapper.get_SOC()
+    def test_command_discarded_during_backoff(self):
+        inv, w = self._init(outage_tolerance_seconds=60, retry_backoff_seconds=60)
+        inv.should_fail = True
+        w.get_SOC()  # triggers failure, starts backoff
+        inv.should_fail = False
 
-        # Now fail
-        mock_inverter.should_fail = True
-        wrapper.get_SOC()  # This will fail and start backoff
-        call_count_after_failure = mock_inverter.get_soc_calls
+        calls_before = len(inv.set_mode_calls)
+        result = w.set_mode_avoid_discharge()
 
-        # Subsequent calls during backoff should NOT hit the inverter
-        for _ in range(3):
-            wrapper.get_SOC()
+        assert result is None
+        assert len(inv.set_mode_calls) == calls_before  # not sent
 
-        # Call count should be same (no new calls during backoff)
-        assert mock_inverter.get_soc_calls == call_count_after_failure
+    def test_command_failure_returns_none_not_crash(self):
+        inv, w = self._init(outage_tolerance_seconds=60)
+        inv.should_fail = True
+        result = w.set_mode_force_charge(5000)
+        assert result is None
+        # The call was attempted
+        assert ('force_charge', 5000) in inv.set_mode_calls
 
-    def test_backoff_uses_cached_value(self):
-        """During backoff period, cached values should be returned."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(
-            mock_inverter,
-            outage_tolerance_seconds=60,
-            retry_backoff_seconds=0.5
-        )
+    def test_command_raises_outage_error_after_tolerance(self):
+        inv, w = self._init(outage_tolerance_seconds=0.1, retry_backoff_seconds=0.05)
+        inv.should_fail = True
+        w.set_mode_allow_discharge()  # first failure, returns None
+        time.sleep(0.2)
+        with pytest.raises(InverterOutageError):
+            w.set_mode_allow_discharge()
 
-        # Initialize with set_mode and cache value
-        wrapper.set_mode_allow_discharge()
-        soc1 = wrapper.get_SOC()
-        assert soc1 == 75.0
+    def test_all_set_mode_variants_work(self):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv)
+        w.set_mode_force_charge(5000)
+        w.set_mode_avoid_discharge()
+        w.set_mode_allow_discharge()
+        w.set_mode_limit_battery_charge(3000)
+        assert ('force_charge', 5000) in inv.set_mode_calls
+        assert ('avoid_discharge',) in inv.set_mode_calls
+        assert ('allow_discharge',) in inv.set_mode_calls
+        assert ('limit_battery_charge', 3000) in inv.set_mode_calls
+        assert w._initialized is True
 
-        # Fail to start backoff
-        mock_inverter.should_fail = True
-        wrapper.get_SOC()
 
-        # During backoff, should return cached value without calling inverter
-        soc2 = wrapper.get_SOC()
-        assert soc2 == 75.0
+# ---------------------------------------------------------------------------
+# Backoff mechanics
+# ---------------------------------------------------------------------------
+
+class TestBackoff:
+    def test_backoff_active_after_failure(self):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=60, retry_backoff_seconds=60)
+        w.set_mode_allow_discharge()
+        w.get_SOC()
+        inv.should_fail = True
+        w.get_SOC()
+        assert w._in_backoff() is True
 
     def test_backoff_expires_and_retries(self):
-        """After backoff period, should retry actual inverter call."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(
-            mock_inverter,
-            outage_tolerance_seconds=60,
-            retry_backoff_seconds=0.1  # 100ms backoff
-        )
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=60, retry_backoff_seconds=0.1)
+        w.set_mode_allow_discharge()
+        w.get_SOC()
+        inv.should_fail = True
+        w.get_SOC()
+        calls_after_fail = inv.soc_calls
 
-        # Initialize with set_mode and cache values
-        wrapper.set_mode_allow_discharge()
-        wrapper.get_SOC()
-
-        # Fail to start backoff
-        mock_inverter.should_fail = True
-        wrapper.get_SOC()
-        call_count_after_first_failure = mock_inverter.get_soc_calls
-
-        # Wait for backoff to expire
         time.sleep(0.15)
+        inv.should_fail = False
+        w.get_SOC()
+        assert inv.soc_calls > calls_after_fail
 
-        # Now call should actually hit the inverter again
-        wrapper.get_SOC()
-        assert mock_inverter.get_soc_calls > call_count_after_first_failure
+    def test_recovery_clears_backoff(self):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=60, retry_backoff_seconds=0.1)
+        w.set_mode_allow_discharge()
+        w.get_SOC()
+        inv.should_fail = True
+        w.get_SOC()
+        assert w._in_backoff() is True
 
-    def test_backoff_recovery_resets_backoff(self):
-        """When inverter recovers, backoff should be reset."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(
-            mock_inverter,
-            outage_tolerance_seconds=60,
-            retry_backoff_seconds=0.5
-        )
-
-        # Initialize with set_mode
-        wrapper.set_mode_allow_discharge()
-        wrapper.get_SOC()
-
-        # Fail
-        mock_inverter.should_fail = True
-        wrapper.get_SOC()
-        assert wrapper._is_in_backoff_period() is True
-
-        # Wait for backoff to expire
-        time.sleep(0.6)
-
-        # Recover
-        mock_inverter.should_fail = False
-        wrapper.get_SOC()
-
-        # Backoff should be reset
-        assert wrapper._is_in_backoff_period() is False
-        assert wrapper._last_failure_time is None
-
-    def test_outage_status_includes_backoff_info(self):
-        """Outage status should include backoff information."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(
-            mock_inverter,
-            outage_tolerance_seconds=60,
-            retry_backoff_seconds=1.0
-        )
-
-        # Initialize with set_mode
-        wrapper.set_mode_allow_discharge()
-        wrapper.get_SOC()
-        status = wrapper.get_outage_status()
-        assert status['in_backoff_period'] is False
-
-        # Fail
-        mock_inverter.should_fail = True
-        wrapper.get_SOC()
-
-        status = wrapper.get_outage_status()
-        assert status['in_backoff_period'] is True
-        assert status['retry_backoff_seconds'] == 1.0
-        assert status['time_until_retry_seconds'] > 0
-
-
-class TestResilientWrapperDefaultValue:
-    """Tests for default value handling when no cache is available."""
-
-    def test_soc_default_value_on_first_failure_after_success(self):
-        """SOC should have a safe default if no cache available."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(mock_inverter, outage_tolerance_seconds=60)
-
-        # Initialize with set_mode and cache values
-        wrapper.set_mode_allow_discharge()
-        wrapper.get_SOC()
-
-        # Clear the cache manually (simulate edge case)
-        wrapper._cache.soc = None
-
-        # Now fail
-        mock_inverter.should_fail = True
-        soc = wrapper.get_SOC()
-
-        # Should return default safe value
-        assert soc == 50.0
-
-
-class TestResilientWrapperWriteOperations:
-    """Tests for write operations (mode changes)."""
-
-    def test_set_mode_passes_through(self):
-        """Set mode operations should pass through to inverter."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(mock_inverter)
-
-        # set_mode calls mark initialization complete
-        wrapper.set_mode_force_charge(5000)
-        assert wrapper._initialization_complete is True
-
-        wrapper.set_mode_avoid_discharge()
-        wrapper.set_mode_allow_discharge()
-
-        assert ('force_charge', 5000) in mock_inverter.set_mode_calls
-        assert ('avoid_discharge',) in mock_inverter.set_mode_calls
-        assert ('allow_discharge',) in mock_inverter.set_mode_calls
-
-    def test_set_mode_failure_during_outage_degrades_gracefully(self):
-        """A transient command failure must not crash; it degrades to None.
-
-        Commands (set_mode_*) have no cached fallback. Within the outage
-        tolerance window a failed command should return None (to be retried
-        next cycle) instead of raising RuntimeError, which would otherwise
-        bring down the whole process.
-        """
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(mock_inverter, outage_tolerance_seconds=60)
-
-        # Initialize with set_mode
-        wrapper.set_mode_allow_discharge()
-
-        # Now fail
-        mock_inverter.should_fail = True
-
-        result = wrapper.set_mode_force_charge(5000)
-
-        assert result is None
-        # The command was actually attempted on the inverter
-        assert ('force_charge', 5000) in mock_inverter.set_mode_calls
-        assert wrapper._consecutive_failures == 1
-
-    def test_set_mode_discarded_during_backoff(self):
-        """During backoff the inverter is presumed unavailable.
-
-        A read failure (e.g. refresh_api_values / get_*) starts a backoff
-        window. A command issued in that window must be discarded (returns
-        None) instead of being fired at a presumed-dead inverter or crashing.
-        batcontrol re-issues the mode on the next cycle.
-        """
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(
-            mock_inverter,
-            outage_tolerance_seconds=60,
-            retry_backoff_seconds=60  # long backoff so it stays active
-        )
-
-        # Initialize and cache a value
-        wrapper.set_mode_allow_discharge()
-        wrapper.get_SOC()
-
-        # A transient read failure starts the backoff window
-        mock_inverter.should_fail = True
-        wrapper.get_SOC()
-        assert wrapper._is_in_backoff_period() is True
-
-        # A command issued during backoff is discarded - not sent, no crash.
-        calls_before = len(mock_inverter.set_mode_calls)
-        result = wrapper.set_mode_avoid_discharge()
-
-        assert result is None
-        assert len(mock_inverter.set_mode_calls) == calls_before
-
-    def test_set_mode_first_run_failure_propagates(self):
-        """Before initialization, a command failure must still fail fast."""
-        mock_inverter = MockInverter(should_fail=True)
-        wrapper = ResilientInverterWrapper(mock_inverter)
-
-        with pytest.raises(ConnectionError):
-            wrapper.set_mode_allow_discharge()
-
-    def test_set_mode_raises_outage_error_after_tolerance(self):
-        """A command must surface InverterOutageError once tolerance is exceeded."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(
-            mock_inverter,
-            outage_tolerance_seconds=0.1,
-            retry_backoff_seconds=0.05
-        )
-
-        # Initialize
-        wrapper.set_mode_allow_discharge()
-
-        # Permanent outage
-        mock_inverter.should_fail = True
-
-        # First failure degrades gracefully (within tolerance)
-        assert wrapper.set_mode_allow_discharge() is None
-
-        # Wait beyond tolerance
         time.sleep(0.15)
-
-        with pytest.raises(InverterOutageError):
-            wrapper.set_mode_allow_discharge()
-
-
-class TestResilientWrapperStatus:
-    """Tests for status/diagnostic methods."""
-
-    def test_get_outage_status_when_connected(self):
-        """Status should show connected state."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(mock_inverter)
-
-        wrapper.set_mode_allow_discharge()
-        status = wrapper.get_outage_status()
-
-        assert status['is_connected'] is True
-        assert status['initialization_complete'] is True
-        assert status['consecutive_failures'] == 0
-
-    def test_get_outage_status_during_outage(self):
-        """Status should show outage state."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(mock_inverter, outage_tolerance_seconds=60)
-
-        wrapper.set_mode_allow_discharge()
-        wrapper.get_SOC()  # Cache a value
-        mock_inverter.should_fail = True
-        wrapper.get_SOC()
-
-        status = wrapper.get_outage_status()
-
-        assert status['is_connected'] is False
-        assert status['consecutive_failures'] == 1
-        assert status['outage_duration_seconds'] >= 0
+        inv.should_fail = False
+        w.get_SOC()
+        assert w._in_backoff() is False
 
 
-class TestResilientWrapperAttributeForwarding:
-    """Tests for attribute forwarding to wrapped inverter."""
+# ---------------------------------------------------------------------------
+# Outage status / diagnostics
+# ---------------------------------------------------------------------------
 
-    def test_attributes_forwarded(self):
-        """Common attributes should be forwarded from wrapped inverter."""
-        mock_inverter = MockInverter()
-        wrapper = ResilientInverterWrapper(mock_inverter)
+class TestOutageStatus:
+    def test_connected_state(self):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv)
+        w.set_mode_allow_discharge()
+        s = w.get_outage_status()
+        assert s['is_connected'] is True
+        assert s['initialization_complete'] is True
+        assert s['in_backoff_period'] is False
 
-        assert wrapper.min_soc == 10
-        assert wrapper.max_soc == 95
-        assert wrapper.max_grid_charge_rate == 5000
+    def test_outage_state(self):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=60)
+        w.set_mode_allow_discharge()
+        w.get_SOC()
+        inv.should_fail = True
+        w.get_SOC()
 
-    def test_unknown_attribute_forwarded(self):
-        """Unknown attributes should be forwarded via __getattr__."""
-        mock_inverter = MockInverter()
-        mock_inverter.custom_attr = "test_value"
-        wrapper = ResilientInverterWrapper(mock_inverter)
+        s = w.get_outage_status()
+        assert s['is_connected'] is False
+        assert s['in_backoff_period'] is True
+        assert s['time_until_retry_seconds'] > 0
 
-        assert wrapper.custom_attr == "test_value"
+    def test_backoff_info_in_status(self):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=60, retry_backoff_seconds=1.0)
+        w.set_mode_allow_discharge()
+        w.get_SOC()
+        inv.should_fail = True
+        w.get_SOC()
+
+        s = w.get_outage_status()
+        assert s['retry_backoff_seconds'] == 1.0
+        assert s['time_until_retry_seconds'] > 0
+
+
+# ---------------------------------------------------------------------------
+# Attribute forwarding
+# ---------------------------------------------------------------------------
+
+class TestAttributeForwarding:
+    def test_common_attributes_forwarded(self):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv)
+        assert w.min_soc == 10
+        assert w.max_soc == 95
+        assert w.max_grid_charge_rate == 5000
+
+    def test_unknown_attributes_forwarded_via_getattr(self):
+        inv = MockInverter()
+        inv.custom_attr = "hello"
+        w = ResilientInverterWrapper(inv)
+        assert w.custom_attr == "hello"
 
     def test_wrapped_inverter_accessible(self):
-        """Wrapped inverter should be accessible for advanced use."""
-        mock_inverter = MockInverter()
-        wrapper = ResilientInverterWrapper(mock_inverter)
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv)
+        assert w.wrapped_inverter is inv
 
-        assert wrapper.wrapped_inverter is mock_inverter
-
-
-class TestResilientWrapperMqtt:
-    """Tests for MQTT-related functionality."""
-
-    def test_activate_mqtt_forwards_to_inverter(self):
-        """MQTT activation should be forwarded."""
-        mock_inverter = MockInverter()
-        wrapper = ResilientInverterWrapper(mock_inverter)
-
-        mock_api = Mock()
-        wrapper.activate_mqtt(mock_api)
-
-        assert mock_inverter.mqtt_api is mock_api
+    def test_activate_mqtt_forwarded(self):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv)
+        api = Mock()
+        w.activate_mqtt(api)
+        assert inv.mqtt_api is api
 
 
-class TestResilientWrapperIntegration:
-    """Integration tests simulating real-world scenarios."""
+# ---------------------------------------------------------------------------
+# Integration scenarios
+# ---------------------------------------------------------------------------
 
-    def test_firmware_upgrade_scenario(self):
-        """Simulate a firmware upgrade with recovery."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(
-            mock_inverter,
-            outage_tolerance_seconds=0.5,
-            retry_backoff_seconds=0.05  # Short backoff for testing
-        )
+class TestIntegration:
+    def test_firmware_upgrade_and_recovery(self):
+        """Simulate: outage -> cached reads -> recovery."""
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=1.0, retry_backoff_seconds=0.05)
+        w.set_mode_allow_discharge()
+        assert w.get_SOC() == 75.0
 
-        # Initialize with set_mode
-        wrapper.set_mode_allow_discharge()
-
-        # Normal operation
-        soc1 = wrapper.get_SOC()
-        assert soc1 == 75.0
-
-        # Firmware upgrade starts - inverter goes offline
-        mock_inverter.should_fail = True
-
-        # Multiple calls during outage - should use cache
-        for _ in range(5):
-            soc = wrapper.get_SOC()
-            assert soc == 75.0
+        inv.should_fail = True
+        for _ in range(3):
+            assert w.get_SOC() == 75.0  # cache
             time.sleep(0.02)
 
-        # Wait for backoff to expire
-        time.sleep(0.1)
+        time.sleep(0.1)  # backoff expires
+        inv.should_fail = False
+        assert w.get_SOC() == 75.0
+        assert w._outage_start is None
 
-        # Inverter comes back online
-        mock_inverter.should_fail = False
-        soc2 = wrapper.get_SOC()
+    def test_permanent_outage_raises(self):
+        """Simulate: outage exceeding tolerance -> InverterOutageError."""
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=0.1, retry_backoff_seconds=0.05)
+        w.set_mode_allow_discharge()
+        w.get_SOC()
 
-        assert soc2 == 75.0
-        assert wrapper._first_failure_time is None  # Reset after recovery
+        inv.should_fail = True
+        w.get_SOC()  # first failure
 
-    def test_permanent_outage_scenario(self):
-        """Simulate a permanent outage exceeding tolerance."""
-        mock_inverter = MockInverter(should_fail=False)
-        wrapper = ResilientInverterWrapper(
-            mock_inverter,
-            outage_tolerance_seconds=0.1,
-            retry_backoff_seconds=0.05  # Short backoff for testing
-        )
-
-        # Initialize with set_mode
-        wrapper.set_mode_allow_discharge()
-
-        # Normal operation
-        wrapper.get_SOC()
-
-        # Permanent outage
-        mock_inverter.should_fail = True
-
-        # First failure uses cache
-        wrapper.get_SOC()
-
-        # Wait beyond tolerance (and backoff)
         time.sleep(0.15)
-
-        # Should raise InverterOutageError
         with pytest.raises(InverterOutageError):
-            wrapper.get_SOC()
+            w.get_SOC()

--- a/tests/batcontrol/inverter/test_resilient_wrapper.py
+++ b/tests/batcontrol/inverter/test_resilient_wrapper.py
@@ -422,8 +422,14 @@ class TestResilientWrapperWriteOperations:
         assert ('avoid_discharge',) in mock_inverter.set_mode_calls
         assert ('allow_discharge',) in mock_inverter.set_mode_calls
 
-    def test_set_mode_failure_during_outage(self):
-        """Set mode failures during outage should raise RuntimeError (no cache)."""
+    def test_set_mode_failure_during_outage_degrades_gracefully(self):
+        """A transient command failure must not crash; it degrades to None.
+
+        Commands (set_mode_*) have no cached fallback. Within the outage
+        tolerance window a failed command should return None (to be retried
+        next cycle) instead of raising RuntimeError, which would otherwise
+        bring down the whole process.
+        """
         mock_inverter = MockInverter(should_fail=False)
         wrapper = ResilientInverterWrapper(mock_inverter, outage_tolerance_seconds=60)
 
@@ -433,12 +439,75 @@ class TestResilientWrapperWriteOperations:
         # Now fail
         mock_inverter.should_fail = True
 
-        # Write operations don't have cache, should raise RuntimeError
-        # because there's no cached value or default for write operations
-        with pytest.raises(RuntimeError) as exc_info:
-            wrapper.set_mode_force_charge(5000)
+        result = wrapper.set_mode_force_charge(5000)
 
-        assert "No cached value or default available" in str(exc_info.value)
+        assert result is None
+        # The command was actually attempted on the inverter
+        assert ('force_charge', 5000) in mock_inverter.set_mode_calls
+        assert wrapper._consecutive_failures == 1
+
+    def test_set_mode_discarded_during_backoff(self):
+        """During backoff the inverter is presumed unavailable.
+
+        A read failure (e.g. refresh_api_values / get_*) starts a backoff
+        window. A command issued in that window must be discarded (returns
+        None) instead of being fired at a presumed-dead inverter or crashing.
+        batcontrol re-issues the mode on the next cycle.
+        """
+        mock_inverter = MockInverter(should_fail=False)
+        wrapper = ResilientInverterWrapper(
+            mock_inverter,
+            outage_tolerance_seconds=60,
+            retry_backoff_seconds=60  # long backoff so it stays active
+        )
+
+        # Initialize and cache a value
+        wrapper.set_mode_allow_discharge()
+        wrapper.get_SOC()
+
+        # A transient read failure starts the backoff window
+        mock_inverter.should_fail = True
+        wrapper.get_SOC()
+        assert wrapper._is_in_backoff_period() is True
+
+        # A command issued during backoff is discarded - not sent, no crash.
+        calls_before = len(mock_inverter.set_mode_calls)
+        result = wrapper.set_mode_avoid_discharge()
+
+        assert result is None
+        assert len(mock_inverter.set_mode_calls) == calls_before
+
+    def test_set_mode_first_run_failure_propagates(self):
+        """Before initialization, a command failure must still fail fast."""
+        mock_inverter = MockInverter(should_fail=True)
+        wrapper = ResilientInverterWrapper(mock_inverter)
+
+        with pytest.raises(ConnectionError):
+            wrapper.set_mode_allow_discharge()
+
+    def test_set_mode_raises_outage_error_after_tolerance(self):
+        """A command must surface InverterOutageError once tolerance is exceeded."""
+        mock_inverter = MockInverter(should_fail=False)
+        wrapper = ResilientInverterWrapper(
+            mock_inverter,
+            outage_tolerance_seconds=0.1,
+            retry_backoff_seconds=0.05
+        )
+
+        # Initialize
+        wrapper.set_mode_allow_discharge()
+
+        # Permanent outage
+        mock_inverter.should_fail = True
+
+        # First failure degrades gracefully (within tolerance)
+        assert wrapper.set_mode_allow_discharge() is None
+
+        # Wait beyond tolerance
+        time.sleep(0.15)
+
+        with pytest.raises(InverterOutageError):
+            wrapper.set_mode_allow_discharge()
 
 
 class TestResilientWrapperStatus:

--- a/tests/batcontrol/inverter/test_resilient_wrapper.py
+++ b/tests/batcontrol/inverter/test_resilient_wrapper.py
@@ -1,10 +1,11 @@
-"""Tests for ResilientInverterWrapper.
+"""Tests for the simplified ResilientInverterWrapper.
 
 Behaviour under test:
-1. Before first successful set_mode_*: errors propagate immediately (fail-fast).
-2. After initialization: read failures return cached values; commands are discarded.
+1. Before the first successful set_mode_*: errors propagate unchanged (fail-fast).
+2. After initialization: any failure raises InverterCommunicationError so the
+   caller can skip the cycle. No caching - nothing is returned on failure.
 3. After the outage tolerance expires: InverterOutageError is raised.
-4. Automatic recovery when the connection is restored.
+4. Successful calls reset the outage tracking (automatic recovery).
 """
 
 import pytest
@@ -12,7 +13,10 @@ import time
 from unittest.mock import Mock
 
 from batcontrol.inverter.resilient_wrapper import ResilientInverterWrapper
-from batcontrol.inverter.exceptions import InverterOutageError
+from batcontrol.inverter.exceptions import (
+    InverterCommunicationError,
+    InverterOutageError,
+)
 
 
 class MockInverter:
@@ -27,6 +31,7 @@ class MockInverter:
         self.max_pv_charge_rate = 0
         self.soc_calls = 0
         self.set_mode_calls = []
+        self.refresh_calls = 0
 
     def _maybe_fail(self):
         if self.should_fail:
@@ -77,6 +82,7 @@ class MockInverter:
         self.mqtt_api = api
 
     def refresh_api_values(self):
+        self.refresh_calls += 1
         self._maybe_fail()
 
     def shutdown(self):
@@ -89,133 +95,136 @@ class MockInverter:
 
 class TestPreInitFailFast:
     def test_read_failure_before_init_propagates(self):
-        inv = MockInverter(should_fail=True)
-        w = ResilientInverterWrapper(inv)
+        w = ResilientInverterWrapper(MockInverter(should_fail=True))
         with pytest.raises(ConnectionError):
             w.get_SOC()
 
     def test_command_failure_before_init_propagates(self):
-        inv = MockInverter(should_fail=True)
-        w = ResilientInverterWrapper(inv)
+        w = ResilientInverterWrapper(MockInverter(should_fail=True))
         with pytest.raises(ConnectionError):
             w.set_mode_allow_discharge()
 
     def test_successful_set_mode_marks_initialized(self):
-        inv = MockInverter()
-        w = ResilientInverterWrapper(inv)
+        w = ResilientInverterWrapper(MockInverter())
         assert w._initialized is False
         w.set_mode_allow_discharge()
         assert w._initialized is True
 
     def test_read_success_does_not_mark_initialized(self):
-        inv = MockInverter()
-        w = ResilientInverterWrapper(inv)
+        w = ResilientInverterWrapper(MockInverter())
         w.get_SOC()
         assert w._initialized is False
 
 
 # ---------------------------------------------------------------------------
-# Cache behaviour during outages
+# After init: failures raise InverterCommunicationError
 # ---------------------------------------------------------------------------
 
-class TestCacheDuringOutage:
+class TestCommunicationError:
     def _init(self, **kw):
         inv = MockInverter()
         w = ResilientInverterWrapper(inv, **kw)
-        w.set_mode_allow_discharge()
-        w.get_SOC()  # prime cache
+        w.set_mode_allow_discharge()  # initialize
         return inv, w
 
-    def test_read_returns_cached_value_after_failure(self):
+    def test_read_failure_raises_communication_error(self):
         inv, w = self._init(outage_tolerance_seconds=60)
         inv.should_fail = True
-        assert w.get_SOC() == 75.0
-
-    def test_read_returns_cached_value_during_backoff(self):
-        inv, w = self._init(outage_tolerance_seconds=60, retry_backoff_seconds=60)
-        inv.should_fail = True
-        w.get_SOC()  # triggers failure, starts backoff
-        inv.should_fail = False
-        # still in backoff - must use cache, not call inverter
-        calls_before = inv.soc_calls
-        assert w.get_SOC() == 75.0
-        assert inv.soc_calls == calls_before  # no new call
-
-    def test_soc_default_used_when_cache_empty(self):
-        inv, w = self._init(outage_tolerance_seconds=60)
-        del w._cache['soc']  # clear soc from cache
-        inv.should_fail = True
-        assert w.get_SOC() == 50.0  # default
-
-    def test_outage_start_set_on_first_failure(self):
-        inv, w = self._init(outage_tolerance_seconds=60)
-        assert w._outage_start is None
-        inv.should_fail = True
-        w.get_SOC()
-        assert w._outage_start is not None
-
-    def test_recovery_resets_outage_state(self):
-        inv, w = self._init(outage_tolerance_seconds=60, retry_backoff_seconds=0.05)
-        inv.should_fail = True
-        w.get_SOC()
-        assert w._outage_start is not None
-
-        time.sleep(0.1)
-        inv.should_fail = False
-        w.get_SOC()
-
-        assert w._outage_start is None
-        assert not w._in_backoff()
-
-    def test_outage_error_after_tolerance_exceeded(self):
-        inv, w = self._init(outage_tolerance_seconds=0.1, retry_backoff_seconds=0.05)
-        inv.should_fail = True
-        w.get_SOC()          # first failure, starts backoff
-        time.sleep(0.2)      # exceed both backoff and tolerance
-        with pytest.raises(InverterOutageError):
+        with pytest.raises(InverterCommunicationError):
             w.get_SOC()
 
+    def test_command_failure_raises_communication_error(self):
+        inv, w = self._init(outage_tolerance_seconds=60)
+        inv.should_fail = True
+        with pytest.raises(InverterCommunicationError):
+            w.set_mode_force_charge(5000)
+        # The command was actually attempted on the inverter
+        assert ('force_charge', 5000) in inv.set_mode_calls
+
+    def test_outage_start_recorded_on_first_failure(self):
+        inv, w = self._init(outage_tolerance_seconds=60)
+        assert w._outage_start is None
+        inv.should_fail = True
+        with pytest.raises(InverterCommunicationError):
+            w.get_SOC()
+        assert w._outage_start is not None
+
+    def test_recovery_resets_outage_tracking(self):
+        inv, w = self._init(outage_tolerance_seconds=60)
+        inv.should_fail = True
+        with pytest.raises(InverterCommunicationError):
+            w.get_SOC()
+        assert w._outage_start is not None
+
+        inv.should_fail = False
+        assert w.get_SOC() == 75.0
+        assert w._outage_start is None
+
 
 # ---------------------------------------------------------------------------
-# Command behaviour during outages
+# Outage tolerance -> InverterOutageError
 # ---------------------------------------------------------------------------
 
-class TestCommandsDuringOutage:
+class TestOutageError:
     def _init(self, **kw):
         inv = MockInverter()
         w = ResilientInverterWrapper(inv, **kw)
         w.set_mode_allow_discharge()
         return inv, w
 
-    def test_command_discarded_during_backoff(self):
-        inv, w = self._init(outage_tolerance_seconds=60, retry_backoff_seconds=60)
+    def test_read_raises_outage_error_after_tolerance(self):
+        inv, w = self._init(outage_tolerance_seconds=0.1)
         inv.should_fail = True
-        w.get_SOC()  # triggers failure, starts backoff
-        inv.should_fail = False
-
-        calls_before = len(inv.set_mode_calls)
-        result = w.set_mode_avoid_discharge()
-
-        assert result is None
-        assert len(inv.set_mode_calls) == calls_before  # not sent
-
-    def test_command_failure_returns_none_not_crash(self):
-        inv, w = self._init(outage_tolerance_seconds=60)
-        inv.should_fail = True
-        result = w.set_mode_force_charge(5000)
-        assert result is None
-        # The call was attempted
-        assert ('force_charge', 5000) in inv.set_mode_calls
+        with pytest.raises(InverterCommunicationError):
+            w.get_SOC()  # first failure, within tolerance
+        time.sleep(0.15)
+        with pytest.raises(InverterOutageError):
+            w.get_SOC()  # tolerance exceeded
 
     def test_command_raises_outage_error_after_tolerance(self):
-        inv, w = self._init(outage_tolerance_seconds=0.1, retry_backoff_seconds=0.05)
+        inv, w = self._init(outage_tolerance_seconds=0.1)
         inv.should_fail = True
-        w.set_mode_allow_discharge()  # first failure, returns None
-        time.sleep(0.2)
+        with pytest.raises(InverterCommunicationError):
+            w.set_mode_allow_discharge()
+        time.sleep(0.15)
         with pytest.raises(InverterOutageError):
             w.set_mode_allow_discharge()
 
-    def test_all_set_mode_variants_work(self):
+    def test_outage_error_is_communication_error_subclass(self):
+        # core.run catches InverterCommunicationError; InverterOutageError must
+        # NOT be swallowed there, so it must not be a subclass of it.
+        assert not issubclass(InverterOutageError, InverterCommunicationError)
+
+
+# ---------------------------------------------------------------------------
+# refresh_api_values is best-effort
+# ---------------------------------------------------------------------------
+
+class TestRefreshApiValues:
+    def test_refresh_never_raises(self):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv)
+        w.set_mode_allow_discharge()
+        inv.should_fail = True
+        # Must not raise even though the inverter is unreachable
+        w.refresh_api_values()
+        assert inv.refresh_calls == 1
+
+    def test_refresh_does_not_start_outage_tracking(self):
+        inv = MockInverter()
+        w = ResilientInverterWrapper(inv)
+        w.set_mode_allow_discharge()
+        inv.should_fail = True
+        w.refresh_api_values()
+        assert w._outage_start is None
+
+
+# ---------------------------------------------------------------------------
+# All set_mode variants
+# ---------------------------------------------------------------------------
+
+class TestSetModeVariants:
+    def test_all_set_mode_variants_pass_through(self):
         inv = MockInverter()
         w = ResilientInverterWrapper(inv)
         w.set_mode_force_charge(5000)
@@ -230,101 +239,17 @@ class TestCommandsDuringOutage:
 
 
 # ---------------------------------------------------------------------------
-# Backoff mechanics
+# Attribute forwarding / passthrough
 # ---------------------------------------------------------------------------
 
-class TestBackoff:
-    def test_backoff_active_after_failure(self):
-        inv = MockInverter()
-        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=60, retry_backoff_seconds=60)
-        w.set_mode_allow_discharge()
-        w.get_SOC()
-        inv.should_fail = True
-        w.get_SOC()
-        assert w._in_backoff() is True
-
-    def test_backoff_expires_and_retries(self):
-        inv = MockInverter()
-        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=60, retry_backoff_seconds=0.1)
-        w.set_mode_allow_discharge()
-        w.get_SOC()
-        inv.should_fail = True
-        w.get_SOC()
-        calls_after_fail = inv.soc_calls
-
-        time.sleep(0.15)
-        inv.should_fail = False
-        w.get_SOC()
-        assert inv.soc_calls > calls_after_fail
-
-    def test_recovery_clears_backoff(self):
-        inv = MockInverter()
-        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=60, retry_backoff_seconds=0.1)
-        w.set_mode_allow_discharge()
-        w.get_SOC()
-        inv.should_fail = True
-        w.get_SOC()
-        assert w._in_backoff() is True
-
-        time.sleep(0.15)
-        inv.should_fail = False
-        w.get_SOC()
-        assert w._in_backoff() is False
-
-
-# ---------------------------------------------------------------------------
-# Outage status / diagnostics
-# ---------------------------------------------------------------------------
-
-class TestOutageStatus:
-    def test_connected_state(self):
-        inv = MockInverter()
-        w = ResilientInverterWrapper(inv)
-        w.set_mode_allow_discharge()
-        s = w.get_outage_status()
-        assert s['is_connected'] is True
-        assert s['initialization_complete'] is True
-        assert s['in_backoff_period'] is False
-
-    def test_outage_state(self):
-        inv = MockInverter()
-        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=60)
-        w.set_mode_allow_discharge()
-        w.get_SOC()
-        inv.should_fail = True
-        w.get_SOC()
-
-        s = w.get_outage_status()
-        assert s['is_connected'] is False
-        assert s['in_backoff_period'] is True
-        assert s['time_until_retry_seconds'] > 0
-
-    def test_backoff_info_in_status(self):
-        inv = MockInverter()
-        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=60, retry_backoff_seconds=1.0)
-        w.set_mode_allow_discharge()
-        w.get_SOC()
-        inv.should_fail = True
-        w.get_SOC()
-
-        s = w.get_outage_status()
-        assert s['retry_backoff_seconds'] == 1.0
-        assert s['time_until_retry_seconds'] > 0
-
-
-# ---------------------------------------------------------------------------
-# Attribute forwarding
-# ---------------------------------------------------------------------------
-
-class TestAttributeForwarding:
+class TestForwarding:
     def test_common_attributes_forwarded(self):
-        inv = MockInverter()
-        w = ResilientInverterWrapper(inv)
+        w = ResilientInverterWrapper(MockInverter())
         assert w.min_soc == 10
         assert w.max_soc == 95
         assert w.max_grid_charge_rate == 5000
 
-    def test_unknown_attributes_forwarded_via_getattr(self):
+    def test_unknown_attribute_forwarded_via_getattr(self):
         inv = MockInverter()
         inv.custom_attr = "hello"
         w = ResilientInverterWrapper(inv)
@@ -348,32 +273,33 @@ class TestAttributeForwarding:
 # ---------------------------------------------------------------------------
 
 class TestIntegration:
-    def test_firmware_upgrade_and_recovery(self):
-        """Simulate: outage -> cached reads -> recovery."""
+    def test_outage_then_recovery(self):
+        """A few failed cycles, then the inverter comes back."""
         inv = MockInverter()
-        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=1.0, retry_backoff_seconds=0.05)
+        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=60)
         w.set_mode_allow_discharge()
         assert w.get_SOC() == 75.0
 
+        # Inverter goes offline - each cycle raises a comm error
         inv.should_fail = True
         for _ in range(3):
-            assert w.get_SOC() == 75.0  # cache
-            time.sleep(0.02)
+            with pytest.raises(InverterCommunicationError):
+                w.get_SOC()
 
-        time.sleep(0.1)  # backoff expires
+        # Inverter recovers
         inv.should_fail = False
         assert w.get_SOC() == 75.0
         assert w._outage_start is None
 
-    def test_permanent_outage_raises(self):
-        """Simulate: outage exceeding tolerance -> InverterOutageError."""
+    def test_permanent_outage_terminates(self):
         inv = MockInverter()
-        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=0.1, retry_backoff_seconds=0.05)
+        w = ResilientInverterWrapper(inv, outage_tolerance_seconds=0.1)
         w.set_mode_allow_discharge()
         w.get_SOC()
 
         inv.should_fail = True
-        w.get_SOC()  # first failure
+        with pytest.raises(InverterCommunicationError):
+            w.get_SOC()
 
         time.sleep(0.15)
         with pytest.raises(InverterOutageError):

--- a/tests/batcontrol/test_core.py
+++ b/tests/batcontrol/test_core.py
@@ -11,6 +11,10 @@ from batcontrol.core import (
     MODE_ALLOW_DISCHARGING,
     MODE_LIMIT_BATTERY_CHARGE_RATE,
 )
+from batcontrol.inverter import (
+    InverterCommunicationError,
+    InverterOutageError,
+)
 from batcontrol.logic.logic import Logic as LogicFactory
 
 
@@ -451,6 +455,39 @@ class TestCoreRunDispatch:
         mock_inverter.set_mode_force_charge.assert_not_called()
         mock_inverter.set_mode_avoid_discharge.assert_not_called()
         mock_inverter.set_mode_limit_battery_charge.assert_not_called()
+
+    def test_run_skips_cycle_on_communication_error(self, run_dispatch_setup):
+        """A transient inverter outage aborts the cycle without raising."""
+        bc, mock_inverter, _fake_logic = run_dispatch_setup
+        mock_inverter.get_stored_energy.side_effect = \
+            InverterCommunicationError("get_stored_energy")
+
+        # Must not raise - the cycle is skipped and retried on the next run.
+        bc.run()
+
+        # No control action was applied this cycle.
+        mock_inverter.set_mode_allow_discharge.assert_not_called()
+        mock_inverter.set_mode_force_charge.assert_not_called()
+        mock_inverter.set_mode_avoid_discharge.assert_not_called()
+
+    def test_run_propagates_outage_error(self, run_dispatch_setup):
+        """A permanent outage propagates so the main loop can terminate."""
+        bc, mock_inverter, _fake_logic = run_dispatch_setup
+        mock_inverter.get_stored_energy.side_effect = \
+            InverterOutageError("permanent", outage_duration_seconds=9999)
+
+        with pytest.raises(InverterOutageError):
+            bc.run()
+
+    def test_api_set_mode_swallows_communication_error(self, run_dispatch_setup):
+        """Externally triggered control tolerates a transient outage."""
+        bc, mock_inverter, _fake_logic = run_dispatch_setup
+        mock_inverter.set_mode_avoid_discharge.side_effect = \
+            InverterCommunicationError("set_mode_avoid_discharge")
+
+        # api_set_mode runs on a background thread; it must not raise.
+        from batcontrol.core import MODE_AVOID_DISCHARGING
+        bc.api_set_mode(MODE_AVOID_DISCHARGING)
 
     def test_run_passes_preserve_min_grid_charge_soc_to_logic(
             self, run_dispatch_setup):


### PR DESCRIPTION
## Summary

Refactor `ResilientInverterWrapper` to use a simpler, three-state failure model instead of caching values during outages. The wrapper now:

1. **Before initialization** (first successful `set_mode_*`): propagate errors unchanged (fail-fast for config errors)
2. **After initialization**: raise `InverterCommunicationError` on any failure, allowing the caller to skip the cycle and retry on the next scheduled run
3. **After tolerance window expires**: escalate to `InverterOutageError` to terminate batcontrol

This eliminates the complexity of caching, backoff periods, and default values while maintaining the same resilience guarantees.

## Key Changes

- **Removed caching logic**: No more `CachedValues` dataclass or cache fallback during outages. Failures are signaled immediately via exceptions instead.
- **Removed retry backoff**: The main loop's natural interval (15 minutes) serves as the backoff; no need for explicit backoff tracking.
- **Simplified state tracking**: Replaced `_initialization_complete`, `_first_failure_time`, `_last_failure_time`, `_consecutive_failures` with just `_initialized` and `_outage_start`.
- **New exception hierarchy**: Added `InverterError` base class and `InverterCommunicationError` for transient failures; `InverterOutageError` remains for permanent outages.
- **Thin proxy design**: `ResilientInverterWrapper` now uses `__getattr__` to delegate all attributes and methods to the wrapped inverter, only intercepting method calls to guard them.
- **Best-effort methods**: `refresh_api_values()` and `shutdown()` never raise or start outage tracking—they log and continue.
- **Updated `core.run()`**: Catches `InverterCommunicationError` to skip the control cycle; `InverterOutageError` propagates to terminate.
- **Background thread safety**: Added `@_tolerate_inverter_outage` decorator for externally triggered actions (MQTT/evcc) to swallow transient failures.

## Implementation Details

- The wrapper intercepts method calls via `__getattr__` and wraps them with `_guard()`, which classifies failures based on initialization state and outage duration.
- Command methods (`set_mode_*`) mark initialization complete on first success.
- Read methods (e.g., `get_SOC()`) no longer cache values; failures immediately raise `InverterCommunicationError`.
- Tests reduced from 582 to 306 lines, focusing on the three-state model rather than caching behavior.
- Documentation updated to reflect the new behavior and exception semantics.

https://claude.ai/code/session_019TARxrY2uWGTDuxwyugtqD