### PR TITLE
docs: generate llms.txt and llms-full.txt via mkdocs-llmstxt plugin

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install documentation dependencies
-        run: pip install "mkdocs-material>=9.5,<10"
+        run: pip install "mkdocs-material>=9.5,<10" "mkdocs-llmstxt>=0.1.0"
 
       - name: Build documentation
         run: mkdocs build --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install documentation dependencies
-        run: pip install "mkdocs-material>=9.5,<10" "mkdocs-llmstxt>=0.1.0"
+        run: pip install "mkdocs-material>=9.5,<10" "mkdocs-llmstxt>=0.5.0,<1.0"
 
       - name: Build documentation
         run: mkdocs build --strict

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,4 +97,4 @@ config/
 ---
 
 **LLM-friendly versions of this documentation:**
-[llms.txt](llms.txt) — [llms-full.txt](llms-full.txt)
+[llms.txt](https://mastr.github.io/batcontrol/llms.txt) — [llms-full.txt](https://mastr.github.io/batcontrol/llms-full.txt)

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,3 +93,8 @@ config/
 📝 **Documentation Status**: This documentation lives in the [`docs/` folder of the batcontrol repository](https://github.com/MaStr/batcontrol/tree/main/docs). If you find outdated information or need additional details, please open an issue or pull request.
 
 🔗 **Project Repository**: [GitHub - Batcontrol](https://github.com/MaStr/batcontrol)
+
+---
+
+**LLM-friendly versions of this documentation:**
+[llms.txt](llms.txt) — [llms-full.txt](llms-full.txt)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,38 @@ markdown_extensions:
 
 plugins:
   - search
+  - llmstxt:
+      markdown_description: |
+        Batcontrol controls a PV battery inverter based on dynamic electricity prices,
+        solar production forecasts, and consumption patterns. It charges from the grid
+        when prices are low and preserves stored energy when prices are high. It supports
+        Fronius Gen24 inverters (HTTP API and Modbus TCP) and any inverter via MQTT bridge.
+        Tariff providers include Tibber, aWATTar, evcc, EnergyForecast.de, and static zone
+        tariffs. Solar forecast sources include Forecast.Solar, Solar-Prognose.de, evcc,
+        and Home Assistant Solar Forecast ML. Peak shaving distributes PV battery charging
+        across the day using forecasts, and works with both dynamic and static tariffs.
+      full_output: llms-full.txt
+      sections:
+        Getting Started:
+          - getting-started/installation.md: Installation guide with pre-flight checklist, Docker setup, and next steps
+          - getting-started/how-batcontrol-works.md: Architecture, control loop, forecasting system, and decision logic
+        Configuration:
+          - configuration/batcontrol-configuration.md: Main configuration file reference
+          - configuration/inverter-configuration.md: Fronius Gen24, Fronius Modbus, and MQTT inverter configuration
+          - configuration/dynamic-tariff-provider.md: Tibber, aWATTar, evcc, EnergyForecast, and static tariff zones
+          - configuration/solar-forecast.md: Forecast.Solar, Solar-Prognose.de, evcc, and Home Assistant ML
+          - configuration/consumption-forecast.md: CSV load profile and Home Assistant API forecast
+        Features:
+          - features/peak-shaving.md: Dynamic PV charge rate limiting to maximize solar absorption
+          - features/battery-control-expert.md: Advanced tuning parameters
+          - features/price-difference-calculation.md: How price thresholds are calculated
+        Integrations:
+          - integrations/mqtt-api.md: MQTT state publishing, runtime overrides, and Home Assistant auto-discovery
+          - integrations/mqtt-inverter.md: Integrating any battery system via MQTT bridge
+          - integrations/evcc-connection.md: Coordinating with EV charging via evcc
+          - integrations/forecast-metrics.md: Forecast data exposed via MQTT
+        Optional:
+          - development/15-min-transform.md: Internal 15-minute interval resolution
 
 nav:
   - Home: index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ test = [
 ]
 docs = [
     "mkdocs-material>=9.5,<10",
-    "mkdocs-llmstxt>=0.5.0; python_version >= '3.10'",
+    "mkdocs-llmstxt>=0.5.0,<1.0; python_version >= '3.10'",
 ]
 
 # Bump Version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = [
 ]
 docs = [
     "mkdocs-material>=9.5,<10",
+    "mkdocs-llmstxt>=0.1.0",
 ]
 
 # Bump Version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ test = [
 ]
 docs = [
     "mkdocs-material>=9.5,<10",
-    "mkdocs-llmstxt>=0.1.0",
+    "mkdocs-llmstxt>=0.5.0; python_version >= '3.10'",
 ]
 
 # Bump Version


### PR DESCRIPTION
## Summary

- Adds the [`mkdocs-llmstxt`](https://github.com/pawamoy/mkdocs-llmstxt) plugin which generates `/llms.txt` and `/llms-full.txt` automatically during each MkDocs build
- `llms.txt` follows the [llmstxt.org](https://llmstxt.org) standard: project summary + curated links to all documentation pages with descriptions
- `llms-full.txt` contains the full content of all linked pages expanded inline
- Both files are served via GitHub Pages at `https://mastr.github.io/batcontrol/llms.txt` and `.../llms-full.txt`
- Links to both files added to the docs index page

## Changes

- `mkdocs.yml` — plugin configured with project description and all doc sections
- `pyproject.toml` — `mkdocs-llmstxt` added to `[docs]` optional dependencies
- `.github/workflows/docs.yml` — plugin added to pip install step
- `docs/index.md` — links to `llms.txt` and `llms-full.txt` added at the bottom

## Test plan

- [ ] CI docs build passes
- [ ] After merge: `https://mastr.github.io/batcontrol/llms.txt` and `llms-full.txt` are reachable
- [ ] Links on the docs index page resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)