### PR TITLE
fix: fill full span of mixed-granularity evcc price entries

### DIFF
--- a/src/batcontrol/dynamictariff/evcc.py
+++ b/src/batcontrol/dynamictariff/evcc.py
@@ -108,14 +108,28 @@ class Evcc(DynamicTariffBaseclass):
             diff = timestamp - current_hour_start
             rel_interval = int(diff.total_seconds() / 900)  # 900 seconds = 15 minutes
 
-            if rel_interval >= 0:
-                # since evcc 0.203.0 value is the name of the price field.
-                if item.get('value', None) is not None:
-                    price = item['value']
-                else:
-                    price = item['price']
+            # evcc may mix granularities: near-term rates are 15-min slots,
+            # but rates further out are sometimes returned as single hourly
+            # (or 30-min) entries. Use start/end to fill every 15-min slot
+            # the entry actually covers, so downstream consumers never see
+            # gaps in the index sequence.
+            span = 1
+            if item.get('end', None) is not None:
+                end_timestamp = datetime.datetime.fromisoformat(
+                    item['end']).astimezone(self.timezone)
+                duration_seconds = (end_timestamp - timestamp).total_seconds()
+                span = max(1, round(duration_seconds / 900))
 
-                prices[rel_interval] = price
+            # since evcc 0.203.0 value is the name of the price field.
+            if item.get('value', None) is not None:
+                price = item['value']
+            else:
+                price = item['price']
+
+            for offset in range(span):
+                idx = rel_interval + offset
+                if idx >= 0:
+                    prices[idx] = price
 
         logger.debug(
             'evcc: Retrieved %d prices at 15-min resolution (hour-aligned)',

--- a/src/batcontrol/dynamictariff/evcc.py
+++ b/src/batcontrol/dynamictariff/evcc.py
@@ -24,6 +24,7 @@ Methods:
 """
 import datetime
 import logging
+import math
 import requests
 from .baseclass import DynamicTariffBaseclass
 
@@ -118,7 +119,12 @@ class Evcc(DynamicTariffBaseclass):
                 end_timestamp = datetime.datetime.fromisoformat(
                     item['end']).astimezone(self.timezone)
                 duration_seconds = (end_timestamp - timestamp).total_seconds()
-                span = max(1, round(duration_seconds / 900))
+                # Round up: an entry slightly wider than an exact multiple of
+                # 15 minutes (e.g. due to timestamp rounding or a DST
+                # transition) must still have its trailing slot filled.
+                # Undercounting here would recreate the exact gap this fix
+                # is meant to eliminate.
+                span = max(1, math.ceil(duration_seconds / 900))
 
             # since evcc 0.203.0 value is the name of the price field.
             if item.get('value', None) is not None:

--- a/tests/batcontrol/dynamictariff/test_evcc.py
+++ b/tests/batcontrol/dynamictariff/test_evcc.py
@@ -228,15 +228,25 @@ class TestEvcc(unittest.TestCase):
 
             prices = evcc._get_prices_native()
 
-        # Hour 0: interval 0 = 0.25 (hourly price at start of hour)
+        # Hour 0: hourly price must be filled across all 4 quarters, not just
+        # the first one, otherwise downstream consumers (core.py) see gaps
+        # in the index sequence and crash with a KeyError.
         self.assertEqual(prices[0], 0.25)
+        self.assertEqual(prices[1], 0.25)
+        self.assertEqual(prices[2], 0.25)
+        self.assertEqual(prices[3], 0.25)
         # Hour 1: intervals 4-7 = individual 15-min prices
         self.assertEqual(prices[4], 0.30)
         self.assertEqual(prices[5], 0.32)
         self.assertEqual(prices[6], 0.34)
         self.assertEqual(prices[7], 0.36)
-        # Hour 2: interval 8 = 0.28 (hourly price at start of hour)
+        # Hour 2: hourly price filled across all 4 quarters again
         self.assertEqual(prices[8], 0.28)
+        self.assertEqual(prices[9], 0.28)
+        self.assertEqual(prices[10], 0.28)
+        self.assertEqual(prices[11], 0.28)
+        # No gaps anywhere in the produced index range
+        self.assertEqual(sorted(prices.keys()), list(range(12)))
 
     def test_native_resolution_is_15min(self):
         """Test that evcc provider has native 15-min resolution"""


### PR DESCRIPTION
## Summary
- evcc's tariff API sometimes mixes granularities: near-term prices are 15-min slots, but prices further out in the horizon can arrive as single hourly-width entries.
- `Evcc._get_prices_native()` only wrote the price into the single 15-min index matching the entry's *start* time, leaving the remaining quarters of an hourly entry missing from the returned dict.
- `core.py._run_once()` assumes a contiguous `price_dict` (`for h in range(fc_period + 1): prices[h] = round(price_dict[h], ...)`), and that loop is not covered by the surrounding exception handler. Hitting the gap raised an uncaught `KeyError`, crashing the whole batcontrol daemon (see attached `startup.txt` traceback that triggered this fix).
- Fix: use each rate entry's `start`/`end` to compute how many 15-min slots it spans, and fill all of them with that entry's price instead of just the first one.

## Test plan
- [x] `uv run pytest tests/batcontrol/dynamictariff/test_evcc.py -q` — 9 passed, including strengthened `test_mixed_granularity_prices` which now asserts the previously-missing quarters are filled and there are no gaps in the index range.
- [x] `uv run pytest tests/ -q` — full suite, 794 passed.
- [x] `uv run pylint src/batcontrol/dynamictariff/evcc.py` — 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)