### PR TITLE
ci: grant contents:read to docs build job in docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     uses: ./.github/workflows/_docs-build.yml
 
   deploy-stable:


### PR DESCRIPTION
## Summary
- `docs.yml` sets workflow-level `permissions: {}`, so the `build` job (which calls the reusable `_docs-build.yml`) inherited `contents: none`
- `_docs-build.yml` declares `permissions: contents: read`, which it needs for its `actions/checkout` step
- A caller job can't grant a reusable workflow more permissions than it itself has, so GitHub Actions rejected the workflow as invalid: "workflow is requesting 'contents: read', but is only allowed 'contents: none'"
- Fix: give the `build` job its own explicit `contents: read` permission

## Test plan
- [x] Validated `docs.yml` YAML syntax parses correctly
- [ ] Confirm the `Deploy Documentation` workflow runs successfully on GitHub Actions after merge


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nec1wWK35Mb8MgpUPUhFsX)_