### PR TITLE
docs: document Fronius GEN24 requirements and inverter config changes

### DIFF
--- a/docs/configuration/inverter-configuration.md
+++ b/docs/configuration/inverter-configuration.md
@@ -77,6 +77,24 @@ inverter:
   fronius_controller_id: '0' # Optional: ID of the controller in Fronius API (default: '0') (ab 0.5.6)
 ```
 
+### Requirements
+
+- The inverter web interface must be reachable over HTTP from the machine that runs batcontrol (local network).
+- A web interface login is required. Both the **customer** and the **technician** login work — use the login name in lowercase (`customer` or `technician`) together with the matching password.
+- The Fronius **Solar.API** does *not* need to be enabled manually: batcontrol activates it automatically at startup, since it is required to read the battery state of charge.
+
+### Changes batcontrol makes to the inverter configuration
+
+At startup, batcontrol:
+
+- **Enables the Solar.API** (`SolarAPIv1Enabled`), which is required to read SoC and power values.
+- **Saves a backup** of the current battery settings (min/max SoC, energy-management mode/power, grid-charging flag) to `config/battery_config.json` and of the time-of-use schedule to `config/timeofuse_config.json`.
+- **Enables charging from grid** (`HYB_EVU_CHARGEFROMGRID`), so batcontrol can charge the battery during cheap price windows.
+
+During operation, batcontrol controls the battery by writing battery settings (min/max SoC in manual mode, energy-management mode and power) and time-of-use schedules.
+
+On a clean shutdown, batcontrol restores the saved battery settings and time-of-use schedule from the backup files. The Solar.API stays enabled — disable it manually in the inverter web UI if no other software needs it (note: the Fronius Wattpilot wallbox requires the Solar.API).
+
 ### Additional Parameters (since 0.5.6)
 - **fronius_inverter_id**: Optional parameter to specify the inverter ID in the Fronius API. Default is '1'.
 - **fronius_controller_id**: Optional parameter to specify the controller ID in the Fronius API. Default is '0'.

--- a/docs/configuration/inverter-configuration.md
+++ b/docs/configuration/inverter-configuration.md
@@ -88,12 +88,12 @@ inverter:
 At startup, batcontrol:
 
 - **Enables the Solar.API** (`SolarAPIv1Enabled`), which is required to read SoC and power values.
-- **Saves a backup** of the current battery settings (min/max SoC, energy-management mode/power, grid-charging flag) to `config/battery_config.json` and of the time-of-use schedule to `config/timeofuse_config.json`.
+- **Saves a backup** of the current battery settings (min/max SoC, energy-management mode/power, grid-charging flag) to `config/battery_config.json` and of the time-of-use schedule to `config/timeofuse_config.json`. The backup files are only written if they do not already exist — after an unclean stop the existing files are kept, so the original pre-batcontrol settings are not overwritten and are reused for the next restore.
 - **Enables charging from grid** (`HYB_EVU_CHARGEFROMGRID`), so batcontrol can charge the battery during cheap price windows.
 
 During operation, batcontrol controls the battery by writing battery settings (min/max SoC in manual mode, energy-management mode and power) and time-of-use schedules.
 
-On a clean shutdown, batcontrol restores the saved battery settings and time-of-use schedule from the backup files. The Solar.API stays enabled — disable it manually in the inverter web UI if no other software needs it (note: the Fronius Wattpilot wallbox requires the Solar.API).
+On a clean shutdown, batcontrol restores the saved battery settings and time-of-use schedule from the backup files and deletes the files after a successful restore. If batcontrol crashes or is killed, the settings are *not* restored — the backup files remain in `config/` and are used on the next clean shutdown. The Solar.API stays enabled — disable it manually in the inverter web UI if no other software needs it (note: the Fronius Wattpilot wallbox requires the Solar.API).
 
 ### Additional Parameters (since 0.5.6)
 - **fronius_inverter_id**: Optional parameter to specify the inverter ID in the Fronius API. Default is '1'.

--- a/docs/configuration/inverter-configuration.md
+++ b/docs/configuration/inverter-configuration.md
@@ -80,7 +80,7 @@ inverter:
 ### Requirements
 
 - The inverter web interface must be reachable over HTTP from the machine that runs batcontrol (local network).
-- A web interface login is required. Both the **customer** and the **technician** login work — use the login name in lowercase (`customer` or `technician`) together with the matching password.
+- A web interface login is required. Both the **customer** and the **technician** logins work — use the login name in lowercase (`customer` or `technician`) together with the matching password.
 - The Fronius **Solar.API** does *not* need to be enabled manually: batcontrol activates it automatically at startup, since it is required to read the battery state of charge.
 
 ### Changes batcontrol makes to the inverter configuration

--- a/docs/configuration/inverter-configuration.md
+++ b/docs/configuration/inverter-configuration.md
@@ -88,12 +88,17 @@ inverter:
 At startup, batcontrol:
 
 - **Enables the Solar.API** (`SolarAPIv1Enabled`), which is required to read SoC and power values.
-- **Saves a backup** of the current battery settings (min/max SoC, energy-management mode/power, grid-charging flag) to `config/battery_config.json` and of the time-of-use schedule to `config/timeofuse_config.json`. The backup files are only written if they do not already exist — after an unclean stop the existing files are kept, so the original pre-batcontrol settings are not overwritten and are reused for the next restore.
+- **Saves a backup** of the current battery settings (min/max SoC, energy-management mode/power, grid-charging flag) to `config/battery_config.json` and of the time-of-use schedule to `config/timeofuse_config.json`. Both files are only written if they do not already exist — after an unclean stop the existing files are preserved.
 - **Enables charging from grid** (`HYB_EVU_CHARGEFROMGRID`), so batcontrol can charge the battery during cheap price windows.
 
 During operation, batcontrol controls the battery by writing battery settings (min/max SoC in manual mode, energy-management mode and power) and time-of-use schedules.
 
-On a clean shutdown, batcontrol restores the saved battery settings and time-of-use schedule from the backup files and deletes the files after a successful restore. If batcontrol crashes or is killed, the settings are *not* restored — the backup files remain in `config/` and are used on the next clean shutdown. The Solar.API stays enabled — disable it manually in the inverter web UI if no other software needs it (note: the Fronius Wattpilot wallbox requires the Solar.API).
+On a clean shutdown, batcontrol restores the original settings. The two backup files behave differently:
+
+- **`config/timeofuse_config.json`** is read from disk and used for the time-of-use restore. If the file was preserved after a crash, the original time-of-use schedule is correctly restored on the next clean shutdown.
+- **`config/battery_config.json`** is written as a reference, but the battery restore uses the settings fetched live from the inverter at startup — the file is not read back. If batcontrol crashed and the inverter still holds batcontrol-modified settings, the live fetch captures those modified settings, so battery settings are not automatically restored to the original pre-crash state. The file can be inspected manually to see what the original settings were.
+
+Both files are deleted after a successful restore. The Solar.API stays enabled — disable it manually in the inverter web UI if no other software needs it (note: the Fronius Wattpilot wallbox requires the Solar.API).
 
 ### Additional Parameters (since 0.5.6)
 - **fronius_inverter_id**: Optional parameter to specify the inverter ID in the Fronius API. Default is '1'.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -131,7 +131,7 @@ Before the first run, verify the following:
 - Confirm your inverter login credentials (customer or technician access both work).
 - If you have previously run any third-party tools that use Modbus, or executed Modbus commands directly, disable Modbus and restart the inverter before starting batcontrol.
 
-Batcontrol will enable the Solar.API on first run (local network only), enable charging from grid, and save the current battery and time-of-use configuration, which it restores on a clean shutdown. See [Inverter Configuration](../configuration/inverter-configuration.md#changes-batcontrol-makes-to-the-inverter-configuration) for the full list of changes.
+If you are using the `fronius_gen24` backend, batcontrol will enable the Solar.API on first run (local network only), enable charging from grid, and save the current battery and time-of-use configuration, which it restores on a clean shutdown. See [Inverter Configuration](../configuration/inverter-configuration.md#changes-batcontrol-makes-to-the-inverter-configuration) for the full list of changes.
 
 ## Next Steps
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -131,7 +131,7 @@ Before the first run, verify the following:
 - Confirm your inverter login credentials (customer or technician access both work).
 - If you have previously run any third-party tools that use Modbus, or executed Modbus commands directly, disable Modbus and restart the inverter before starting batcontrol.
 
-Batcontrol will enable the Solar.API on first run (local network only) and save the current battery configuration, which it restores on shutdown.
+Batcontrol will enable the Solar.API on first run (local network only), enable charging from grid, and save the current battery and time-of-use configuration, which it restores on shutdown. See [Inverter Configuration](../configuration/inverter-configuration.md#changes-batcontrol-makes-to-the-inverter-configuration) for the full list of changes.
 
 ## Next Steps
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -131,7 +131,7 @@ Before the first run, verify the following:
 - Confirm your inverter login credentials (customer or technician access both work).
 - If you have previously run any third-party tools that use Modbus, or executed Modbus commands directly, disable Modbus and restart the inverter before starting batcontrol.
 
-If you are using the `fronius_gen24` backend, batcontrol will enable the Solar.API on first run (local network only), enable charging from grid, and save the current battery and time-of-use configuration, which it restores on a clean shutdown. See [Inverter Configuration](../configuration/inverter-configuration.md#changes-batcontrol-makes-to-the-inverter-configuration) for the full list of changes.
+If you are using the `fronius_gen24` backend, batcontrol will enable the Solar.API at startup (local network only), enable charging from grid, and save the current battery and time-of-use configuration, which it restores on a clean shutdown. See [Inverter Configuration](../configuration/inverter-configuration.md#changes-batcontrol-makes-to-the-inverter-configuration) for the full list of changes.
 
 ## Next Steps
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -131,7 +131,7 @@ Before the first run, verify the following:
 - Confirm your inverter login credentials (customer or technician access both work).
 - If you have previously run any third-party tools that use Modbus, or executed Modbus commands directly, disable Modbus and restart the inverter before starting batcontrol.
 
-Batcontrol will enable the Solar.API on first run (local network only), enable charging from grid, and save the current battery and time-of-use configuration, which it restores on shutdown. See [Inverter Configuration](../configuration/inverter-configuration.md#changes-batcontrol-makes-to-the-inverter-configuration) for the full list of changes.
+Batcontrol will enable the Solar.API on first run (local network only), enable charging from grid, and save the current battery and time-of-use configuration, which it restores on a clean shutdown. See [Inverter Configuration](../configuration/inverter-configuration.md#changes-batcontrol-makes-to-the-inverter-configuration) for the full list of changes.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Closes #74.

The issue asks to document the Fronius configuration requirements: which login is required, that the Solar.API must be active, and which settings batcontrol changes on the inverter. Most of this was already covered (login options, automatic Solar.API activation on startup), but the changes batcontrol makes to the inverter configuration — in particular enabling grid charging (`HYB_EVU_CHARGEFROMGRID`) and backing up/overwriting the time-of-use schedules — were not documented anywhere.

## Changes

- **`docs/configuration/inverter-configuration.md`**: Added two subsections to the `fronius_gen24` section:
  - *Requirements* — local HTTP access to the inverter web interface, customer or technician login (lowercase), and a note that the Solar.API does not need to be enabled manually since batcontrol activates it at startup.
  - *Changes batcontrol makes to the inverter configuration* — Solar.API activation, grid-charging enablement, backup of battery and time-of-use settings to `config/battery_config.json` / `config/timeofuse_config.json`, what is written during operation, restore on clean shutdown, and that the Solar.API stays enabled afterwards (with the Wattpilot note).
- **`docs/getting-started/installation.md`**: Extended the inverter-preparation note to mention grid charging and the time-of-use backup, and linked to the new section for the full list.

Documentation-only change; the described behavior matches the current implementation in `src/batcontrol/inverter/fronius.py` (Solar.API activation and `set_allow_grid_charging(True)` in `__init__`, restore in `shutdown()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFWr16tYg5NJeLdruUFRjz