### PR TITLE
fix: add tag push trigger for documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,12 @@ name: Deploy Documentation
 
 on:
   push:
+    tags:
+      - '*.*.*'
     branches:
       - main
     paths:
+      - 'pyproject.toml'
       - 'docs/**'
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'


### PR DESCRIPTION
Trigger documentation update when running through release pipeline based on tags + changed version.