### PR TITLE
ci: restrict docs deployment to version tags and manual trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,13 +4,6 @@ on:
   push:
     tags:
       - '*.*.*'
-    branches:
-      - main
-    paths:
-      - 'pyproject.toml'
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Remove automatic deployment on push to main to avoid updating the website with every documentation commit. Docs now deploy only on version tag pushes or via manual workflow_dispatch.