### PR TITLE
fix: add WORKDIR /build in builder stage to fix uv 0.11 cache error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM python:3.13-alpine AS builder
 # Install uv for fast, reliable Python packaging
 COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /usr/local/bin/uv
 
+WORKDIR /build
+
 # Copy only whats needed for dependencies first
 COPY pyproject.toml LICENSE README.md ./
 


### PR DESCRIPTION
uv 0.11 refuses to build if its cache dir (/root/.cache/uv) is inside
the build source directory. Without an explicit WORKDIR the builder stage
defaulted to /, making / the source root and triggering the new safety
check.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Zhp8eDqpSFxMru61fBKXK