### PR TITLE
feat: add Solcast rooftop API as solar forecast provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ src/batcontrol/
   logic/                  # Battery control decisions (default, next)
   inverter/               # Backends: Fronius HTTP, Fronius Modbus, MQTT, Dummy
   dynamictariff/          # Tariff providers: Awattar, Tibber, evcc, EnergyForecast, NetworkFees
-  forecastsolar/          # Solar forecast: FCSolar, SolarPrognose, evcc, HA-ML
+  forecastsolar/          # Solar forecast: FCSolar, SolarPrognose, evcc, HA-ML, Solcast
   forecastconsumption/    # Consumption forecast: CSV, HomeAssistant
   fetcher/                # HTTP caching helper
   scheduler.py            # Main loop

--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -176,6 +176,7 @@ mqtt:
 #  - solarprognose.de : needs an API key, see https://www.solarprognose.de/solar-api/ for details
 #  - homeassistant-solar-forecast-ml: HomeAssistant Solar Forecast ML integration (HACS)
 #  - evcc: local instance of evcc via REST API
+#  - solcast: Solcast rooftop API, free hobbyist account, see https://solcast.com/
 #
 #  DEMO: This configuration uses a simple PV installation for demonstration.
 #  For real operation, update the values below with your actual PV system details.
@@ -201,6 +202,14 @@ pvinstallations:
   #   entity_id: sensor.solar_forecast_ml_evcc_solar_prognose  # Forecast sensor entity
   #   sensor_unit: auto                           # Options: 'auto' (detect), 'Wh', or 'kWh'
   #   cache_ttl_hours: 24.0                       # Cache duration in hours
+
+  # ALTERNATIVE: Solcast - https://solcast.com/ (free hobbyist account, 10 requests/day)
+  # Site geometry (lat/lon, tilt, azimuth, kWp) is configured in the Solcast
+  # web toolkit, not here. Set solar_forecast_provider: solcast to use it.
+  # - name: Haus
+  #   resource_id: xxxx-xxxx-xxxx-xxxx  # from your Solcast rooftop site
+  #   apikey: your-solcast-api-key      # from your Solcast account settings
+  #   percentile: 50                    # optional: 10 (pessimistic), 50 (default), 90 (optimistic)
 
 #--------------------------
 #  Forecast Consumption

--- a/docs/configuration/solar-forecast.md
+++ b/docs/configuration/solar-forecast.md
@@ -4,6 +4,7 @@ The following providers are currently available:
 * [Solarprognose.de](https://www.solarprognose.de) - since 0.5.0
 * local evcc instance - since 0.5.3
 * [HomeAssistant Solar Forecast ML](https://zara-toorox.github.io/) - since 0.7.0
+* [Solcast](https://solcast.com/) - since 0.8.1
 
 Multiple Installations can be entered, like this:
 
@@ -147,6 +148,66 @@ The `sensor_unit` parameter:
 - `kWh`: If you know your sensor reports in kWh
 
 Setting the explicit unit (`Wh` or `kWh`) can speed up startup by skipping auto-detection.
+
+## Solcast
+
+[Solcast](https://solcast.com/) provides satellite-based solar forecasts in native 30-minute resolution. batcontrol interpolates the values to 15-minute intervals (linear power interpolation) or aggregates them to hourly values, depending on your `time_resolution_minutes` setting.
+
+Solcast delivers three estimates per 30-minute period: a most-likely value (50 % percentile), a pessimistic one (10 %, more clouds) and an optimistic one (90 %, fewer clouds). By default batcontrol uses the most-likely value.
+
+### Free hobbyist account (registration walkthrough)
+
+Solcast offers a free "Home User" (hobbyist) account which is sufficient for batcontrol:
+
+1. Register at [solcast.com](https://solcast.com/free-rooftop-solar-forecasting) and choose the free **Home User** (hobbyist) plan.
+2. In the Solcast toolkit, create a **Rooftop Site**. Enter your location (latitude/longitude), panel tilt, azimuth and capacity (kWp) there — the site geometry lives in your Solcast account, **not** in the batcontrol configuration.
+3. Copy the site's **resource id** (shown in the site details, format `xxxx-xxxx-xxxx-xxxx`).
+4. Copy your **API key** from the Solcast account settings.
+
+The free account is limited to **one location with up to two rooftop sites** (e.g. an east/west split) and **10 API requests per day**.
+
+### Configuration
+
+The minimum configuration is:
+
+```yaml
+solar_forecast_provider: solcast
+pvinstallations:
+  - name: Haus #name
+    resource_id: xxxx-xxxx-xxxx-xxxx  # from your Solcast rooftop site
+    apikey: your-solcast-api-key      # from your Solcast account settings
+```
+
+For two rooftop sites (e.g. east/west arrays) use one entry per site. The API key is the same for both, each site has its own resource id:
+
+```yaml
+solar_forecast_provider: solcast
+pvinstallations:
+  - name: Dach Ost
+    resource_id: xxxx-xxxx-xxxx-aaaa
+    apikey: your-solcast-api-key
+  - name: Dach West
+    resource_id: xxxx-xxxx-xxxx-bbbb
+    apikey: your-solcast-api-key
+```
+
+### Optional percentile parameter
+
+You can select which estimate batcontrol uses per installation:
+
+```yaml
+pvinstallations:
+  - name: Haus
+    resource_id: xxxx-xxxx-xxxx-xxxx
+    apikey: your-solcast-api-key
+    percentile: 10  # 10 (pessimistic), 50 (default, most likely), 90 (optimistic)
+```
+
+A pessimistic setting (`percentile: 10`) makes batcontrol plan with less expected solar production, which reduces the risk of an undercharged battery on cloudy days.
+
+### Rate limit
+
+batcontrol keeps well within the free tier's 10 requests/day: it enforces a minimum refresh interval of 3 hours per configured site, scaled with the number of sites (one site: every 3 hours, two sites: every 6 hours — at most 8 requests per day, leaving 2 in reserve). If the API reports that the quota is exhausted (HTTP 429), batcontrol pauses requests and keeps working on cached forecast data.
 
 ## Adjusting Production Forecasts
 

--- a/docs/development/15-min-transform.md
+++ b/docs/development/15-min-transform.md
@@ -328,7 +328,7 @@ class ForecastSolarBase(ABC):
     Key Design: Providers return FULL-HOUR aligned data, baseclass shifts to CURRENT interval.
     
     Subclasses must:
-    1. Set self.native_resolution (15 or 60) in __init__
+    1. Set self.native_resolution (15, 30 or 60) in __init__
     2. Implement _fetch_forecast() to return hour-aligned data
     
     Example at 10:20:
@@ -548,7 +548,72 @@ class EvccSolar(ForecastSolarBase):
         return self._parse_15min_data(response)
 ```
 
-##### C. Tibber (Dynamic Resolution)
+##### C. Solcast (30-min Native)
+```python
+# src/batcontrol/forecastsolar/solcast.py
+
+from .baseclass import ForecastSolarBaseclass
+
+class Solcast(ForecastSolarBaseclass):
+    """Solcast rooftop provider - returns 30-minute data."""
+
+    def __init__(self, ...):
+        super().__init__(..., native_resolution=30)  # Declares: "I provide 30-min data"
+        # ... rest of init ...
+
+    def get_forecast_from_raw_data(self) -> Dict[int, float]:
+        """Parse cached 30-minute forecast periods, hour-aligned."""
+        # Returns: {0: 500, 1: 700, 2: 900, ...}  # Wh per 30-min bucket
+        # Index 0 = :00-:30 of the current hour, index 1 = :30-:00, etc.
+        ...
+```
+
+#### 30-Minute Native Resolution
+
+Some providers (e.g. Solcast) deliver forecast periods of 30 minutes. The
+baseclass converts them with the same rules used for the existing 60/15
+paths — implemented in `interval_utils` via the `source_resolution`
+parameter:
+
+| Conversion | Function call | Rule |
+|------------|---------------|------|
+| 30 → 15 | `upsample_forecast(data, target_resolution=15, method='linear', source_resolution=30)` | Linear **power** interpolation between buckets |
+| 30 → 60 | `downsample_to_hourly(data, source_resolution=30)` | Sum of the two 30-min buckets per hour (exact energy) |
+
+**Index contract** (Full-Hour Alignment unchanged): with
+`native_resolution=30` the provider returns hour-aligned data where index 0
+covers `:00`–`:30` of the current hour and index 1 covers `:30`–`:00`.
+Since 30-minute periods always sit on hour/half-hour boundaries, the
+alignment strategy needs no special handling.
+
+**Worked example (30 → 15, linear)** — analogous to the hourly example
+above. Input buckets in Wh per 30 minutes:
+
+```python
+{0: 500, 1: 1000}   # avg power: 1000 W, 2000 W
+```
+
+The values are NOT simply halved/duplicated per quarter — power rises (or
+falls) across the interpolation:
+
+```python
+# 15-min intervals (linear power ramp 1000 W -> 2000 W):
+# [0]: Power = 1000 W -> Energy = 1000 * 0.25 = 250 Wh
+# [1]: Power = 1500 W -> Energy = 1500 * 0.25 = 375 Wh
+# [2]: Power = 2000 W -> Energy = 2000 * 0.25 = 500 Wh  (last bucket)
+# [3]: Power = 2000 W -> Energy = 2000 * 0.25 = 500 Wh
+{0: 250, 1: 375, 2: 500, 3: 500}
+```
+
+Plain duplication would have produced `{0: 250, 1: 250, 2: 500, 3: 500}`
+with a hard step between the buckets — the interpolation produces a smooth
+ramp instead, which matches the physical behavior of solar power.
+
+**Last-bucket rule**: the final bucket has no successor to interpolate
+towards, so its power is kept constant across its quarters (same rule as
+the last hour in the 60 → 15 path).
+
+##### D. Tibber (Dynamic Resolution)
 ```python
 # src/batcontrol/dynamictariff/tibber.py
 

--- a/src/batcontrol/forecastsolar/baseclass.py
+++ b/src/batcontrol/forecastsolar/baseclass.py
@@ -29,9 +29,16 @@ class ForecastSolarBaseclass(ForecastSolarInterface):
 
         Supports Full-Hour Alignment strategy:
         - Providers return hour-aligned data (index 0 = start of current hour)
-        - Baseclass handles resolution conversion (hourly <-> 15-min)
+        - Baseclass handles resolution conversion (hourly <-> 15-min, 30-min -> 15/60-min)
         - Baseclass shifts indices to current-interval alignment
         - Core receives data where [0] = current interval
+
+        Provider contract per native_resolution:
+        - 60: index = hour offset from start of current hour, values in Wh per hour
+        - 30: index = 30-min offset from start of current hour
+          (index 0 = :00-:30, index 1 = :30-:00), values in Wh per 30 minutes
+        - 15: index = 15-min offset from start of current hour,
+          values in Wh per 15 minutes
     """
 
     def __init__(self, pvinstallations, timezone, min_time_between_API_calls,
@@ -47,7 +54,7 @@ class ForecastSolarBaseclass(ForecastSolarInterface):
 
         # Resolution configuration
         self.target_resolution = target_resolution  # What core.py expects (15 or 60)
-        self.native_resolution = native_resolution  # What provider returns (15 or 60)
+        self.native_resolution = native_resolution  # What provider returns (15, 30 or 60)
 
         logger.info(
             '%s: native_resolution=%d min, target_resolution=%d min',
@@ -188,6 +195,17 @@ class ForecastSolarBaseclass(ForecastSolarInterface):
             logger.debug('%s: Downsampling 15min -> 60min by summing quarters',
                          self.__class__.__name__)
             return downsample_to_hourly(forecast)
+
+        if self.native_resolution == 30 and self.target_resolution == 15:
+            logger.debug('%s: Upsampling 30min -> 15min using linear interpolation',
+                         self.__class__.__name__)
+            return upsample_forecast(forecast, target_resolution=15,
+                                     method='linear', source_resolution=30)
+
+        if self.native_resolution == 30 and self.target_resolution == 60:
+            logger.debug('%s: Downsampling 30min -> 60min by summing bucket pairs',
+                         self.__class__.__name__)
+            return downsample_to_hourly(forecast, source_resolution=30)
 
         logger.error('%s: Cannot convert %d min -> %d min',
                      self.__class__.__name__,

--- a/src/batcontrol/forecastsolar/solar.py
+++ b/src/batcontrol/forecastsolar/solar.py
@@ -5,6 +5,7 @@ from .fcsolar import FCSolar
 from .solarprognose import SolarPrognose
 from .evcc_solar import EvccSolar
 from .forecast_homeassistant_ml import ForecastSolarHomeAssistantML
+from .solcast import Solcast
 
 
 class ForecastSolar:
@@ -24,7 +25,7 @@ class ForecastSolar:
             min_time_between_api_calls: Minimum seconds between API calls
             api_delay: Delay for API evaluation
             requested_provider: Provider name ('fcsolarapi', 'solarprognose', 'evcc-solar',
-                                'homeassistant-solar-forecast-ml')
+                                'homeassistant-solar-forecast-ml', 'solcast')
             target_resolution: Target resolution in minutes (15 or 60)
 
         Raises:
@@ -41,6 +42,9 @@ class ForecastSolar:
         elif requested_provider.lower() == 'evcc-solar':
             provider = EvccSolar(config, timezone, min_time_between_api_calls,
                                  api_delay, target_resolution)
+        elif requested_provider.lower() == 'solcast':
+            provider = Solcast(config, timezone, min_time_between_api_calls,
+                               api_delay, target_resolution)
         elif requested_provider.lower() == 'homeassistant-solar-forecast-ml':
             # Parse HomeAssistant Solar Forecast ML configuration from pvinstallations
             # Each installation can have type='homeassistant-solar-forecast-ml' with connection details

--- a/src/batcontrol/forecastsolar/solcast.py
+++ b/src/batcontrol/forecastsolar/solcast.py
@@ -1,0 +1,220 @@
+""" Module to get solar forecasts from the Solcast rooftop API
+
+https://docs.solcast.com.au/
+GET https://api.solcast.com.au/rooftop_sites/{resource_id}/forecasts
+
+The rooftop site (location, tilt, azimuth, capacity) is configured in the
+Solcast web toolkit, not in batcontrol. Each installation entry only needs
+the site's resource_id and the account's apikey.
+
+The free hobbyist plan allows 10 API requests per day. Each configured
+installation costs one request per refresh, so the minimum time between
+refreshes is scaled with the number of installations (see __init__).
+"""
+
+import datetime
+import logging
+import time
+import requests
+from .baseclass import ForecastSolarBaseclass, ProviderError, RateLimitException
+
+logger = logging.getLogger(__name__)
+logger.info('Loading module')
+
+API_BASE_URL = 'https://api.solcast.com.au/rooftop_sites'
+FORECAST_HOURS = 72
+PERCENTILE_FIELD_MAP = {10: 'pv_estimate10', 50: 'pv_estimate', 90: 'pv_estimate90'}
+
+
+class Solcast(ForecastSolarBaseclass):
+    """ Provider to get data from the Solcast rooftop API
+
+    Returns 30-minute data at native resolution.
+    Baseclass handles conversion to 15-min (linear power interpolation)
+    or 60-min (bucket pair sum) as needed.
+    """
+
+    def __init__(self, pvinstallations, timezone, min_time_between_api_calls,
+                 delay_evaluation_by_seconds, target_resolution=60) -> None:
+        """ Initialize the Solcast class
+
+        Args:
+            pvinstallations: List of PV installation configurations.
+                             Each entry needs 'name', 'resource_id' and 'apikey';
+                             'percentile' (10, 50 or 90) is optional.
+            timezone: Timezone for forecast data
+            min_time_between_api_calls: Minimum seconds between API calls
+            delay_evaluation_by_seconds: Delay for API evaluation
+            target_resolution: Target resolution in minutes (15 or 60)
+        """
+        # Free hobbyist tier allows 10 API requests/day; each installation
+        # costs one request per refresh. Budget 8 refresh cycles/day to keep
+        # 2 requests in reserve; scale with the number of installations.
+        self._provider_min = 24 * 60 * 60 * max(1, len(pvinstallations)) // 8
+        super().__init__(pvinstallations, timezone,
+                         max(min_time_between_api_calls, self._provider_min),
+                         delay_evaluation_by_seconds,
+                         target_resolution=target_resolution,
+                         native_resolution=30)  # Solcast provides 30-minute data
+
+        for unit in pvinstallations:
+            name = unit.get('name')
+            if not unit.get('resource_id'):
+                raise ValueError(
+                    f'[Solcast] No resource_id provided for installation {name}')
+            if not unit.get('apikey'):
+                raise ValueError(
+                    f'[Solcast] No API key provided for installation {name}')
+            percentile = unit.get('percentile', 50)
+            if percentile not in PERCENTILE_FIELD_MAP:
+                raise ValueError(
+                    f'[Solcast] percentile must be one of 10, 50, 90 '
+                    f'for installation {name}, got {percentile}')
+
+    def get_forecast_from_raw_data(self) -> dict[int, float]:
+        """ Get hour-aligned 30-minute forecast from cached raw data.
+
+        Returns a dict mapping 30-minute interval index to energy in Wh.
+        Index 0 = :00-:30 of the current hour, index 1 = :30-:00, etc.
+        Baseclass converts to the target resolution.
+        """
+        results = self.get_all_raw_data()
+
+        now = datetime.datetime.now().astimezone(self.timezone)
+        current_hour_start = now.replace(minute=0, second=0, microsecond=0)
+
+        prediction = {}
+
+        for name, result in results.items():
+            unit = self._get_installation(name)
+            field = PERCENTILE_FIELD_MAP[unit.get('percentile', 50)]
+
+            if not result or 'forecasts' not in result:
+                logger.warning(
+                    'No forecasts in raw data for installation %s', name)
+                continue
+
+            for entry in result['forecasts']:
+                try:
+                    period_end = self._parse_period_end(entry['period_end'])
+                    period_start = period_end - datetime.timedelta(minutes=30)
+
+                    diff = period_start.astimezone(self.timezone) - current_hour_start
+                    rel_interval = int(diff.total_seconds() // 1800)
+                    if rel_interval < 0:
+                        continue
+
+                    value = entry.get(field, 0)
+                    if value is None:
+                        value = 0
+
+                    # API delivers average power in kW for a 30-minute period:
+                    # energy [Wh] = kW * 1000 [W] * 0.5 [h]
+                    energy_wh = float(value) * 500.0
+                    if rel_interval in prediction:
+                        prediction[rel_interval] += energy_wh
+                    else:
+                        prediction[rel_interval] = energy_wh
+                except (KeyError, ValueError, TypeError) as e:
+                    logger.warning(
+                        'Error processing forecast entry %s: %s', entry, e)
+                    continue
+
+        # complete intervals without production with 0 values
+        if prediction:
+            max_interval = max(prediction.keys())
+            for i in range(max_interval + 1):
+                if i not in prediction:
+                    prediction[i] = 0.0
+        else:
+            logger.warning('No results from Solcast API available')
+            return {}
+
+        output = dict(sorted(prediction.items()))
+        logger.debug('Returning %d 30-minute intervals', len(output))
+        return output
+
+    def get_raw_data_from_provider(self, pvinstallation_name) -> dict:
+        """ Get raw data from the Solcast rooftop API """
+        unit = self._get_installation(pvinstallation_name)
+        if unit is None:
+            raise RuntimeError(
+                f'[Solcast] PV Installation {pvinstallation_name} not found')
+
+        name = unit['name']
+        resource_id = unit['resource_id']
+        apikey = unit['apikey']
+
+        url = f'{API_BASE_URL}/{resource_id}/forecasts'
+        url += f'?format=json&hours={FORECAST_HOURS}'
+
+        logger.info(
+            'Requesting Information for PV Installation %s', name)
+
+        # API key goes into the Authorization header to keep it out of
+        # logged URLs.
+        headers = {'Authorization': f'Bearer {apikey}'}
+        response = requests.get(url, headers=headers, timeout=60)
+
+        if response.status_code == 200:
+            try:
+                return response.json()
+            except ValueError as e:
+                raise ProviderError(
+                    f'[Solcast] Invalid JSON response: {e}') from e
+        elif response.status_code in (401, 403):
+            logger.error(
+                'API returned %s - Unauthorized, apikey correct?',
+                response.status_code)
+            raise ProviderError(
+                f'[Solcast] API returned {response.status_code} - '
+                'Unauthorized, apikey correct?')
+        elif response.status_code == 404:
+            logger.error(
+                'API returned 404 - resource_id %s not found', resource_id)
+            raise ProviderError(
+                f'[Solcast] API returned 404 - resource_id {resource_id} not found')
+        elif response.status_code == 429:
+            self.__store_retry(response)
+            raise RateLimitException(
+                '[Solcast] API rate limit exceeded')
+        else:
+            logger.warning(
+                'Solcast API returned %s - %s',
+                response.status_code, response.text)
+            raise ProviderError(
+                f'[Solcast] API returned {response.status_code}')
+
+    def _get_installation(self, pvinstallation_name):
+        """ Find installation config by name """
+        for installation in self.pvinstallations:
+            if installation['name'] == pvinstallation_name:
+                return installation
+        return None
+
+    @staticmethod
+    def _parse_period_end(timestamp_str: str) -> datetime.datetime:
+        """ Parse Solcast period_end timestamps into UTC-aware datetimes.
+
+        Solcast returns e.g. '2026-01-01T01:00:00.0000000Z'. The 7-digit
+        fractional seconds and the trailing 'Z' are not supported by
+        datetime.fromisoformat before Python 3.11, so normalize first.
+        Periods always sit on :00/:30 boundaries, dropping the fractional
+        part is lossless.
+        """
+        base = timestamp_str.rstrip('Z').split('.')[0]
+        return datetime.datetime.fromisoformat(base).replace(
+            tzinfo=datetime.timezone.utc)
+
+    def __store_retry(self, response):
+        """ Set the rate limit blackout window after a 429 response """
+        retry_after = response.headers.get('Retry-After')
+        blackout_ts = 0
+        if retry_after is not None:
+            try:
+                blackout_ts = time.time() + int(retry_after)
+            except ValueError:
+                logger.debug('Unparseable Retry-After header: %s', retry_after)
+        if blackout_ts <= 0:
+            blackout_ts = time.time() + self._provider_min
+        self.rate_limit_blackout_window_ts = blackout_ts

--- a/src/batcontrol/forecastsolar/solcast.py
+++ b/src/batcontrol/forecastsolar/solcast.py
@@ -80,7 +80,7 @@ class Solcast(ForecastSolarBaseclass):
         """
         results = self.get_all_raw_data()
 
-        now = datetime.datetime.now().astimezone(self.timezone)
+        now = datetime.datetime.now(datetime.timezone.utc).astimezone(self.timezone)
         current_hour_start = now.replace(minute=0, second=0, microsecond=0)
 
         prediction = {}

--- a/src/batcontrol/forecastsolar/solcast.py
+++ b/src/batcontrol/forecastsolar/solcast.py
@@ -154,7 +154,11 @@ class Solcast(ForecastSolarBaseclass):
         # API key goes into the Authorization header to keep it out of
         # logged URLs.
         headers = {'Authorization': f'Bearer {apikey}'}
-        response = requests.get(url, headers=headers, timeout=60)
+        try:
+            response = requests.get(url, headers=headers, timeout=60)
+        except requests.exceptions.RequestException as e:
+            raise ProviderError(
+                f'[Solcast] API request failed: {e}') from e
 
         if response.status_code == 200:
             try:

--- a/src/batcontrol/interval_utils.py
+++ b/src/batcontrol/interval_utils.py
@@ -2,7 +2,7 @@
 Utility functions for time interval conversions and upsampling.
 
 This module provides functions to convert between different time resolutions
-(e.g., hourly to 15-minute intervals) for forecast data.
+(e.g., hourly or 30-minute to 15-minute intervals) for forecast data.
 """
 
 import logging
@@ -14,23 +14,25 @@ logger = logging.getLogger(__name__)
 def upsample_forecast(
     hourly_forecast: Dict[int, float],
     target_resolution: int = 15,
-    method: Literal['linear', 'constant'] = 'linear'
+    method: Literal['linear', 'constant'] = 'linear',
+    source_resolution: int = 60
 ) -> Dict[int, float]:
     """
-    Convert hourly forecast to finer resolution intervals.
+    Convert forecast to finer resolution intervals.
 
     Args:
-        hourly_forecast: Dictionary mapping hour index to energy value (Wh)
+        hourly_forecast: Dictionary mapping source interval index to energy value (Wh)
         target_resolution: Target resolution in minutes (currently only 15 supported)
         method: Upsampling method:
             - 'linear': Linear interpolation of power (recommended for solar)
             - 'constant': Equal distribution (recommended for prices/consumption)
+        source_resolution: Source resolution in minutes (60 or 30)
 
     Returns:
         Dictionary mapping interval index to energy value (Wh per interval)
 
     Note:
-        - Input values are Wh per hour (energy)
+        - Input values are Wh per source interval (energy)
         - Output values are Wh per target interval (energy)
         - Linear method interpolates power, then converts back to energy
         - Constant method divides energy equally across intervals
@@ -39,32 +41,39 @@ def upsample_forecast(
         raise ValueError(
             f"Only 15-minute resolution is currently supported, got {target_resolution}")
 
+    if source_resolution not in (30, 60):
+        raise ValueError(
+            f"Only 30 or 60 minute source resolution is supported, got {source_resolution}")
+
     if not hourly_forecast:
         logger.warning("Empty hourly_forecast provided to upsample_forecast")
         return {}
 
     if method == 'linear':
-        return _upsample_linear(hourly_forecast)
+        return _upsample_linear(hourly_forecast, source_resolution)
     if method == 'constant':
-        return _upsample_constant(hourly_forecast)
+        return _upsample_constant(hourly_forecast, source_resolution)
     raise ValueError(f"Unknown upsampling method: {method}")
 
 
-def _upsample_linear(hourly_forecast: Dict[int, float]) -> Dict[int, float]:
+def _upsample_linear(
+    hourly_forecast: Dict[int, float],
+    source_resolution: int = 60
+) -> Dict[int, float]:
     """
-    Convert hourly Wh forecast to 15-minute intervals with linear interpolation.
+    Convert Wh forecast to 15-minute intervals with linear interpolation.
 
     Important:
-    - Input is Wh per hour (energy values)
+    - Input is Wh per source interval (energy values, 60 or 30 minutes)
     - Output is Wh per 15 minutes
     - Uses linear power interpolation, then converts to energy
 
     Method:
-    1. Calculate average power per hour (Wh -> W)
-    2. Interpolate power linearly between hours
+    1. Calculate average power per source interval (Wh -> W)
+    2. Interpolate power linearly between source intervals
     3. Convert interpolated power back to energy (W -> Wh for 15 min)
 
-    Example:
+    Example (60-minute source):
         Hour 0: 1000 Wh -> avg power = 1000 W
         Hour 1: 2000 Wh -> avg power = 2000 W
 
@@ -74,23 +83,36 @@ def _upsample_linear(hourly_forecast: Dict[int, float]) -> Dict[int, float]:
         [2]: Power = 1500 W -> Energy = 1500 * 0.25 = 375 Wh
         [3]: Power = 1750 W -> Energy = 1750 * 0.25 = 437.5 Wh
         [4]: Power = 2000 W -> Energy = 2000 * 0.25 = 500 Wh (next hour begins)
+
+    Example (30-minute source):
+        Bucket 0: 500 Wh -> avg power = 1000 W
+        Bucket 1: 1000 Wh -> avg power = 2000 W
+
+        15-min intervals (linear power ramp, no plain doubling):
+        [0]: Power = 1000 W -> Energy = 1000 * 0.25 = 250 Wh
+        [1]: Power = 1500 W -> Energy = 1500 * 0.25 = 375 Wh
+        [2]: Power = 2000 W -> Energy = 2000 * 0.25 = 500 Wh (next bucket begins)
     """
     forecast_15min = {}
-    max_hour = max(hourly_forecast.keys())
+    max_idx = max(hourly_forecast.keys())
 
-    for hour in range(max_hour):
-        current_wh = hourly_forecast.get(hour, 0)
-        next_wh = hourly_forecast.get(hour + 1, 0)
+    # Number of 15-min intervals per source interval (60 -> 4, 30 -> 2)
+    steps = source_resolution // 15
+    # Wh per source interval -> average power in W (60 -> x1, 30 -> x2)
+    power_factor = 60 / source_resolution
+
+    for idx in range(max_idx):
+        current_wh = hourly_forecast.get(idx, 0)
+        next_wh = hourly_forecast.get(idx + 1, 0)
 
         # Convert Wh to average W (power)
-        # 1 Wh over 1 hour = 1 W average power
-        current_power = current_wh
-        next_power = next_wh
+        current_power = current_wh * power_factor
+        next_power = next_wh * power_factor
 
-        # Linear power interpolation across 4 quarters
-        for quarter in range(4):
-            interval_idx = hour * 4 + quarter
-            fraction = quarter / 4
+        # Linear power interpolation across the sub-intervals
+        for step in range(steps):
+            interval_idx = idx * steps + step
+            fraction = step / steps
 
             # Interpolate power linearly
             interpolated_power = current_power + (next_power - current_power) * fraction
@@ -98,47 +120,55 @@ def _upsample_linear(hourly_forecast: Dict[int, float]) -> Dict[int, float]:
             # Convert power to energy for 15 minutes: P[W] * 0.25[h] = E[Wh]
             forecast_15min[interval_idx] = interpolated_power * 0.25
 
-    # Handle the last hour (no interpolation, just divide)
-    if max_hour in hourly_forecast:
-        last_wh = hourly_forecast[max_hour]
-        last_power = last_wh
-        for quarter in range(4):
-            interval_idx = max_hour * 4 + quarter
+    # Handle the last source interval (no interpolation, constant power)
+    if max_idx in hourly_forecast:
+        last_power = hourly_forecast[max_idx] * power_factor
+        for step in range(steps):
+            interval_idx = max_idx * steps + step
             forecast_15min[interval_idx] = last_power * 0.25
 
     return forecast_15min
 
 
-def _upsample_constant(hourly_forecast: Dict[int, float]) -> Dict[int, float]:
+def _upsample_constant(
+    hourly_forecast: Dict[int, float],
+    source_resolution: int = 60
+) -> Dict[int, float]:
     """
-    Convert hourly forecast to 15-minute intervals with constant distribution.
+    Convert forecast to 15-minute intervals with constant distribution.
 
-    Simply divides each hourly value by 4 to get quarter-hourly values.
-    This is appropriate for prices or consumption where interpolation
-    doesn't make physical sense.
+    Simply divides each source value by the number of 15-minute steps it
+    contains (4 for hourly, 2 for 30-minute data). This is appropriate for
+    prices or consumption where interpolation doesn't make physical sense.
 
-    Example:
+    Example (60-minute source):
         Hour 0: 1000 Wh -> 250, 250, 250, 250 Wh per 15 min
         Hour 1: 2000 Wh -> 500, 500, 500, 500 Wh per 15 min
     """
     forecast_15min = {}
 
-    for hour, value in hourly_forecast.items():
-        # Distribute equally across 4 quarters
-        quarter_value = value / 4
-        for quarter in range(4):
-            interval_idx = hour * 4 + quarter
-            forecast_15min[interval_idx] = quarter_value
+    steps = source_resolution // 15
+
+    for idx, value in hourly_forecast.items():
+        # Distribute equally across the sub-intervals
+        step_value = value / steps
+        for step in range(steps):
+            interval_idx = idx * steps + step
+            forecast_15min[interval_idx] = step_value
 
     return forecast_15min
 
 
-def downsample_to_hourly(data_15min: Dict[int, float]) -> Dict[int, float]:
+def downsample_to_hourly(
+    data_15min: Dict[int, float],
+    source_resolution: int = 15
+) -> Dict[int, float]:
     """
-    Convert 15-minute intervals to hourly by summing quarters.
+    Convert 15- or 30-minute intervals to hourly by summing.
 
     Args:
-        data_15min: Dictionary mapping 15-min interval index to energy value (Wh)
+        data_15min: Dictionary mapping source interval index to energy value (Wh)
+        source_resolution: Source resolution in minutes (15 or 30)
 
     Returns:
         Dictionary mapping hour index to energy value (Wh per hour)
@@ -147,10 +177,19 @@ def downsample_to_hourly(data_15min: Dict[int, float]) -> Dict[int, float]:
         15-min intervals: {0: 250, 1: 300, 2: 350, 3: 400, 4: 450, ...}
         Hourly: {0: 1300, 1: ..., ...}
                 (250 + 300 + 350 + 400 = 1300 Wh for hour 0)
+
+        30-min intervals: {0: 500, 1: 700, 2: 300, 3: 100}
+        Hourly: {0: 1200, 1: 400}
     """
+    if source_resolution not in (15, 30):
+        raise ValueError(
+            f"Only 15 or 30 minute source resolution is supported, got {source_resolution}")
+
+    per_hour = 60 // source_resolution
+
     hourly = {}
-    for interval_15, value in data_15min.items():
-        hour = interval_15 // 4
+    for interval_idx, value in data_15min.items():
+        hour = interval_idx // per_hour
         if hour not in hourly:
             hourly[hour] = 0
         hourly[hour] += value

--- a/tests/batcontrol/forecastsolar/test_baseclass.py
+++ b/tests/batcontrol/forecastsolar/test_baseclass.py
@@ -17,9 +17,12 @@ class ConcreteForecastSolar(ForecastSolarBaseclass):
     """Concrete implementation of ForecastSolarBaseclass for testing"""
 
     def __init__(self, pvinstallations, timezone, min_time_between_API_calls,
-                 delay_evaluation_by_seconds, mock_provider_func=None, mock_forecast_func=None):
+                 delay_evaluation_by_seconds, mock_provider_func=None, mock_forecast_func=None,
+                 target_resolution=60, native_resolution=60):
         super().__init__(pvinstallations, timezone, min_time_between_API_calls,
-                        delay_evaluation_by_seconds)
+                        delay_evaluation_by_seconds,
+                        target_resolution=target_resolution,
+                        native_resolution=native_resolution)
         self.mock_provider_func = mock_provider_func
         self.mock_forecast_func = mock_forecast_func
 
@@ -469,3 +472,103 @@ class TestForecastSolarBaseclass:
 
         assert instance.timezone == timezone
         assert str(instance.timezone) == 'Europe/Berlin'
+
+
+class TestNativeResolution30:
+    """Tests for the 30-minute native resolution conversion paths."""
+
+    @pytest.fixture
+    def timezone(self):
+        """Fixture for timezone"""
+        return pytz.timezone('Europe/Berlin')
+
+    @pytest.fixture
+    def single_installation(self):
+        """Fixture for single PV installation"""
+        return [{'name': 'single'}]
+
+    def _make_instance(self, single_installation, timezone, target_resolution,
+                       forecast_30min):
+        """Build a ConcreteForecastSolar with native 30-min data."""
+        return ConcreteForecastSolar(
+            single_installation,
+            timezone,
+            min_time_between_API_calls=900,
+            delay_evaluation_by_seconds=0,
+            mock_provider_func=lambda name: {'data': 'test'},
+            mock_forecast_func=lambda: forecast_30min,
+            target_resolution=target_resolution,
+            native_resolution=30
+        )
+
+    def test_convert_resolution_30_to_15_interpolates(self, single_installation, timezone):
+        """30 -> 15 conversion must interpolate power, not duplicate values."""
+        instance = self._make_instance(single_installation, timezone, 15, {})
+
+        # Bucket 0: 500 Wh (1000 W), bucket 1: 1000 Wh (2000 W)
+        result = instance._convert_resolution({0: 500.0, 1: 1000.0})
+
+        assert result[0] == pytest.approx(250, rel=0.01)
+        assert result[1] == pytest.approx(375, rel=0.01)
+        assert result[2] == pytest.approx(500, rel=0.01)
+        assert result[3] == pytest.approx(500, rel=0.01)
+        # Plain doubling of the 30-min bucket would yield identical quarters
+        assert result[0] != result[1]
+
+    def test_convert_resolution_30_to_60_sums_pairs(self, single_installation, timezone):
+        """30 -> 60 conversion must sum bucket pairs exactly."""
+        instance = self._make_instance(single_installation, timezone, 60, {})
+
+        result = instance._convert_resolution({0: 500.0, 1: 700.0, 2: 300.0, 3: 100.0})
+
+        assert result[0] == pytest.approx(1200, abs=0.001)
+        assert result[1] == pytest.approx(400, abs=0.001)
+
+    def test_get_forecast_native_30_target_15(self, single_installation, timezone):
+        """Full get_forecast() path with native 30-min data and 15-min target."""
+        import datetime as dt
+
+        # 24 buckets = 12 hours of 30-min data with a rising ramp
+        forecast_30min = {i: float(100 * i) for i in range(24)}
+
+        instance = self._make_instance(single_installation, timezone, 15, forecast_30min)
+
+        fixed_now = timezone.localize(dt.datetime(2024, 6, 1, 10, 0, 0))
+        with patch('batcontrol.forecastsolar.baseclass.datetime') as mock_dt:
+            mock_dt.datetime.now.return_value = fixed_now
+            mock_dt.timedelta = dt.timedelta
+            mock_dt.timezone = dt.timezone
+            forecast = instance.get_forecast()
+
+        # 12 hours of data, padded to midnight (14 hours) = 56 intervals minimum
+        assert len(forecast) >= 48
+
+        # Bucket 0 = 0 Wh (0 W), bucket 1 = 100 Wh (200 W):
+        # quarters of bucket 0 ramp from 0 W to 200 W -> 0 W and 100 W
+        # -> 0 Wh and 100 W * 0.25h = 25 Wh
+        assert forecast[0] == pytest.approx(0, abs=0.001)
+        assert forecast[1] == pytest.approx(25.0, rel=0.01)
+        # Interpolated output: adjacent quarters of a bucket differ on a ramp
+        assert forecast[2] != forecast[3]
+
+    def test_get_forecast_native_30_target_60(self, single_installation, timezone):
+        """Full get_forecast() path with native 30-min data and 60-min target."""
+        import datetime as dt
+
+        forecast_30min = {i: float(100 * i) for i in range(24)}
+
+        instance = self._make_instance(single_installation, timezone, 60, forecast_30min)
+
+        fixed_now = timezone.localize(dt.datetime(2024, 6, 1, 10, 0, 0))
+        with patch('batcontrol.forecastsolar.baseclass.datetime') as mock_dt:
+            mock_dt.datetime.now.return_value = fixed_now
+            mock_dt.timedelta = dt.timedelta
+            mock_dt.timezone = dt.timezone
+            forecast = instance.get_forecast()
+
+        assert len(forecast) >= 12
+
+        # Hourly values are the exact bucket pair sums
+        assert forecast[0] == pytest.approx(0 + 100, abs=0.001)
+        assert forecast[1] == pytest.approx(200 + 300, abs=0.001)
+        assert forecast[11] == pytest.approx(2200 + 2300, abs=0.001)

--- a/tests/batcontrol/forecastsolar/test_solcast.py
+++ b/tests/batcontrol/forecastsolar/test_solcast.py
@@ -8,8 +8,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 import pytz
 
+import requests
+
 from batcontrol.forecastsolar.solcast import Solcast
 from batcontrol.forecastsolar.baseclass import ProviderError, RateLimitException
+
+# Fixed reference time (mid-hour, away from hour boundaries) so all time
+# calculations in the tests and in the provider share the same clock.
+TZ = pytz.timezone('Europe/Berlin')
+FIXED_NOW = TZ.localize(datetime.datetime(2026, 6, 1, 12, 20, 0))
 
 
 def _period_end_str(dt_utc: datetime.datetime) -> str:
@@ -20,10 +27,27 @@ def _period_end_str(dt_utc: datetime.datetime) -> str:
 class TestSolcast:
     """Tests for the Solcast provider."""
 
+    @pytest.fixture(autouse=True)
+    def frozen_time(self):
+        """Freeze datetime.now() in the solcast and baseclass modules.
+
+        Without this, the hour start computed in a test could differ from
+        the provider's hour start when a real hour boundary is crossed
+        mid-test, shifting interval indices and causing flaky failures.
+        """
+        with patch('batcontrol.forecastsolar.solcast.datetime') as mock_solcast_dt, \
+                patch('batcontrol.forecastsolar.baseclass.datetime') as mock_base_dt:
+            for mock_dt in (mock_solcast_dt, mock_base_dt):
+                mock_dt.datetime.now.return_value = FIXED_NOW
+                mock_dt.timedelta = datetime.timedelta
+                mock_dt.timezone = datetime.timezone
+            mock_solcast_dt.datetime.fromisoformat = datetime.datetime.fromisoformat
+            yield FIXED_NOW
+
     @pytest.fixture
     def timezone(self):
         """Fixture for timezone"""
-        return pytz.timezone('Europe/Berlin')
+        return TZ
 
     @pytest.fixture
     def pvinstallations(self):
@@ -45,9 +69,9 @@ class TestSolcast:
         )
 
     def _current_hour_start_utc(self, timezone):
-        """Start of the current hour as a UTC datetime."""
-        now = datetime.datetime.now().astimezone(timezone)
-        local_hour_start = now.replace(minute=0, second=0, microsecond=0)
+        """Start of the (frozen) current hour as a UTC datetime."""
+        local_hour_start = FIXED_NOW.astimezone(timezone).replace(
+            minute=0, second=0, microsecond=0)
         return local_hour_start.astimezone(datetime.timezone.utc)
 
     # ------------------------------------------------------------------
@@ -354,6 +378,23 @@ class TestSolcast:
         with patch('batcontrol.forecastsolar.solcast.requests.get',
                    return_value=self._mock_response(500)):
             with pytest.raises(ProviderError):
+                instance.get_raw_data_from_provider('default')
+
+    @pytest.mark.parametrize('exception', [
+        requests.exceptions.ConnectTimeout('timed out'),
+        requests.exceptions.ConnectionError('dns failure'),
+        requests.exceptions.ReadTimeout('read timed out'),
+    ])
+    def test_network_errors_raise_provider_error(self, instance, exception):
+        """Test that network-level errors are wrapped as ProviderError.
+
+        The baseclass only catches (ConnectionError, TimeoutError,
+        ProviderError); raw requests exceptions would escape refresh_data
+        and crash the refresh scheduling instead of falling back to cache.
+        """
+        with patch('batcontrol.forecastsolar.solcast.requests.get',
+                   side_effect=exception):
+            with pytest.raises(ProviderError, match='request failed'):
                 instance.get_raw_data_from_provider('default')
 
     # ------------------------------------------------------------------

--- a/tests/batcontrol/forecastsolar/test_solcast.py
+++ b/tests/batcontrol/forecastsolar/test_solcast.py
@@ -1,0 +1,416 @@
+"""
+Test module for the Solcast solar forecast provider.
+"""
+import datetime
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytz
+
+from batcontrol.forecastsolar.solcast import Solcast
+from batcontrol.forecastsolar.baseclass import ProviderError, RateLimitException
+
+
+def _period_end_str(dt_utc: datetime.datetime) -> str:
+    """Format a UTC datetime like Solcast does (7-digit fraction + Z)."""
+    return dt_utc.strftime('%Y-%m-%dT%H:%M:%S.0000000Z')
+
+
+class TestSolcast:
+    """Tests for the Solcast provider."""
+
+    @pytest.fixture
+    def timezone(self):
+        """Fixture for timezone"""
+        return pytz.timezone('Europe/Berlin')
+
+    @pytest.fixture
+    def pvinstallations(self):
+        """Fixture for a single Solcast installation"""
+        return [{
+            'name': 'default',
+            'resource_id': 'aaaa-bbbb-cccc-dddd',
+            'apikey': 'test-api-key'
+        }]
+
+    @pytest.fixture
+    def instance(self, pvinstallations, timezone):
+        """Fixture for a Solcast instance"""
+        return Solcast(
+            pvinstallations,
+            timezone,
+            min_time_between_api_calls=900,
+            delay_evaluation_by_seconds=0
+        )
+
+    def _current_hour_start_utc(self, timezone):
+        """Start of the current hour as a UTC datetime."""
+        now = datetime.datetime.now().astimezone(timezone)
+        local_hour_start = now.replace(minute=0, second=0, microsecond=0)
+        return local_hour_start.astimezone(datetime.timezone.utc)
+
+    # ------------------------------------------------------------------
+    # Initialization
+    # ------------------------------------------------------------------
+
+    def test_initialization(self, instance):
+        """Test init: native resolution and rate limit floor for one site."""
+        assert instance.native_resolution == 30
+        # 1 installation: 86400 // 8 = 10800 s (3 h)
+        assert instance.min_time_between_updates == 10800
+
+    def test_rate_limit_floor_scales_with_installations(self, timezone):
+        """Test that the refresh floor doubles with two sites."""
+        installations = [
+            {'name': 'east', 'resource_id': 'res-1', 'apikey': 'key'},
+            {'name': 'west', 'resource_id': 'res-2', 'apikey': 'key'},
+        ]
+        instance = Solcast(installations, timezone,
+                           min_time_between_api_calls=900,
+                           delay_evaluation_by_seconds=0)
+        # 2 installations: 86400 * 2 // 8 = 21600 s (6 h)
+        assert instance.min_time_between_updates == 21600
+
+    def test_larger_caller_value_respected(self, pvinstallations, timezone):
+        """Test that a caller value above the floor is kept."""
+        instance = Solcast(pvinstallations, timezone,
+                           min_time_between_api_calls=50000,
+                           delay_evaluation_by_seconds=0)
+        assert instance.min_time_between_updates == 50000
+
+    def test_missing_resource_id(self, timezone):
+        """Test that a missing resource_id raises ValueError."""
+        with pytest.raises(ValueError, match='resource_id'):
+            Solcast([{'name': 'default', 'apikey': 'key'}], timezone,
+                    min_time_between_api_calls=900,
+                    delay_evaluation_by_seconds=0)
+
+    def test_missing_apikey(self, timezone):
+        """Test that a missing apikey raises ValueError."""
+        with pytest.raises(ValueError, match='API key'):
+            Solcast([{'name': 'default', 'resource_id': 'res-1'}], timezone,
+                    min_time_between_api_calls=900,
+                    delay_evaluation_by_seconds=0)
+
+    def test_invalid_percentile(self, timezone):
+        """Test that an invalid percentile raises ValueError."""
+        with pytest.raises(ValueError, match='percentile'):
+            Solcast([{'name': 'default', 'resource_id': 'res-1',
+                      'apikey': 'key', 'percentile': 25}], timezone,
+                    min_time_between_api_calls=900,
+                    delay_evaluation_by_seconds=0)
+
+    # ------------------------------------------------------------------
+    # Parsing 30-minute raw data
+    # ------------------------------------------------------------------
+
+    def test_parse_30min_periods(self, instance, timezone):
+        """Test that periods map to 30-minute indices with kW -> Wh conversion."""
+        hour_start_utc = self._current_hour_start_utc(timezone)
+
+        raw_data = {'forecasts': [
+            {   # covers :00-:30 -> index 0
+                'pv_estimate': 1.0,
+                'period_end': _period_end_str(
+                    hour_start_utc + datetime.timedelta(minutes=30)),
+                'period': 'PT30M'
+            },
+            {   # covers :30-:00 -> index 1
+                'pv_estimate': 2.0,
+                'period_end': _period_end_str(
+                    hour_start_utc + datetime.timedelta(minutes=60)),
+                'period': 'PT30M'
+            },
+        ]}
+        instance.store_raw_data('default', raw_data)
+
+        forecast = instance.get_forecast_from_raw_data()
+
+        # 1 kW avg over 30 min = 500 Wh; 2 kW = 1000 Wh
+        assert forecast[0] == pytest.approx(500.0, abs=0.001)
+        assert forecast[1] == pytest.approx(1000.0, abs=0.001)
+
+    def test_partial_current_hour(self, instance, timezone):
+        """Test that a missing first half-hour is filled with zero."""
+        hour_start_utc = self._current_hour_start_utc(timezone)
+
+        raw_data = {'forecasts': [
+            {   # only :30-:00 -> index 1
+                'pv_estimate': 2.0,
+                'period_end': _period_end_str(
+                    hour_start_utc + datetime.timedelta(minutes=60)),
+                'period': 'PT30M'
+            },
+        ]}
+        instance.store_raw_data('default', raw_data)
+
+        forecast = instance.get_forecast_from_raw_data()
+
+        assert forecast[0] == 0.0
+        assert forecast[1] == pytest.approx(1000.0, abs=0.001)
+
+    def test_gap_filling(self, instance, timezone):
+        """Test that gaps between periods are filled with zero."""
+        hour_start_utc = self._current_hour_start_utc(timezone)
+
+        raw_data = {'forecasts': [
+            {
+                'pv_estimate': 1.0,
+                'period_end': _period_end_str(
+                    hour_start_utc + datetime.timedelta(minutes=30)),
+                'period': 'PT30M'
+            },
+            {   # gap at indices 1 and 2, next period -> index 3
+                'pv_estimate': 1.0,
+                'period_end': _period_end_str(
+                    hour_start_utc + datetime.timedelta(minutes=120)),
+                'period': 'PT30M'
+            },
+        ]}
+        instance.store_raw_data('default', raw_data)
+
+        forecast = instance.get_forecast_from_raw_data()
+
+        assert forecast[0] == pytest.approx(500.0, abs=0.001)
+        assert forecast[1] == 0.0
+        assert forecast[2] == 0.0
+        assert forecast[3] == pytest.approx(500.0, abs=0.001)
+
+    def test_past_periods_skipped(self, instance, timezone):
+        """Test that periods before the current hour are skipped."""
+        hour_start_utc = self._current_hour_start_utc(timezone)
+
+        raw_data = {'forecasts': [
+            {   # ends exactly at hour start -> in the past
+                'pv_estimate': 5.0,
+                'period_end': _period_end_str(hour_start_utc),
+                'period': 'PT30M'
+            },
+            {
+                'pv_estimate': 1.0,
+                'period_end': _period_end_str(
+                    hour_start_utc + datetime.timedelta(minutes=30)),
+                'period': 'PT30M'
+            },
+        ]}
+        instance.store_raw_data('default', raw_data)
+
+        forecast = instance.get_forecast_from_raw_data()
+
+        assert forecast[0] == pytest.approx(500.0, abs=0.001)
+        assert len(forecast) == 1
+
+    def test_empty_raw_data(self, instance):
+        """Test that empty raw data yields an empty forecast."""
+        instance.store_raw_data('default', {'forecasts': []})
+        assert instance.get_forecast_from_raw_data() == {}
+
+    # ------------------------------------------------------------------
+    # Percentile selection
+    # ------------------------------------------------------------------
+
+    def _raw_data_with_percentiles(self, timezone):
+        hour_start_utc = self._current_hour_start_utc(timezone)
+        return {'forecasts': [
+            {
+                'pv_estimate': 2.0,
+                'pv_estimate10': 1.0,
+                'pv_estimate90': 3.0,
+                'period_end': _period_end_str(
+                    hour_start_utc + datetime.timedelta(minutes=30)),
+                'period': 'PT30M'
+            },
+        ]}
+
+    def test_percentile_default_50(self, instance, timezone):
+        """Test that pv_estimate is used by default."""
+        instance.store_raw_data('default', self._raw_data_with_percentiles(timezone))
+        forecast = instance.get_forecast_from_raw_data()
+        assert forecast[0] == pytest.approx(1000.0, abs=0.001)  # 2.0 kW
+
+    @pytest.mark.parametrize('percentile,expected_wh', [(10, 500.0), (90, 1500.0)])
+    def test_percentile_option(self, timezone, percentile, expected_wh):
+        """Test that percentile 10/90 selects pv_estimate10/pv_estimate90."""
+        installations = [{'name': 'default', 'resource_id': 'res-1',
+                          'apikey': 'key', 'percentile': percentile}]
+        instance = Solcast(installations, timezone,
+                           min_time_between_api_calls=900,
+                           delay_evaluation_by_seconds=0)
+        instance.store_raw_data('default', self._raw_data_with_percentiles(timezone))
+
+        forecast = instance.get_forecast_from_raw_data()
+        assert forecast[0] == pytest.approx(expected_wh, abs=0.001)
+
+    # ------------------------------------------------------------------
+    # Multiple installations
+    # ------------------------------------------------------------------
+
+    def test_multiple_installations_summed(self, timezone):
+        """Test that forecasts of two rooftop sites are summed per slot."""
+        installations = [
+            {'name': 'east', 'resource_id': 'res-1', 'apikey': 'key'},
+            {'name': 'west', 'resource_id': 'res-2', 'apikey': 'key'},
+        ]
+        instance = Solcast(installations, timezone,
+                           min_time_between_api_calls=900,
+                           delay_evaluation_by_seconds=0)
+
+        hour_start_utc = self._current_hour_start_utc(timezone)
+        period_end = _period_end_str(
+            hour_start_utc + datetime.timedelta(minutes=30))
+
+        instance.store_raw_data('east', {'forecasts': [
+            {'pv_estimate': 1.0, 'period_end': period_end, 'period': 'PT30M'}]})
+        instance.store_raw_data('west', {'forecasts': [
+            {'pv_estimate': 2.0, 'period_end': period_end, 'period': 'PT30M'}]})
+
+        forecast = instance.get_forecast_from_raw_data()
+
+        assert forecast[0] == pytest.approx(1500.0, abs=0.001)  # 500 + 1000 Wh
+
+    # ------------------------------------------------------------------
+    # Timestamp parsing
+    # ------------------------------------------------------------------
+
+    def test_parse_period_end(self):
+        """Regression: Solcast's 7-digit fraction + Z parses on Python < 3.11."""
+        result = Solcast._parse_period_end('2026-01-01T01:00:00.0000000Z')
+
+        assert result == datetime.datetime(
+            2026, 1, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        assert result.tzinfo is not None
+
+    def test_parse_period_end_without_fraction(self):
+        """Test parsing a timestamp without fractional seconds."""
+        result = Solcast._parse_period_end('2026-01-01T12:30:00Z')
+
+        assert result == datetime.datetime(
+            2026, 1, 1, 12, 30, 0, tzinfo=datetime.timezone.utc)
+
+    # ------------------------------------------------------------------
+    # HTTP handling
+    # ------------------------------------------------------------------
+
+    def _mock_response(self, status_code, json_data=None, headers=None):
+        response = MagicMock()
+        response.status_code = status_code
+        response.json.return_value = json_data if json_data is not None else {}
+        response.headers = headers if headers is not None else {}
+        response.text = ''
+        return response
+
+    def test_http_200(self, instance):
+        """Test that a 200 response returns parsed JSON with Bearer auth."""
+        payload = {'forecasts': []}
+        with patch('batcontrol.forecastsolar.solcast.requests.get',
+                   return_value=self._mock_response(200, payload)) as mock_get:
+            result = instance.get_raw_data_from_provider('default')
+
+        assert result == payload
+        args, kwargs = mock_get.call_args
+        assert 'aaaa-bbbb-cccc-dddd/forecasts' in args[0]
+        assert 'format=json' in args[0]
+        assert kwargs['headers']['Authorization'] == 'Bearer test-api-key'
+        # API key must not appear in the URL
+        assert 'test-api-key' not in args[0]
+
+    def test_http_429_sets_blackout_with_retry_after(self, instance):
+        """Test that 429 with Retry-After raises RateLimitException + blackout."""
+        with patch('batcontrol.forecastsolar.solcast.requests.get',
+                   return_value=self._mock_response(429, headers={'Retry-After': '600'})):
+            with pytest.raises(RateLimitException):
+                instance.get_raw_data_from_provider('default')
+
+        assert instance.rate_limit_blackout_window_ts == pytest.approx(
+            time.time() + 600, abs=5)
+
+    def test_http_429_sets_blackout_without_retry_after(self, instance):
+        """Test that 429 without Retry-After falls back to the provider floor."""
+        with patch('batcontrol.forecastsolar.solcast.requests.get',
+                   return_value=self._mock_response(429)):
+            with pytest.raises(RateLimitException):
+                instance.get_raw_data_from_provider('default')
+
+        assert instance.rate_limit_blackout_window_ts == pytest.approx(
+            time.time() + 10800, abs=5)
+
+    def test_http_401(self, instance):
+        """Test that 401 raises ProviderError."""
+        with patch('batcontrol.forecastsolar.solcast.requests.get',
+                   return_value=self._mock_response(401)):
+            with pytest.raises(ProviderError, match='Unauthorized'):
+                instance.get_raw_data_from_provider('default')
+
+    def test_http_404(self, instance):
+        """Test that 404 raises ProviderError mentioning the resource_id."""
+        with patch('batcontrol.forecastsolar.solcast.requests.get',
+                   return_value=self._mock_response(404)):
+            with pytest.raises(ProviderError, match='resource_id'):
+                instance.get_raw_data_from_provider('default')
+
+    def test_http_500(self, instance):
+        """Test that other status codes raise ProviderError."""
+        with patch('batcontrol.forecastsolar.solcast.requests.get',
+                   return_value=self._mock_response(500)):
+            with pytest.raises(ProviderError):
+                instance.get_raw_data_from_provider('default')
+
+    # ------------------------------------------------------------------
+    # End-to-end through the baseclass
+    # ------------------------------------------------------------------
+
+    def _build_ramp_raw_data(self, timezone, buckets=28):
+        """Raw data with a rising power ramp over `buckets` half hours."""
+        hour_start_utc = self._current_hour_start_utc(timezone)
+        forecasts = []
+        for i in range(buckets):
+            forecasts.append({
+                'pv_estimate': float(i),  # kW, rising ramp
+                'period_end': _period_end_str(
+                    hour_start_utc + datetime.timedelta(minutes=30 * (i + 1))),
+                'period': 'PT30M'
+            })
+        return {'forecasts': forecasts}
+
+    def test_get_forecast_target_15_interpolates(self, pvinstallations, timezone):
+        """End-to-end: 30-min data is interpolated to 15-min, not duplicated."""
+        instance = Solcast(pvinstallations, timezone,
+                           min_time_between_api_calls=900,
+                           delay_evaluation_by_seconds=0,
+                           target_resolution=15)
+        raw_data = self._build_ramp_raw_data(timezone)
+
+        with patch.object(instance, 'get_raw_data_from_provider',
+                          return_value=raw_data):
+            forecast = instance.get_forecast()
+
+        assert len(forecast) >= 48
+
+        # On a strictly rising ramp the interpolated quarters keep rising,
+        # so adjacent quarters of one bucket must not be identical.
+        rising_pairs = [(forecast[i], forecast[i + 1])
+                        for i in range(0, 8, 2)]
+        assert any(a != b for a, b in rising_pairs)
+
+    def test_get_forecast_target_60_sums_pairs(self, pvinstallations, timezone):
+        """End-to-end: 30-min data is summed into hourly values."""
+        instance = Solcast(pvinstallations, timezone,
+                           min_time_between_api_calls=900,
+                           delay_evaluation_by_seconds=0,
+                           target_resolution=60)
+        raw_data = self._build_ramp_raw_data(timezone)
+
+        with patch.object(instance, 'get_raw_data_from_provider',
+                          return_value=raw_data):
+            forecast = instance.get_forecast()
+
+        assert len(forecast) >= 12
+
+        # Bucket i has pv_estimate = i kW -> i * 500 Wh.
+        # Hour h sums buckets 2h and 2h+1: (2h + 2h+1) * 500 Wh.
+        # Use a future hour to be independent of the current-interval shift
+        # (hour-aligned index equals shifted index at target 60 only when
+        # shift is 0; with 60-min resolution shift is always 0).
+        assert forecast[1] == pytest.approx((2 + 3) * 500.0, abs=0.001)
+        assert forecast[5] == pytest.approx((10 + 11) * 500.0, abs=0.001)

--- a/tests/batcontrol/test_interval_utils.py
+++ b/tests/batcontrol/test_interval_utils.py
@@ -338,3 +338,261 @@ class TestRealWorldScenario:
 
         # Allow some difference due to interpolation
         assert final_total == pytest.approx(original_total, rel=0.15)
+
+
+class TestUpsampleLinear30:
+    """Tests for linear upsampling of 30-minute source data to 15-minute intervals."""
+
+    def test_rising_power_ramp(self):
+        """Test that power is interpolated, not duplicated, on a rising ramp."""
+        buckets_30min = {
+            0: 500,   # Bucket 0: 500 Wh -> avg power 1000 W
+            1: 1000,  # Bucket 1: 1000 Wh -> avg power 2000 W
+        }
+
+        result = upsample_forecast(buckets_30min, target_resolution=15,
+                                   method='linear', source_resolution=30)
+
+        # Linear power ramp 1000 W -> 2000 W:
+        # [0]: 1000 W * 0.25h = 250 Wh
+        # [1]: 1500 W * 0.25h = 375 Wh
+        # [2]: 2000 W * 0.25h = 500 Wh (last bucket, constant)
+        # [3]: 2000 W * 0.25h = 500 Wh
+        assert result[0] == pytest.approx(250, rel=0.01)
+        assert result[1] == pytest.approx(375, rel=0.01)
+        assert result[2] == pytest.approx(500, rel=0.01)
+        assert result[3] == pytest.approx(500, rel=0.01)
+
+        # The two quarters of the first bucket must NOT be identical:
+        # plain halving/doubling of the 30-min value would yield 250/250.
+        assert result[0] != result[1]
+
+    def test_falling_power_ramp(self):
+        """Test interpolation on a falling ramp (power decreases over the bucket)."""
+        buckets_30min = {
+            0: 1000,  # 2000 W
+            1: 500,   # 1000 W
+        }
+
+        result = upsample_forecast(buckets_30min, target_resolution=15,
+                                   method='linear', source_resolution=30)
+
+        # Linear power ramp 2000 W -> 1000 W:
+        # [0]: 2000 W -> 500 Wh, [1]: 1500 W -> 375 Wh
+        # [2]/[3]: last bucket constant at 1000 W -> 250 Wh
+        assert result[0] == pytest.approx(500, rel=0.01)
+        assert result[1] == pytest.approx(375, rel=0.01)
+        assert result[2] == pytest.approx(250, rel=0.01)
+        assert result[3] == pytest.approx(250, rel=0.01)
+        assert result[0] != result[1]
+
+    def test_constant_power(self):
+        """Test that constant power degenerates to equal quarters."""
+        buckets_30min = {
+            0: 500,
+            1: 500,
+            2: 500,
+        }
+
+        result = upsample_forecast(buckets_30min, target_resolution=15,
+                                   method='linear', source_resolution=30)
+
+        # 1000 W constant -> 250 Wh per quarter
+        for i in range(6):  # 3 buckets * 2 quarters
+            assert result[i] == pytest.approx(250, rel=0.01)
+
+    def test_zero_values_sunrise(self):
+        """Test ramp starting from zero (sunrise), no negative values."""
+        buckets_30min = {
+            0: 0,
+            1: 500,  # 1000 W
+        }
+
+        result = upsample_forecast(buckets_30min, target_resolution=15,
+                                   method='linear', source_resolution=30)
+
+        # Ramp 0 W -> 1000 W: [0]: 0 W -> 0 Wh, [1]: 500 W -> 125 Wh
+        assert result[0] == pytest.approx(0, abs=0.001)
+        assert result[1] == pytest.approx(125, rel=0.01)
+        assert all(v >= 0 for v in result.values())
+
+    def test_last_bucket_constant(self):
+        """Test that the last bucket without successor is distributed constantly."""
+        buckets_30min = {
+            0: 500,
+            1: 800,  # last bucket: 1600 W constant
+        }
+
+        result = upsample_forecast(buckets_30min, target_resolution=15,
+                                   method='linear', source_resolution=30)
+
+        assert result[2] == pytest.approx(400, rel=0.01)  # 1600 W * 0.25h
+        assert result[3] == pytest.approx(400, rel=0.01)
+        assert result[2] == result[3]
+
+    def test_realistic_solar_curve(self):
+        """Test upsampling a realistic 30-minute solar day curve."""
+        # Night - ramp up - peak - ramp down - night (30-min buckets)
+        buckets_30min = {
+            0: 0,     # Night
+            1: 0,
+            2: 50,    # Dawn
+            3: 250,
+            4: 750,   # Morning
+            5: 1250,
+            6: 1500,  # Midday peak
+            7: 1250,
+            8: 750,   # Afternoon
+            9: 250,
+            10: 50,   # Dusk
+            11: 0,    # Night
+        }
+
+        result = upsample_forecast(buckets_30min, target_resolution=15,
+                                   method='linear', source_resolution=30)
+
+        # 12 buckets * 2 quarters = 24 intervals
+        assert len(result) == 24
+
+        # All values are non-negative
+        assert all(v >= 0 for v in result.values())
+
+        # Peak is around midday (bucket 6 -> intervals 12/13)
+        max_interval = max(result.items(), key=lambda x: x[1])
+        assert 10 <= max_interval[0] <= 14
+
+
+class TestUpsampleConstant30:
+    """Tests for constant upsampling of 30-minute source data."""
+
+    def test_simple_division(self):
+        """Test that 30-minute values are divided by 2."""
+        buckets_30min = {
+            0: 500,
+            1: 1000,
+        }
+
+        result = upsample_forecast(buckets_30min, target_resolution=15,
+                                   method='constant', source_resolution=30)
+
+        assert result[0] == 250  # 500/2
+        assert result[1] == 250
+        assert result[2] == 500  # 1000/2
+        assert result[3] == 500
+
+    def test_energy_conservation(self):
+        """Test that total energy is exactly conserved per bucket."""
+        buckets_30min = {
+            0: 1234,
+            1: 5678,
+        }
+
+        result = upsample_forecast(buckets_30min, target_resolution=15,
+                                   method='constant', source_resolution=30)
+
+        assert result[0] + result[1] == pytest.approx(1234, abs=0.001)
+        assert result[2] + result[3] == pytest.approx(5678, abs=0.001)
+
+
+class TestDownsample30:
+    """Tests for downsampling 30-minute intervals to hourly."""
+
+    def test_pair_summing(self):
+        """Test that pairs of 30-minute buckets are summed per hour."""
+        data_30min = {
+            0: 500,  # Hour 0
+            1: 700,
+            2: 300,  # Hour 1
+            3: 100,
+        }
+
+        result = downsample_to_hourly(data_30min, source_resolution=30)
+
+        assert result[0] == 1200  # 500+700
+        assert result[1] == 400   # 300+100
+
+    def test_energy_conservation(self):
+        """Test that total energy is exactly conserved."""
+        data_30min = {i: 100 + i * 10 for i in range(10)}  # 5 hours of data
+
+        result = downsample_to_hourly(data_30min, source_resolution=30)
+
+        assert sum(result.values()) == pytest.approx(sum(data_30min.values()), abs=0.001)
+
+    def test_incomplete_hour(self):
+        """Test handling of an hour with only one bucket present."""
+        data_30min = {
+            0: 500,
+            # Missing bucket 1
+        }
+
+        result = downsample_to_hourly(data_30min, source_resolution=30)
+
+        assert result[0] == 500
+
+
+class TestSourceResolutionValidation:
+    """Validation and regression tests for the source_resolution parameter."""
+
+    def test_invalid_source_resolution_upsample(self):
+        """Test that invalid source resolutions raise ValueError on upsampling."""
+        data = {0: 1000}
+
+        for invalid in (20, 45):
+            with pytest.raises(ValueError, match="source resolution"):
+                upsample_forecast(data, target_resolution=15,
+                                  method='linear', source_resolution=invalid)
+
+    def test_invalid_source_resolution_downsample(self):
+        """Test that invalid source resolutions raise ValueError on downsampling."""
+        data = {0: 1000}
+
+        for invalid in (20, 45, 60):
+            with pytest.raises(ValueError, match="source resolution"):
+                downsample_to_hourly(data, source_resolution=invalid)
+
+    def test_target_resolution_30_still_invalid(self):
+        """Test that 30 is only allowed as source, never as target resolution."""
+        data = {0: 1000}
+
+        with pytest.raises(ValueError, match="Only 15-minute resolution"):
+            upsample_forecast(data, target_resolution=30,
+                              method='linear', source_resolution=30)
+
+    def test_empty_input_30min(self):
+        """Test handling of empty input with 30-minute source resolution."""
+        result = upsample_forecast({}, target_resolution=15,
+                                   method='linear', source_resolution=30)
+        assert result == {}
+
+        assert downsample_to_hourly({}, source_resolution=30) == {}
+
+    def test_roundtrip_30_to_15_to_60(self):
+        """Test that 30->15->60 roughly matches the direct 30->60 sum."""
+        data_30min = {
+            0: 500,
+            1: 700,
+            2: 900,
+            3: 600,
+        }
+
+        upsampled = upsample_forecast(data_30min, target_resolution=15,
+                                      method='linear', source_resolution=30)
+        via_15min = downsample_to_hourly(upsampled)
+        direct = downsample_to_hourly(data_30min, source_resolution=30)
+
+        assert sum(via_15min.values()) == pytest.approx(sum(direct.values()), rel=0.15)
+
+    def test_default_source_resolution_unchanged(self):
+        """Test that omitting source_resolution keeps the previous 60/15 behavior."""
+        hourly = {0: 1000, 1: 2000}
+
+        explicit = upsample_forecast(hourly, target_resolution=15,
+                                     method='linear', source_resolution=60)
+        implicit = upsample_forecast(hourly, target_resolution=15, method='linear')
+        assert explicit == implicit
+        assert implicit[0] == pytest.approx(250, rel=0.01)
+
+        data_15min = {0: 250, 1: 300, 2: 350, 3: 400}
+        assert downsample_to_hourly(data_15min) == \
+            downsample_to_hourly(data_15min, source_resolution=15)


### PR DESCRIPTION
# Add Solcast rooftop API as solar forecast provider

Adds [Solcast](https://solcast.com/) (rooftop PV API, https://docs.solcast.com.au) as a new solar forecast provider, including native 30-minute resolution support in the interval conversion infrastructure.

## Motivation

Solcast provides satellite-based solar forecasts with a free "Home User" (hobbyist) account: one location with up to two rooftop sites and 10 API requests per day — enough for batcontrol. Its data comes in 30-minute periods, a resolution batcontrol could not represent so far (`interval_utils` only knew 15/60 min).

## Changes

### Native 30-minute resolution support
- `interval_utils.py`: new optional `source_resolution` parameter for `upsample_forecast` (60 default, 30 new) and `downsample_to_hourly` (15 default, 30 new).
  - **30 → 15**: linear *power* interpolation between buckets — values are not simply halved/duplicated; power ramps up or down across the interpolation (e.g. buckets 500/1000 Wh become quarters of 250/375/500/500 Wh instead of 250/250/500/500).
  - **30 → 60**: exact energy sum of the two half-hour buckets.
  - Existing callers are unchanged (defaults preserve previous behavior).
- `forecastsolar/baseclass.py`: `_convert_resolution` handles `native_resolution=30` for both target resolutions; the per-resolution provider contract is documented in the class docstring.

### Solcast provider (`forecastsolar/solcast.py`)
- Endpoint `rooftop_sites/{resource_id}/forecasts` with Bearer authentication (API key stays out of logged URLs); site geometry (lat/lon, tilt, azimuth, kWp) lives in the Solcast toolkit, batcontrol only needs `resource_id` and `apikey` per installation.
- Optional `percentile: 10|50|90` per installation (pessimistic / most likely / optimistic estimate, default 50).
- Rate limiting for the free tier: refresh interval floor scaled by installation count (1 site: 3 h, 2 sites: 6 h → at most 8 of the 10 daily requests, 2 in reserve); HTTP 429 sets a blackout window (honoring `Retry-After`) and falls back to cached data. Network-level errors are wrapped as `ProviderError` so the cache fallback applies.
- Timestamp parser for Solcast's `…T01:00:00.0000000Z` format (7-digit fraction + `Z`), which `fromisoformat` cannot parse before Python 3.11.
- Registered in the provider factory as `solar_forecast_provider: solcast`.

### Configuration example

```yaml
solar_forecast_provider: solcast
pvinstallations:
  - name: Haus
    resource_id: xxxx-xxxx-xxxx-xxxx  # from your Solcast rooftop site
    apikey: your-solcast-api-key      # from your Solcast account settings
    percentile: 50                    # optional: 10 / 50 / 90
```

### Documentation
- `docs/configuration/solar-forecast.md`: new Solcast section with a free-account registration walkthrough, one- and two-site examples, percentile explanation and rate-limit notes.
- `docs/development/15-min-transform.md`: 30-minute conversion rules, index contract and a worked interpolation example.
- `config/batcontrol_config_dummy.yaml`: commented Solcast example.

### Tests (+50)
- `test_interval_utils.py`: rising/falling interpolation ramps (with explicit no-plain-doubling assertions), energy conservation, last-bucket rule, realistic solar curve, validation of invalid resolutions, regression of the existing 60/15 paths.
- `test_baseclass.py`: native-30 conversion paths and full `get_forecast()` runs for both target resolutions.
- `test_solcast.py`: parsing, percentile selection, multi-site summing, HTTP handling (200/401/404/429/network errors), timestamp regression, end-to-end resolution conversion; wall-clock frozen via autouse fixture to avoid hour-boundary flakiness.

## Verification

- Full test suite: **731 passed** (previously 681)
- Pylint: **9.46/10** (CI threshold: 9)
- All review comments from the Copilot review are addressed and resolved.

---
https://claude.ai/code/session_01H5Q9tGhRPEWyc6t5H21DPW

🤖 Generated with [Claude Code](https://claude.com/claude-code)