### PR TITLE
Add external grid-charge lock signal support (section 14a EnWG)

### DIFF
--- a/config/batcontrol_config_dummy.yaml
+++ b/config/batcontrol_config_dummy.yaml
@@ -193,6 +193,14 @@ mqtt:
   keyfile: /etc/ssl/certs/client.key           # path to client private key (optional, for mutual TLS)
   auto_discover_enable: true # enables mqtt auto discover => https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
   auto_discover_topic: homeassistant # base topic path for auto discover config messages - default 'homeassistant' -> https://www.home-assistant.io/integrations/mqtt/#discovery-options
+  # Optional: external grid-charge lock signal (e.g. from a HEMS or grid operator
+  # controllable-consumption-device request, section 14a EnWG).
+  # This is a full/absolute topic, NOT nested below 'topic' above, since it is
+  # published by an external system. Mirrors evcc's "External Limit":
+  # https://docs.evcc.io/en/user-defined-devices/#external-limit
+  # Payload 1/true: block charging from the grid immediately.
+  # Payload 0/false (default): restore the previous max_charging_from_grid_limit.
+  # grid_charge_lock_topic: hems/batcontrol/grid_charge_lock
 
 #--------------------------
 #  Forecast Solar

--- a/docs/integrations/mqtt-api.md
+++ b/docs/integrations/mqtt-api.md
@@ -65,6 +65,38 @@ mqtt:
 | `certfile` | string | — | Path to the client certificate (optional, for mutual TLS) |
 | `keyfile` | string | — | Path to the client private key (optional, for mutual TLS) |
 
+### Grid Charge Lock (external HEMS/grid operator signal)
+
+Some grid operators (in Germany: section 14a EnWG) or home energy management
+systems (HEMS) can request that controllable consumption devices stop drawing
+power from the grid. Batcontrol can listen to a single external MQTT topic for
+this signal. It mirrors evcc's
+[External Limit](https://docs.evcc.io/en/user-defined-devices/#external-limit)
+convention.
+
+```yaml
+mqtt:
+  enabled: true
+  grid_charge_lock_topic: hems/batcontrol/grid_charge_lock
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `grid_charge_lock_topic` | string | — | Optional. Full/absolute topic (not nested below `topic`) published by an external system. |
+
+Payload semantics (case-insensitive):
+
+- `1` or `true` - Immediately block charging from the grid. The current
+  `max_charging_from_grid_limit` is remembered and forced to `0`; an active
+  forced grid charge (`mode` `-1`) is cancelled right away.
+- `0` or `false` (default) - Restore the previously remembered
+  `max_charging_from_grid_limit`.
+
+The current lock state is published (retained) to `house/batcontrol/grid_charge_locked`.
+
+This only blocks *charging from the grid*; PV charging and battery discharging
+are not affected.
+
 ## Home Assistant Auto-Discovery
 
 Batcontrol supports Home Assistant's MQTT auto-discovery feature, which automatically creates entities in Home Assistant without manual configuration.
@@ -105,6 +137,7 @@ Batcontrol publishes data to the following topic structure (assuming base topic 
 - `house/batcontrol/discharge_blocked` - Whether discharge is blocked (`true`/`false`)
 - `house/batcontrol/api_override_active` - Whether a temporary external/API override is active (`true`/`false`)
 - `house/batcontrol/control_source` - Source that last selected the current control state (`api` or `optimizer`)
+- `house/batcontrol/grid_charge_locked` - Whether an external (HEMS/grid operator) request is currently blocking charging from the grid (`true`/`false`), see [Grid Charge Lock](#grid-charge-lock-external-hemsgrid-operator-signal) below
 
 ### Battery Information
 - `house/batcontrol/SOC` - State of Charge in % (two decimal places, e.g., `69.00`)

--- a/docs/integrations/mqtt-api.md
+++ b/docs/integrations/mqtt-api.md
@@ -137,7 +137,7 @@ Batcontrol publishes data to the following topic structure (assuming base topic 
 - `house/batcontrol/discharge_blocked` - Whether discharge is blocked (`true`/`false`)
 - `house/batcontrol/api_override_active` - Whether a temporary external/API override is active (`true`/`false`)
 - `house/batcontrol/control_source` - Source that last selected the current control state (`api` or `optimizer`)
-- `house/batcontrol/grid_charge_locked` - Whether an external (HEMS/grid operator) request is currently blocking charging from the grid (`true`/`false`), see [Grid Charge Lock](#grid-charge-lock-external-hemsgrid-operator-signal) below
+- `house/batcontrol/grid_charge_locked` - Whether an external (HEMS/grid operator) request is currently blocking charging from the grid (`true`/`false`), see [Grid Charge Lock](#grid-charge-lock-external-hemsgrid-operator-signal)
 
 ### Battery Information
 - `house/batcontrol/SOC` - State of Charge in % (two decimal places, e.g., `69.00`)

--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -106,6 +106,16 @@ def _parse_optional_ratio(value, config_key: str) -> Optional[float]:
     return ratio
 
 
+def _parse_bool_flag(value) -> bool:
+    """Parse an MQTT payload for a boolean flag: 1/0 or true/false (case-insensitive)."""
+    normalized = str(value).strip().lower()
+    if normalized in ('1', 'true'):
+        return True
+    if normalized in ('0', 'false'):
+        return False
+    raise ValueError(f"Invalid boolean flag payload: {value!r}")
+
+
 class Batcontrol:
     """ Main class for Batcontrol, handles the logic and control of the battery system """
     general_logic = None  # type: CommonLogic
@@ -133,6 +143,10 @@ class Batcontrol:
 
         self.discharge_blocked = False
         self.discharge_limit = 0
+
+        # External (e.g. HEMS/grid operator, section 14a EnWG) grid-charge lock
+        self._grid_charge_locked = False
+        self._pre_lock_max_charging_from_grid_limit = None
 
         self.fetched_stored_energy = False
         self.fetched_reserved_energy = False
@@ -391,6 +405,14 @@ class Batcontrol:
                     self.api_set_peak_shaving_mode,
                     str
                 )
+                grid_charge_lock_topic = config.get(
+                    'mqtt').get('grid_charge_lock_topic')
+                if grid_charge_lock_topic:
+                    self.mqtt_api.register_external_topic_callback(
+                        grid_charge_lock_topic,
+                        self.api_set_grid_charge_lock,
+                        _parse_bool_flag
+                    )
                 # Inverter Callbacks
                 self.inverter.activate_mqtt(self.mqtt_api)
 
@@ -1058,6 +1080,7 @@ class Batcontrol:
             self.mqtt_api.publish_last_evaluation_time(self.last_run_time)
             #
             self.mqtt_api.publish_discharge_blocked(self.discharge_blocked)
+            self.mqtt_api.publish_grid_charge_locked(self._grid_charge_locked)
             # Peak shaving
             self.mqtt_api.publish_peak_shaving_enabled(
                 self.peak_shaving_config.enabled)
@@ -1175,6 +1198,35 @@ class Batcontrol:
         logger.info(
             'API: Setting max charging from grid limit to %.2f', limit)
         self.set_max_charging_from_grid_limit(limit)
+
+    @_tolerate_inverter_outage
+    def api_set_grid_charge_lock(self, locked: bool) -> None:
+        """ Block/unblock charging from the grid on request of an external
+            system (e.g. HEMS or grid operator signal, section 14a EnWG).
+
+            locked=True: remember the current max_charging_from_grid_limit and
+            force it to 0, so batcontrol will not charge the battery from the
+            grid. An active forced grid charge (mode -1) is cancelled
+            immediately.
+            locked=False (default): restore the previously remembered limit.
+        """
+        if locked == self._grid_charge_locked:
+            return
+        logger.info('API: External grid charge lock set to %s', locked)
+        self._grid_charge_locked = locked
+        if locked:
+            self._pre_lock_max_charging_from_grid_limit = (
+                self.max_charging_from_grid_limit)
+            if self.last_mode == MODE_FORCE_CHARGING:
+                self.allow_discharging(CONTROL_SOURCE_API)
+            self.set_max_charging_from_grid_limit(0.0)
+        else:
+            if self._pre_lock_max_charging_from_grid_limit is not None:
+                self.set_max_charging_from_grid_limit(
+                    self._pre_lock_max_charging_from_grid_limit)
+                self._pre_lock_max_charging_from_grid_limit = None
+        if self.mqtt_api is not None:
+            self.mqtt_api.publish_grid_charge_locked(locked)
 
     def api_set_min_price_difference(self, min_price_difference: float):
         """ Set min price difference for battery control via external API request.

--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -1222,8 +1222,14 @@ class Batcontrol:
             self.set_max_charging_from_grid_limit(0.0)
         else:
             if self._pre_lock_max_charging_from_grid_limit is not None:
-                self.set_max_charging_from_grid_limit(
-                    self._pre_lock_max_charging_from_grid_limit)
+                # Clamp to always_allow_discharge_limit: it may have been
+                # lowered while locked, which would otherwise make
+                # set_max_charging_from_grid_limit reject the restore and
+                # leave the limit stuck at 0.0.
+                restore_value = min(
+                    self._pre_lock_max_charging_from_grid_limit,
+                    self.get_always_allow_discharge_limit())
+                self.set_max_charging_from_grid_limit(restore_value)
                 self._pre_lock_max_charging_from_grid_limit = None
         if self.mqtt_api is not None:
             self.mqtt_api.publish_grid_charge_locked(locked)

--- a/src/batcontrol/mqtt_api.py
+++ b/src/batcontrol/mqtt_api.py
@@ -32,6 +32,8 @@ The following topics are published:
 - /solar_active: bool indicating whether solar is currently producing (slot 0 > 0)
 - /pv_start_battery_wh: battery level in Wh (above MIN_SOC) at the next net-charging point (when PV first exceeds consumption)
 - /forecast_min_battery_wh: minimum battery level in Wh (above MIN_SOC) over the entire forecast horizon (0 = shortage expected)
+- /grid_charge_locked: bool indicating whether an external (e.g. HEMS/grid operator,
+  section 14a EnWG) request is currently blocking charging from the grid
 
 The following statistical arrays are published as JSON arrays:
 - /FCST/production: forecasted production, Wh per interval (plus power_w: average W)
@@ -52,6 +54,11 @@ Implemented Input-API:
 - /min_price_difference/set: set minimum price difference in EUR
 - /production_offset/set: set production offset percentage (0.0-2.0)
 
+Additionally, an arbitrary external topic (not namespaced below the base topic) can be
+registered via register_external_topic_callback(), e.g. to receive a grid-charge-lock
+signal from a HEMS or grid operator (section 14a EnWG). See core.py for the
+grid_charge_lock_topic config option.
+
 The module uses the paho-mqtt library for MQTT communication and numpy for handling arrays.
 """
 import time
@@ -70,6 +77,7 @@ TOPIC_CHARGE_RATE = 'charge_rate'
 TOPIC_LIMIT_BATTERY_CHARGE_RATE = 'limit_battery_charge_rate'
 TOPIC_API_OVERRIDE_ACTIVE = 'api_override_active'
 TOPIC_CONTROL_SOURCE = 'control_source'
+TOPIC_GRID_CHARGE_LOCKED = 'grid_charge_locked'
 TOPIC_SET_SUFFIX = '/set'
 
 
@@ -221,6 +229,21 @@ class MqttApi:
             'function': callback, 'convert': convert}
         self.client.subscribe(topic_string)
         self.client.message_callback_add(topic_string, self._handle_message)
+
+    def register_external_topic_callback(
+            self,
+            topic: str,
+            callback: callable,
+            convert: callable) -> None:
+        """ Register a callback for an absolute external topic, used as-is
+            (not namespaced below base_topic and without a /set suffix).
+            Useful for listening to topics published by external systems
+            (e.g. a HEMS or grid operator signal).
+        """
+        logger.debug('Registering callback for external topic %s', topic)
+        self.callbacks[topic] = {'function': callback, 'convert': convert}
+        self.client.subscribe(topic)
+        self.client.message_callback_add(topic, self._handle_message)
 
     def publish_mode(self, mode: int) -> None:
         """ Publish the mode (charge, lock, discharge) to MQTT
@@ -532,6 +555,16 @@ class MqttApi:
                 self.base_topic +
                 '/discharge_blocked',
                 str(discharge_blocked).lower())
+
+    def publish_grid_charge_locked(self, locked: bool) -> None:
+        """ Publish whether an external request is blocking charging from the grid
+            /grid_charge_locked
+        """
+        if self.client.is_connected():
+            self.client.publish(
+                self._topic(TOPIC_GRID_CHARGE_LOCKED),
+                str(locked).lower(),
+                retain=True)
 
     def publish_production_offset(self, production_offset: float) -> None:
         """ Publish the production offset percentage to MQTT
@@ -878,6 +911,16 @@ class MqttApi:
             None,
             self._topic(TOPIC_CONTROL_SOURCE),
             entity_category="diagnostic")
+
+        self.publish_mqtt_discovery_message(
+            "Grid Charge Locked",
+            "batcontrol_grid_charge_locked",
+            "binary_sensor",
+            None,
+            None,
+            self._topic(TOPIC_GRID_CHARGE_LOCKED),
+            entity_category="diagnostic",
+            value_template="{% if value == 'true' %}ON{% else %}OFF{% endif %}")
 
         # sensors
         self.publish_mqtt_discovery_message(

--- a/tests/batcontrol/test_core.py
+++ b/tests/batcontrol/test_core.py
@@ -9,7 +9,9 @@ from batcontrol.core import (
     CONTROL_SOURCE_API,
     CONTROL_SOURCE_OPTIMIZER,
     MODE_ALLOW_DISCHARGING,
+    MODE_FORCE_CHARGING,
     MODE_LIMIT_BATTERY_CHARGE_RATE,
+    _parse_bool_flag,
 )
 from batcontrol.inverter import (
     InverterCommunicationError,
@@ -1327,6 +1329,187 @@ class TestMarketPriceRefresh:
         bc.shutdown()
 
         assert sched_module.get_jobs() == []
+
+
+class TestParseBoolFlag:
+    """_parse_bool_flag() parses MQTT payloads for the grid-charge lock (issue #216)."""
+
+    @pytest.mark.parametrize("payload,expected", [
+        ("1", True), ("true", True), ("True", True), ("TRUE", True),
+        (" 1 ", True), (" true ", True),
+        ("0", False), ("false", False), ("False", False), ("FALSE", False),
+        (" 0 ", False), (" false ", False),
+    ])
+    def test_valid_payloads(self, payload, expected):
+        assert _parse_bool_flag(payload) is expected
+
+    @pytest.mark.parametrize("payload", ["", "maybe", "2", "yes", "on"])
+    def test_invalid_payload_raises(self, payload):
+        with pytest.raises(ValueError):
+            _parse_bool_flag(payload)
+
+
+class TestApiSetGridChargeLock:
+    """External grid-charge lock signal (e.g. HEMS/grid operator, section 14a EnWG)."""
+
+    BASE_CONFIG = {
+        'timezone': 'Europe/Berlin',
+        'time_resolution_minutes': 60,
+        'inverter': {
+            'type': 'dummy',
+            'max_grid_charge_rate': 5000,
+            'max_pv_charge_rate': 3000,
+            'min_pv_charge_rate': 0,
+        },
+        'utility': {'type': 'tibber', 'apikey': 'test_token'},
+        'pvinstallations': [],
+        'consumption_forecast': {'type': 'simple', 'value': 500},
+        'battery_control': {
+            'max_charging_from_grid_limit': 0.8,
+            'min_price_difference': 0.05,
+        },
+        'mqtt': {'enabled': False},
+    }
+
+    @pytest.fixture
+    def bc(self, mocker):
+        mock_inverter = mocker.MagicMock()
+        mock_inverter.max_pv_charge_rate = 3000
+        mock_inverter.max_grid_charge_rate = 5000
+        mock_inverter.get_max_capacity.return_value = 10000
+        mocker.patch('batcontrol.core.tariff_factory.create_tarif_provider',
+                     autospec=True, return_value=mocker.MagicMock())
+        mocker.patch('batcontrol.core.inverter_factory.create_inverter',
+                     autospec=True, return_value=mock_inverter)
+        mocker.patch('batcontrol.core.solar_factory.create_solar_provider',
+                     autospec=True, return_value=mocker.MagicMock())
+        mocker.patch('batcontrol.core.consumption_factory.create_consumption',
+                     autospec=True, return_value=mocker.MagicMock())
+        instance = Batcontrol(dict(self.BASE_CONFIG))
+        yield instance
+        instance.shutdown()
+
+    def test_lock_zeroes_grid_charge_limit_and_remembers_previous(self, bc):
+        bc.mqtt_api = MagicMock()
+
+        bc.api_set_grid_charge_lock(True)
+
+        assert bc.max_charging_from_grid_limit == 0.0
+        assert bc._grid_charge_locked is True
+        assert bc._pre_lock_max_charging_from_grid_limit == 0.8
+        bc.mqtt_api.publish_grid_charge_locked.assert_called_once_with(True)
+
+    def test_unlock_restores_previous_grid_charge_limit(self, bc):
+        bc.mqtt_api = MagicMock()
+        bc.api_set_grid_charge_lock(True)
+
+        bc.api_set_grid_charge_lock(False)
+
+        assert bc.max_charging_from_grid_limit == 0.8
+        assert bc._grid_charge_locked is False
+        assert bc._pre_lock_max_charging_from_grid_limit is None
+        bc.mqtt_api.publish_grid_charge_locked.assert_called_with(False)
+
+    def test_unlock_without_prior_lock_is_a_noop(self, bc):
+        bc.mqtt_api = MagicMock()
+
+        bc.api_set_grid_charge_lock(False)
+
+        assert bc.max_charging_from_grid_limit == 0.8
+        bc.mqtt_api.publish_grid_charge_locked.assert_not_called()
+
+    def test_repeated_lock_is_idempotent(self, bc):
+        bc.mqtt_api = MagicMock()
+        bc.api_set_grid_charge_lock(True)
+
+        bc.api_set_grid_charge_lock(True)
+
+        bc.mqtt_api.publish_grid_charge_locked.assert_called_once_with(True)
+        assert bc._pre_lock_max_charging_from_grid_limit == 0.8
+
+    def test_lock_cancels_active_force_charge(self, bc):
+        bc.mqtt_api = MagicMock()
+        bc.force_charge(1000, control_source=CONTROL_SOURCE_API)
+        assert bc.last_mode == MODE_FORCE_CHARGING
+
+        bc.api_set_grid_charge_lock(True)
+
+        assert bc.last_mode == MODE_ALLOW_DISCHARGING
+        assert bc.max_charging_from_grid_limit == 0.0
+
+
+class TestGridChargeLockTopicRegistration:
+    """Wiring of the optional mqtt.grid_charge_lock_topic config option."""
+
+    BASE_CONFIG = {
+        'timezone': 'Europe/Berlin',
+        'time_resolution_minutes': 60,
+        'inverter': {
+            'type': 'dummy',
+            'max_grid_charge_rate': 5000,
+            'max_pv_charge_rate': 3000,
+            'min_pv_charge_rate': 0,
+        },
+        'utility': {'type': 'tibber', 'apikey': 'test_token'},
+        'pvinstallations': [],
+        'consumption_forecast': {'type': 'simple', 'value': 500},
+        'battery_control': {
+            'max_charging_from_grid_limit': 0.8,
+            'min_price_difference': 0.05,
+        },
+    }
+
+    def _patch_core(self, mocker):
+        mock_inverter = mocker.MagicMock()
+        mock_inverter.max_pv_charge_rate = 3000
+        mock_inverter.get_max_capacity.return_value = 10000
+        mocker.patch('batcontrol.core.tariff_factory.create_tarif_provider',
+                     autospec=True, return_value=mocker.MagicMock())
+        mocker.patch('batcontrol.core.inverter_factory.create_inverter',
+                     autospec=True, return_value=mock_inverter)
+        mocker.patch('batcontrol.core.solar_factory.create_solar_provider',
+                     autospec=True, return_value=mocker.MagicMock())
+        mocker.patch('batcontrol.core.consumption_factory.create_consumption',
+                     autospec=True, return_value=mocker.MagicMock())
+
+    def test_registers_external_topic_when_configured(self, mocker):
+        self._patch_core(mocker)
+        mock_mqtt_api = mocker.MagicMock()
+        mocker.patch('batcontrol.core.MqttApi', return_value=mock_mqtt_api)
+        config = dict(self.BASE_CONFIG)
+        config['mqtt'] = {
+            'enabled': True,
+            'broker': 'localhost',
+            'port': 1883,
+            'topic': 'house/batcontrol',
+            'grid_charge_lock_topic': 'hems/batcontrol/grid_charge_lock',
+        }
+
+        bc = Batcontrol(config)
+
+        mock_mqtt_api.register_external_topic_callback.assert_called_once_with(
+            'hems/batcontrol/grid_charge_lock',
+            bc.api_set_grid_charge_lock,
+            _parse_bool_flag,
+        )
+        bc.shutdown()
+
+    def test_no_registration_when_topic_not_configured(self, mocker):
+        self._patch_core(mocker)
+        mock_mqtt_api = mocker.MagicMock()
+        mocker.patch('batcontrol.core.MqttApi', return_value=mock_mqtt_api)
+        config = dict(self.BASE_CONFIG)
+        config['mqtt'] = {
+            'enabled': True,
+            'broker': 'localhost',
+            'port': 1883,
+            'topic': 'house/batcontrol',
+        }
+
+        bc = Batcontrol(config)
+
+        mock_mqtt_api.register_external_topic_callback.assert_not_called()
+        bc.shutdown()
 
 
 if __name__ == '__main__':

--- a/tests/batcontrol/test_core.py
+++ b/tests/batcontrol/test_core.py
@@ -1437,6 +1437,21 @@ class TestApiSetGridChargeLock:
         assert bc.last_mode == MODE_ALLOW_DISCHARGING
         assert bc.max_charging_from_grid_limit == 0.0
 
+    def test_unlock_clamps_restore_to_always_allow_discharge_limit(self, bc):
+        """If always_allow_discharge_limit was lowered below the remembered
+        value while locked, set_max_charging_from_grid_limit would otherwise
+        reject the restore and leave the limit stuck at 0.0 (issue found in
+        PR #416 review)."""
+        bc.mqtt_api = MagicMock()
+        bc.api_set_grid_charge_lock(True)
+        bc.set_always_allow_discharge_limit(0.5)
+
+        bc.api_set_grid_charge_lock(False)
+
+        assert bc.max_charging_from_grid_limit == 0.5
+        assert bc._grid_charge_locked is False
+        assert bc._pre_lock_max_charging_from_grid_limit is None
+
 
 class TestGridChargeLockTopicRegistration:
     """Wiring of the optional mqtt.grid_charge_lock_topic config option."""

--- a/tests/batcontrol/test_mqtt_api.py
+++ b/tests/batcontrol/test_mqtt_api.py
@@ -69,6 +69,9 @@ def _make_publish_stub():
     api.publish_effective_min_grid_charge_soc = (
         MqttApi.publish_effective_min_grid_charge_soc.__get__(api, MqttApi)
     )
+    api.publish_grid_charge_locked = (
+        MqttApi.publish_grid_charge_locked.__get__(api, MqttApi)
+    )
     return api
 
 
@@ -158,6 +161,50 @@ class TestReconnectSubscriptions:
         ]
 
 
+class TestRegisterExternalTopicCallback:
+    """register_external_topic_callback subscribes to the raw topic as-is,
+    without namespacing it below base_topic or appending a /set suffix."""
+
+    def test_subscribes_to_raw_topic_and_registers_callback(self):
+        from unittest.mock import Mock
+
+        mock_config = {
+            'broker': 'localhost',
+            'port': 1883,
+            'topic': 'test/batcontrol',
+            'auto_discover_enable': False,
+            'tls': False,
+        }
+
+        with patch('batcontrol.mqtt_api.mqtt.Client') as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+
+            mqtt_api = MqttApi(mock_config)
+
+            callback_fn = Mock()
+            mqtt_api.register_external_topic_callback(
+                'hems/batcontrol/grid_charge_lock', callback_fn, str)
+
+            mock_client.subscribe.assert_called_with(
+                'hems/batcontrol/grid_charge_lock')
+            assert 'hems/batcontrol/grid_charge_lock' in mqtt_api.callbacks
+            # Not namespaced below base_topic, unlike register_set_callback
+            assert 'test/batcontrol/hems/batcontrol/grid_charge_lock' \
+                not in mqtt_api.callbacks
+
+    def test_dispatches_received_message_to_callback(self):
+        api = _make_handler_stub()
+        received = []
+        api.callbacks['hems/batcontrol/grid_charge_lock'] = {
+            'function': received.append,
+            'convert': str,
+        }
+        msg = _make_message('hems/batcontrol/grid_charge_lock', b'1')
+        api._handle_message(None, None, msg)
+        assert received == ['1']
+
+
 class TestPublishedState:
     """Published state payloads should preserve precision and parse cleanly."""
 
@@ -197,6 +244,17 @@ class TestPublishedState:
             call('batcontrol/effective_min_grid_charge_soc_percent', '79'),
             call('batcontrol/effective_min_grid_charge_soc', '0.79'),
         ]
+
+    def test_publish_grid_charge_locked_uses_lowercase_boolean(self):
+        api = _make_publish_stub()
+
+        api.publish_grid_charge_locked(True)
+
+        api.client.publish.assert_called_once_with(
+            'batcontrol/grid_charge_locked',
+            'true',
+            retain=True,
+        )
 
 
 def _make_forecast_publish_stub(interval_minutes: int):
@@ -380,6 +438,23 @@ class TestDiscoveryMessages:
             and call.args[4] == '%'
             and call.args[5] == 'batcontrol/min_grid_charge_soc_percent'
             and call.kwargs['entity_category'] == 'diagnostic'
+            for call in api.publish_mqtt_discovery_message.call_args_list
+        )
+
+    def test_discovery_includes_grid_charge_locked_binary_sensor(self):
+        api = _make_discovery_stub()
+
+        api.send_mqtt_discovery_messages()
+
+        assert any(
+            call.args[:3] == (
+                'Grid Charge Locked',
+                'batcontrol_grid_charge_locked',
+                'binary_sensor',
+            )
+            and call.args[5] == 'batcontrol/grid_charge_locked'
+            and call.kwargs['entity_category'] == 'diagnostic'
+            and "value == 'true'" in call.kwargs['value_template']
             for call in api.publish_mqtt_discovery_message.call_args_list
         )
 


### PR DESCRIPTION
## Summary

Implements support for external grid-charge lock signals from HEMS or grid operators (section 14a EnWG). Batcontrol can now listen to an optional MQTT topic and immediately block charging from the grid when requested, while preserving the ability to restore the previous limit when unlocked.

## Key Changes

- **New `_parse_bool_flag()` utility** in `core.py`: Parses MQTT payloads for boolean flags (`1`/`true` or `0`/`false`, case-insensitive, with whitespace tolerance). Raises `ValueError` for invalid payloads.

- **New `api_set_grid_charge_lock()` method** in `Batcontrol` class:
  - When locked (`True`): remembers the current `max_charging_from_grid_limit`, forces it to `0`, and cancels any active forced grid charge (`MODE_FORCE_CHARGING`).
  - When unlocked (`False`): restores the previously remembered limit.
  - Idempotent: repeated calls with the same state are no-ops.
  - Publishes lock state to MQTT for external visibility.

- **MQTT integration**:
  - New `register_external_topic_callback()` method in `MqttApi`: registers callbacks for absolute external topics (not namespaced below base topic), useful for listening to external systems.
  - New `publish_grid_charge_locked()` method: publishes lock state as retained boolean (`true`/`false`).
  - New Home Assistant auto-discovery entry for `grid_charge_locked` binary sensor.

- **Configuration**:
  - Optional `mqtt.grid_charge_lock_topic` config parameter: full/absolute MQTT topic published by external systems (e.g., HEMS or grid operator).
  - Automatically registers the callback during initialization if configured.

- **State tracking**:
  - New instance variables: `_grid_charge_locked` and `_pre_lock_max_charging_from_grid_limit`.
  - Lock state is published during `refresh_static_values()`.

- **Documentation**: Updated `docs/integrations/mqtt-api.md` with Grid Charge Lock section, payload semantics, and example configuration. Updated reference config with commented example.

## Implementation Details

- The lock only blocks *charging from the grid*; PV charging and battery discharging are unaffected.
- Mirrors evcc's [External Limit](https://docs.evcc.io/en/user-defined-devices/#external-limit) convention for payload semantics.
- Uses the `@_tolerate_inverter_outage` decorator to handle inverter communication failures gracefully.
- Comprehensive test coverage: `TestParseBoolFlag`, `TestApiSetGridChargeLock`, and `TestGridChargeLockTopicRegistration` classes verify parsing, locking behavior, and MQTT wiring.

https://claude.ai/code/session_01DuzLNaLaNCtbPUYVhFvWpr