### PR TITLE
ci: split docs workflow into reusable build + stable/dev deploy

### DIFF
--- a/.github/workflows/_docs-build.yml
+++ b/.github/workflows/_docs-build.yml
@@ -4,8 +4,11 @@ on:
   workflow_call:
     outputs:
       artifact-id:
-        description: "ID of the uploaded pages artifact"
+        description: "ID of the uploaded docs artifact"
         value: ${{ jobs.build.outputs.artifact-id }}
+
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/_docs-build.yml
+++ b/.github/workflows/_docs-build.yml
@@ -1,0 +1,42 @@
+name: Build Documentation
+
+on:
+  workflow_call:
+    outputs:
+      artifact-id:
+        description: "ID of the uploaded pages artifact"
+        value: ${{ jobs.build.outputs.artifact-id }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Install documentation dependencies
+        run: pip install "mkdocs-material>=9.5,<10" "mkdocs-llmstxt>=0.5.0,<1.0"
+
+      - name: Install batcontrol (for documentation data generation)
+        run: pip install -e .
+
+      - name: Generate peak shaving scenario data
+        run: python scripts/generate_peak_shaving_csv.py
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site
+          retention-days: 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,12 @@ on:
       - '.github/workflows/_docs-build.yml'
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
 jobs:
   build:
     uses: ./.github/workflows/_docs-build.yml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,54 +4,59 @@ on:
   push:
     tags:
       - '*.*.*'
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+      - '.github/workflows/_docs-build.yml'
   workflow_dispatch:
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, do not cancel in-progress runs.
-concurrency:
-  group: pages
-  cancel-in-progress: false
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+    uses: ./.github/workflows/_docs-build.yml
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.12'
-
-      - name: Install documentation dependencies
-        run: pip install "mkdocs-material>=9.5,<10" "mkdocs-llmstxt>=0.5.0,<1.0"
-
-      - name: Install batcontrol (for documentation data generation)
-        run: pip install -e .
-
-      - name: Generate peak shaving scenario data
-        run: python scripts/generate_peak_shaving_csv.py
-
-      - name: Build documentation
-        run: mkdocs build --strict
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: site
-
-  deploy:
+  deploy-stable:
+    if: startsWith(github.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: write
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-site
+          path: site
+
+      - name: Deploy to GitHub Pages (stable)
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          destination_dir: .
+          commit_message: "docs(stable): deploy ${{ github.ref_name }}"
+
+  deploy-dev:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-site
+          path: site
+
+      - name: Deploy to batcontrol-dev GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ secrets.BATCONTROL_DEV_DEPLOY_TOKEN }}
+          external_repository: MaStr/batcontrol-dev
+          publish_branch: main
+          publish_dir: ./site
+          destination_dir: docs
+          commit_message: "docs(dev): deploy ${{ github.sha }}"


### PR DESCRIPTION
- _docs-build.yml: reusable workflow (workflow_call) that builds MkDocs and uploads artifact
- docs.yml: tag push deploys to gh-pages root (stable), main push deploys to dev/ subdir
- path filter on main trigger: docs/**, mkdocs.yml, workflow files only